### PR TITLE
Various fixes/additions

### DIFF
--- a/src/main/resources/cards/421-team_up.yaml
+++ b/src/main/resources/cards/421-team_up.yaml
@@ -12,7 +12,7 @@ cards:
   number: '1'
   types: [G]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 270
   retreatCost: 4
   moves:
@@ -735,7 +735,7 @@ cards:
   number: '33'
   types: [L]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 240
   retreatCost: 3
   moves:
@@ -1251,7 +1251,7 @@ cards:
   number: '53'
   types: [P]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 240
   retreatCost: 2
   moves:
@@ -2720,11 +2720,11 @@ cards:
   number: '113'
   types: [N]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 250
   retreatCost: 1
   moves:
-  - cost: [P, P, W, C]
+  - cost: [W, P, P, C]
     name: Buster Purge
     damage: '240'
     text: Discard 3 Energy from this Pokémon.
@@ -2879,7 +2879,7 @@ cards:
   number: '120'
   types: [C]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 270
   retreatCost: 4
   moves:
@@ -3473,7 +3473,7 @@ cards:
   number: '159'
   types: [G]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 270
   retreatCost: 4
   moves:
@@ -3502,7 +3502,7 @@ cards:
   number: '160'
   types: [W]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 300
   retreatCost: 4
   moves:
@@ -3527,7 +3527,7 @@ cards:
   number: '161'
   types: [W]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 300
   retreatCost: 4
   moves:
@@ -3552,7 +3552,7 @@ cards:
   number: '162'
   types: [L]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 240
   retreatCost: 3
   moves:
@@ -3613,7 +3613,7 @@ cards:
   number: '164'
   types: [P]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 240
   retreatCost: 2
   moves:
@@ -3642,7 +3642,7 @@ cards:
   number: '165'
   types: [P]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 240
   retreatCost: 2
   moves:
@@ -3769,11 +3769,11 @@ cards:
   number: '169'
   types: [N]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 250
   retreatCost: 1
   moves:
-  - cost: [P, P, W, C]
+  - cost: [W, P, P, C]
     name: Buster Purge
     damage: '240'
     text: Discard 3 Energy from this Pokémon.
@@ -3795,11 +3795,11 @@ cards:
   number: '170'
   types: [N]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 250
   retreatCost: 1
   moves:
-  - cost: [P, P, W, C]
+  - cost: [W, P, P, C]
     name: Buster Purge
     damage: '240'
     text: Discard 3 Energy from this Pokémon.
@@ -3821,7 +3821,7 @@ cards:
   number: '171'
   types: [C]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 270
   retreatCost: 4
   moves:
@@ -3957,7 +3957,7 @@ cards:
   number: '182'
   types: [G]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 270
   retreatCost: 4
   moves:
@@ -3986,7 +3986,7 @@ cards:
   number: '183'
   types: [W]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 300
   retreatCost: 4
   moves:
@@ -4011,7 +4011,7 @@ cards:
   number: '184'
   types: [L]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 240
   retreatCost: 3
   moves:
@@ -4072,7 +4072,7 @@ cards:
   number: '186'
   types: [P]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 240
   retreatCost: 2
   moves:
@@ -4199,7 +4199,7 @@ cards:
   number: '190'
   types: [N]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 250
   retreatCost: 1
   moves:
@@ -4225,7 +4225,7 @@ cards:
   number: '191'
   types: [C]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
   hp: 270
   retreatCost: 4
   moves:

--- a/src/main/resources/cards/427-cosmic_eclipse.yaml
+++ b/src/main/resources/cards/427-cosmic_eclipse.yaml
@@ -4392,7 +4392,7 @@ cards:
   name: Bellelba & Brycen-Man
   number: '186'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, TAG_TEAM]
   rarity: Uncommon
   text: [Discard 3 cards from the top of each player’s deck., 'When you play this
       card, you may discard 3 other cards from your hand. If you do, each player discards
@@ -4424,7 +4424,7 @@ cards:
   name: Cynthia & Caitlin
   number: '189'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, TAG_TEAM]
   rarity: Uncommon
   text: [Put a Supporter card from your discard pile into your hand. You can't choose
       Cynthia & Caitlin or a card you discarded with the effect of this card., 'When
@@ -4465,7 +4465,7 @@ cards:
   name: Guzma & Hala
   number: '193'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, TAG_TEAM]
   rarity: Uncommon
   text: ['Search your deck for a Stadium card, reveal it, and put it into your hand.
       Then, shuffle your deck.', 'When you play this card, you may discard 2 other
@@ -4522,7 +4522,7 @@ cards:
   name: Mallow & Lana
   number: '198'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, TAG_TEAM]
   rarity: Uncommon
   text: ['Switch your Active Pokémon with 1 of your Benched Pokémon. ', 'When you
       play this card, you may discard 2 other cards from your hand. If you do, heal
@@ -4533,7 +4533,7 @@ cards:
   name: Misty & Lorelei
   number: '199'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, TAG_TEAM]
   rarity: Uncommon
   text: ['Search your deck for up to 3 [W] Energy cards, reveal them, and put them
       into your hand. Then, shuffle your deck.', 'When you play this card, you may
@@ -4564,7 +4564,7 @@ cards:
   name: Red & Blue
   number: '202'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, TAG_TEAM]
   rarity: Uncommon
   text: ['Search your deck for a Pokémon-GX that evolves from 1 of your Pokémon and
       put it onto that Pokémon to evolve it. Then, shuffle your deck. (You can''t
@@ -5205,7 +5205,7 @@ cards:
   name: Cynthia & Caitlin
   number: '228'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, TAG_TEAM]
   rarity: Ultra Rare
   text: [Put a Supporter card from your discard pile into your hand. You can't choose
       Cynthia & Caitlin or a card you discarded with the effect of this card., 'When
@@ -5219,7 +5219,7 @@ cards:
   name: Guzma & Hala
   number: '229'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, TAG_TEAM]
   rarity: Ultra Rare
   text: ['Search your deck for a Stadium card, reveal it, and put it into your hand.
       Then, shuffle your deck.', 'When you play this card, you may discard 2 other
@@ -5246,7 +5246,7 @@ cards:
   name: Mallow & Lana
   number: '231'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, TAG_TEAM]
   rarity: Ultra Rare
   text: ['Switch your Active Pokémon with 1 of your Benched Pokémon. ', 'When you
       play this card, you may discard 2 other cards from your hand. If you do, heal
@@ -5281,7 +5281,7 @@ cards:
   name: Red & Blue
   number: '234'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, TAG_TEAM]
   rarity: Ultra Rare
   text: ['Search your deck for a Pokémon-GX that evolves from 1 of your Pokémon and
       put it onto that Pokémon to evolve it. Then, shuffle your deck. (You can''t

--- a/src/main/resources/cards/430-sword_shield.yaml
+++ b/src/main/resources/cards/430-sword_shield.yaml
@@ -4415,3 +4415,93 @@ cards:
       shuffle your deck.']
   copyOf: 430-179
   copyType: Secret Art
+- id: 430-217
+  pioId: swsh1-217
+  enumId: PSYCHIC_ENERGY_217
+  name: Psychic Energy
+  number: '217'
+  superType: ENERGY
+  subTypes: [BASIC_ENERGY]
+  rarity: Common
+  energy:
+  - [P]
+- id: 430-218
+  pioId: swsh1-2
+  enumId: METAL_ENERGY_217
+  name: Metal Energy
+  number: '218'
+  superType: ENERGY
+  subTypes: [BASIC_ENERGY]
+  rarity: Common
+  energy:
+  - [M]
+- id: 430-219
+  pioId: swsh1-219
+  enumId: GRASS_ENERGY_219
+  name: Grass Energy
+  number: '219'
+  superType: ENERGY
+  subTypes: [BASIC_ENERGY]
+  rarity: Common
+  energy:
+  - [G]
+- id: 430-220
+  pioId: swsh1-220
+  enumId: FIRE_ENERGY_220
+  name: Fire Energy
+  number: '220'
+  superType: ENERGY
+  subTypes: [BASIC_ENERGY]
+  rarity: Common
+  energy:
+  - [R]
+- id: 430-221
+  pioId: swsh1-221
+  enumId: WATER_ENERGY_221
+  name: Water Energy
+  number: '221'
+  superType: ENERGY
+  subTypes: [BASIC_ENERGY]
+  rarity: Common
+  energy:
+  - [W]
+- id: 430-222
+  pioId: swsh1-222
+  enumId: LIGHTNING_ENERGY_222
+  name: Lightning Energy
+  number: '222'
+  superType: ENERGY
+  subTypes: [BASIC_ENERGY]
+  rarity: Common
+  energy:
+  - [L]
+- id: 430-223
+  pioId: swsh1-223
+  enumId: FIGHTING_ENERGY_223
+  name: Fighting Energy
+  number: '223'
+  superType: ENERGY
+  subTypes: [BASIC_ENERGY]
+  rarity: Common
+  energy:
+  - [F]
+- id: 430-224
+  pioId: swsh1-224
+  enumId: DARKNESS_ENERGY_224
+  name: Darkness Energy
+  number: '224'
+  superType: ENERGY
+  subTypes: [BASIC_ENERGY]
+  rarity: Common
+  energy:
+  - [D]
+- id: 430-225
+  pioId: swsh1-225
+  enumId: FAIRY_ENERGY_225
+  name: Fairy Energy
+  number: '225'
+  superType: ENERGY
+  subTypes: [BASIC_ENERGY]
+  rarity: Common
+  energy:
+  - [Y]

--- a/src/main/resources/cards/432-darkness-ablaze.yaml
+++ b/src/main/resources/cards/432-darkness-ablaze.yaml
@@ -33,7 +33,7 @@ cards:
   number: '2'
   types: [G]
   superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1, VMAX]
+  subTypes: [EVOLUTION, VMAX]
   evolvesFrom: Butterfree V
   hp: 300
   retreatCost: 0
@@ -426,7 +426,7 @@ cards:
   number: '20'
   types: [R]
   superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1, VMAX]
+  subTypes: [EVOLUTION, VMAX]
   evolvesFrom: Charizard V
   hp: 330
   retreatCost: 3
@@ -796,7 +796,7 @@ cards:
   number: '36'
   types: [R]
   superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1, VMAX]
+  subTypes: [EVOLUTION, VMAX]
   evolvesFrom: Centiskorch V
   hp: 320
   retreatCost: 3
@@ -1608,7 +1608,7 @@ cards:
   number: '72'
   types: [P]
   superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1, VMAX]
+  subTypes: [EVOLUTION, VMAX]
   evolvesFrom: Gardevoir V
   hp: 320
   retreatCost: 2
@@ -2846,7 +2846,7 @@ cards:
   number: '126'
   types: [D]
   superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1, VMAX]
+  subTypes: [EVOLUTION, VMAX]
   evolvesFrom: Grimmsnarl V
   hp: 330
   retreatCost: 3
@@ -2892,7 +2892,7 @@ cards:
   number: '128'
   types: [D]
   superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1, VMAX]
+  subTypes: [EVOLUTION, VMAX]
   evolvesFrom: Eternatus V
   hp: 340
   retreatCost: 2
@@ -3468,7 +3468,7 @@ cards:
   number: '152'
   types: [C]
   superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1, VMAX]
+  subTypes: [EVOLUTION, VMAX]
   evolvesFrom: Salamence V
   hp: 320
   retreatCost: 2


### PR DESCRIPTION
* Removes the Stage 1 marker from Darkness Ablaze's VMAXs.
* Adds missing Tag Team markers to Tag Team Pokemon from Team Up and Cosmic Eclipse supporters.
* Fixes Latios & Latias GX's Buster Purge attack cost to match the order on the card.
* Adds Sword & Shield Energy.