### PR TITLE
Fix CEC IDs / attack cost orders on some cards

### DIFF
--- a/src/main/resources/cards/410-sun_moon_promos.yaml
+++ b/src/main/resources/cards/410-sun_moon_promos.yaml
@@ -5229,12 +5229,12 @@ cards:
     name: Linear Attack
     text: This attack does 40 damage to 1 of your opponent''s Pokémon. (Don''t apply
       Weakness and Resistance for Benched Pokémon.)
-  - cost: [F, P, C]
+  - cost: [P, F, C]
     name: Calamitous Slash
     damage: 160+
     text: If your opponent's Active Pokémon already has any damage counters on it,
       this attack does 80 more damage.
-  - cost: [F, P, P]
+  - cost: [P, P, F]
     name: GG End GX
     text: Discard 1 of your opponent's Pokémon and all cards attached to it. If this
       Pokémon has at least 3 extra [F] Energy attached to it (in addition to this
@@ -5653,7 +5653,7 @@ cards:
   hp: 300
   retreatCost: 3
   moves:
-  - cost: [R, L, W, C]
+  - cost: [R, W, L, C]
     name: Trinity Burn
     damage: '210'
   - cost: [C]

--- a/src/main/resources/cards/421-team_up.yaml
+++ b/src/main/resources/cards/421-team_up.yaml
@@ -2839,7 +2839,7 @@ cards:
   hp: 90
   retreatCost: 2
   moves:
-  - cost: [L, W]
+  - cost: [W, L]
     name: Twister
     damage: '30'
     text: Flip 2 coins. For each heads, discard an Energy from your opponent's Active
@@ -2865,7 +2865,7 @@ cards:
     text: Once during your turn (before your attack), you may search your deck for
       a Supporter card, reveal it, and put it into your hand. Then, shuffle your deck.
   moves:
-  - cost: [L, W, C]
+  - cost: [W, L, C]
     name: Dragon Claw
     damage: '120'
   weaknesses:

--- a/src/main/resources/cards/424-unified_minds.yaml
+++ b/src/main/resources/cards/424-unified_minds.yaml
@@ -3398,12 +3398,12 @@ cards:
     name: Linear Attack
     text: This attack does 40 damage to 1 of your opponent’s Pokémon. (Don’t apply
       Weakness and Resistance for Benched Pokémon.)
-  - cost: [F, P, C]
+  - cost: [P, F, C]
     name: Calamitous Slash
     damage: 160+
     text: If your opponent's Active Pokémon already has any damage counters on it,
       this attack does 80 more damage.
-  - cost: [F, P, P]
+  - cost: [P, P, F]
     name: GG End GX
     text: Discard 1 of your opponent's Pokémon and all cards attached to it. If this
       Pokémon has at least 3 extra [F] Energy attached to it (in addition to this
@@ -3468,7 +3468,7 @@ cards:
   hp: 90
   retreatCost: 2
   moves:
-  - cost: [L, W]
+  - cost: [W, L]
     name: Twister
     damage: '30'
     text: Flip 2 coins. For each heads, discard an Energy from your opponent's Active
@@ -3518,7 +3518,7 @@ cards:
       card, a [L] Energy card, or 1 of each from your hand to your Pokémon in any
       way you like.
   moves:
-  - cost: [L, W, C, C]
+  - cost: [W, L, C, C]
     name: Dragon Impact
     damage: '170'
     text: Discard 3 Energy from this Pokémon.
@@ -3538,7 +3538,7 @@ cards:
   hp: 250
   retreatCost: 2
   moves:
-  - cost: [L, W, C]
+  - cost: [W, L, C]
     name: Dragon Claw
     damage: '130'
   - cost: [C, C, C, C, C]
@@ -3685,7 +3685,7 @@ cards:
   hp: 60
   retreatCost: 1
   moves:
-  - cost: [D, P]
+  - cost: [P, D]
     name: Air Slash
     damage: '50'
     text: Discard an Energy from this Pokémon.
@@ -3709,7 +3709,7 @@ cards:
     name: Boomburst
     text: This attack does 20 damage to each of your opponent's Pokémon. (Don't apply
       Weakness and Resistance for Benched Pokémon.)
-  - cost: [D, P, C]
+  - cost: [P, D, C]
     name: Dragon Pulse
     damage: '120'
     text: Discard the top card of your deck.
@@ -5070,12 +5070,12 @@ cards:
     name: Linear Attack
     text: This attack does 40 damage to 1 of your opponent’s Pokémon. (Don’t apply
       Weakness and Resistance for Benched Pokémon.)
-  - cost: [F, P, C]
+  - cost: [P, F, C]
     name: Calamitous Slash
     damage: 160+
     text: If your opponent's Active Pokémon already has any damage counters on it,
       this attack does 80 more damage.
-  - cost: [F, P, P]
+  - cost: [P, P, F]
     name: GG End GX
     text: Discard 1 of your opponent's Pokémon and all cards attached to it. If this
       Pokémon has at least 3 extra [F] Energy attached to it (in addition to this
@@ -5099,7 +5099,7 @@ cards:
   hp: 250
   retreatCost: 2
   moves:
-  - cost: [L, W, C]
+  - cost: [W, L, C]
     name: Dragon Claw
     damage: '130'
   - cost: [C, C, C, C, C]
@@ -5545,12 +5545,12 @@ cards:
     name: Linear Attack
     text: This attack does 40 damage to 1 of your opponent’s Pokémon. (Don’t apply
       Weakness and Resistance for Benched Pokémon.)
-  - cost: [F, P, C]
+  - cost: [P, F, C]
     name: Calamitous Slash
     damage: 160+
     text: If your opponent's Active Pokémon already has any damage counters on it,
       this attack does 80 more damage.
-  - cost: [F, P, P]
+  - cost: [P, P, F]
     name: GG End GX
     text: Discard 1 of your opponent's Pokémon and all cards attached to it. If this
       Pokémon has at least 3 extra [F] Energy attached to it (in addition to this
@@ -5574,7 +5574,7 @@ cards:
   hp: 250
   retreatCost: 2
   moves:
-  - cost: [L, W, C]
+  - cost: [W, L, C]
     name: Dragon Claw
     damage: '130'
   - cost: [C, C, C, C, C]

--- a/src/main/resources/cards/425-hidden_fates.yaml
+++ b/src/main/resources/cards/425-hidden_fates.yaml
@@ -968,7 +968,7 @@ cards:
   hp: 300
   retreatCost: 3
   moves:
-  - cost: [R, L, W, C]
+  - cost: [R, W, L, C]
     name: Trinity Burn
     damage: '210'
   - cost: [C]
@@ -1263,7 +1263,7 @@ cards:
   hp: 300
   retreatCost: 3
   moves:
-  - cost: [R, L, W, C]
+  - cost: [R, W, L, C]
     name: Trinity Burn
     damage: '210'
   - cost: [C]
@@ -1316,7 +1316,7 @@ cards:
   hp: 300
   retreatCost: 3
   moves:
-  - cost: [R, L, W, C]
+  - cost: [R, W, L, C]
     name: Trinity Burn
     damage: '210'
   - cost: [C]

--- a/src/main/resources/cards/427-cosmic_eclipse.yaml
+++ b/src/main/resources/cards/427-cosmic_eclipse.yaml
@@ -5,7 +5,7 @@ set:
   enumId: COSMIC_ECLIPSE
   abbr: CEC
 cards:
-- id: 426-1
+- id: 427-1
   pioId: sm12-1
   enumId: VENUSAUR_SNIVY_GX_1
   name: Venusaur & Snivy-GX
@@ -35,7 +35,7 @@ cards:
   - type: R
     value: x2
   rarity: Ultra Rare
-- id: 426-2
+- id: 427-2
   pioId: sm12-2
   enumId: ODDISH_2
   name: Oddish
@@ -53,7 +53,7 @@ cards:
   - type: R
     value: x2
   rarity: Common
-- id: 426-3
+- id: 427-3
   pioId: sm12-3
   enumId: GLOOM_3
   name: Gloom
@@ -73,7 +73,7 @@ cards:
   - type: R
     value: x2
   rarity: Uncommon
-- id: 426-4
+- id: 427-4
   pioId: sm12-4
   enumId: VILEPLUME_GX_4
   name: Vileplume-GX
@@ -103,7 +103,7 @@ cards:
   - type: R
     value: x2
   rarity: Ultra Rare
-- id: 426-5
+- id: 427-5
   pioId: sm12-5
   enumId: TANGELA_5
   name: Tangela
@@ -122,7 +122,7 @@ cards:
   - type: R
     value: x2
   rarity: Common
-- id: 426-6
+- id: 427-6
   pioId: sm12-6
   enumId: TANGROWTH_6
   name: Tangrowth
@@ -147,7 +147,7 @@ cards:
   - type: R
     value: x2
   rarity: Uncommon
-- id: 426-7
+- id: 427-7
   pioId: sm12-7
   enumId: SUNKERN_7
   name: Sunkern
@@ -166,7 +166,7 @@ cards:
   - type: R
     value: x2
   rarity: Common
-- id: 426-8
+- id: 427-8
   pioId: sm12-8
   enumId: SUNFLORA_8
   name: Sunflora
@@ -189,7 +189,7 @@ cards:
   - type: R
     value: x2
   rarity: Rare
-- id: 426-9
+- id: 427-9
   pioId: sm12-9
   enumId: HERACROSS_9
   name: Heracross
@@ -212,7 +212,7 @@ cards:
   - type: R
     value: x2
   rarity: Uncommon
-- id: 426-10
+- id: 427-10
   pioId: sm12-10
   enumId: LILEEP_10
   name: Lileep
@@ -234,7 +234,7 @@ cards:
   - type: R
     value: x2
   rarity: Uncommon
-- id: 426-11
+- id: 427-11
   pioId: sm12-11
   enumId: CRADILY_11
   name: Cradily
@@ -258,7 +258,7 @@ cards:
   - type: R
     value: x2
   rarity: Rare
-- id: 426-12
+- id: 427-12
   pioId: sm12-12
   enumId: TROPIUS_12
   name: Tropius
@@ -281,7 +281,7 @@ cards:
   - type: R
     value: x2
   rarity: Uncommon
-- id: 426-13
+- id: 427-13
   pioId: sm12-13
   enumId: KRICKETOT_13
   name: Kricketot
@@ -302,7 +302,7 @@ cards:
   - type: R
     value: x2
   rarity: Common
-- id: 426-14
+- id: 427-14
   pioId: sm12-14
   enumId: KRICKETUNE_14
   name: Kricketune
@@ -326,7 +326,7 @@ cards:
   - type: R
     value: x2
   rarity: Uncommon
-- id: 426-15
+- id: 427-15
   pioId: sm12-15
   enumId: DEERLING_15
   name: Deerling
@@ -344,7 +344,7 @@ cards:
   - type: R
     value: x2
   rarity: Common
-- id: 426-16
+- id: 427-16
   pioId: sm12-16
   enumId: SAWSBUCK_16
   name: Sawsbuck
@@ -368,7 +368,7 @@ cards:
   - type: R
     value: x2
   rarity: Rare Holo
-- id: 426-17
+- id: 427-17
   pioId: sm12-17
   enumId: ROWLET_17
   name: Rowlet
@@ -390,7 +390,7 @@ cards:
   - type: R
     value: x2
   rarity: Common
-- id: 426-18
+- id: 427-18
   pioId: sm12-18
   enumId: ROWLET_18
   name: Rowlet
@@ -409,7 +409,7 @@ cards:
   - type: R
     value: x2
   rarity: Common
-- id: 426-19
+- id: 427-19
   pioId: sm12-19
   enumId: DARTRIX_19
   name: Dartrix
@@ -432,7 +432,7 @@ cards:
   - type: R
     value: x2
   rarity: Uncommon
-- id: 426-20
+- id: 427-20
   pioId: sm12-20
   enumId: DECIDUEYE_20
   name: Decidueye
@@ -458,7 +458,7 @@ cards:
   - type: R
     value: x2
   rarity: Rare Holo
-- id: 426-21
+- id: 427-21
   pioId: sm12-21
   enumId: BUZZWOLE_21
   name: Buzzwole
@@ -482,7 +482,7 @@ cards:
   - type: R
     value: x2
   rarity: Rare Holo
-- id: 426-22
+- id: 427-22
   pioId: sm12-22
   enumId: CHARIZARD_BRAIXEN_GX_22
   name: Charizard & Braixen-GX
@@ -508,7 +508,7 @@ cards:
   - type: W
     value: x2
   rarity: Ultra Rare
-- id: 426-23
+- id: 427-23
   pioId: sm12-23
   enumId: PONYTA_23
   name: Ponyta
@@ -530,7 +530,7 @@ cards:
   - type: W
     value: x2
   rarity: Common
-- id: 426-24
+- id: 427-24
   pioId: sm12-24
   enumId: RAPIDASH_24
   name: Rapidash
@@ -554,7 +554,7 @@ cards:
   - type: W
     value: x2
   rarity: Uncommon
-- id: 426-25
+- id: 427-25
   pioId: sm12-25
   enumId: FLAREON_25
   name: Flareon
@@ -580,7 +580,7 @@ cards:
   - type: W
     value: x2
   rarity: Uncommon
-- id: 426-26
+- id: 427-26
   pioId: sm12-26
   enumId: SLUGMA_26
   name: Slugma
@@ -598,7 +598,7 @@ cards:
   - type: W
     value: x2
   rarity: Common
-- id: 426-27
+- id: 427-27
   pioId: sm12-27
   enumId: MAGCARGO_27
   name: Magcargo
@@ -621,7 +621,7 @@ cards:
   - type: W
     value: x2
   rarity: Rare
-- id: 426-28
+- id: 427-28
   pioId: sm12-28
   enumId: ENTEI_28
   name: Entei
@@ -644,7 +644,7 @@ cards:
   - type: W
     value: x2
   rarity: Rare
-- id: 426-29
+- id: 427-29
   pioId: sm12-29
   enumId: TORKOAL_29
   name: Torkoal
@@ -667,7 +667,7 @@ cards:
   - type: W
     value: x2
   rarity: Uncommon
-- id: 426-30
+- id: 427-30
   pioId: sm12-30
   enumId: VICTINI_30
   name: Victini
@@ -690,7 +690,7 @@ cards:
   - type: W
     value: x2
   rarity: Rare Holo
-- id: 426-31
+- id: 427-31
   pioId: sm12-31
   enumId: TEPIG_31
   name: Tepig
@@ -711,7 +711,7 @@ cards:
   - type: W
     value: x2
   rarity: Common
-- id: 426-32
+- id: 427-32
   pioId: sm12-32
   enumId: PIGNITE_32
   name: Pignite
@@ -733,7 +733,7 @@ cards:
   - type: W
     value: x2
   rarity: Uncommon
-- id: 426-33
+- id: 427-33
   pioId: sm12-33
   enumId: EMBOAR_33
   name: Emboar
@@ -759,7 +759,7 @@ cards:
   - type: W
     value: x2
   rarity: Rare
-- id: 426-34
+- id: 427-34
   pioId: sm12-34
   enumId: LARVESTA_34
   name: Larvesta
@@ -780,7 +780,7 @@ cards:
   - type: W
     value: x2
   rarity: Uncommon
-- id: 426-35
+- id: 427-35
   pioId: sm12-35
   enumId: VOLCARONA_GX_35
   name: Volcarona-GX
@@ -810,7 +810,7 @@ cards:
   - type: W
     value: x2
   rarity: Ultra Rare
-- id: 426-36
+- id: 427-36
   pioId: sm12-36
   enumId: LITLEO_36
   name: Litleo
@@ -831,7 +831,7 @@ cards:
   - type: W
     value: x2
   rarity: Common
-- id: 426-37
+- id: 427-37
   pioId: sm12-37
   enumId: PYROAR_37
   name: Pyroar
@@ -855,7 +855,7 @@ cards:
   - type: W
     value: x2
   rarity: Uncommon
-- id: 426-38
+- id: 427-38
   pioId: sm12-38
   enumId: BLASTOISE_PIPLUP_GX_38
   name: Blastoise & Piplup-GX
@@ -883,7 +883,7 @@ cards:
   - type: G
     value: x2
   rarity: Ultra Rare
-- id: 426-39
+- id: 427-39
   pioId: sm12-39
   enumId: ALOLAN_VULPIX_39
   name: Alolan Vulpix
@@ -906,7 +906,7 @@ cards:
   - type: M
     value: x2
   rarity: Common
-- id: 426-40
+- id: 427-40
   pioId: sm12-40
   enumId: PSYDUCK_40
   name: Psyduck
@@ -928,7 +928,7 @@ cards:
   - type: G
     value: x2
   rarity: Common
-- id: 426-41
+- id: 427-41
   pioId: sm12-41
   enumId: GOLDUCK_41
   name: Golduck
@@ -951,7 +951,7 @@ cards:
   - type: G
     value: x2
   rarity: Uncommon
-- id: 426-42
+- id: 427-42
   pioId: sm12-42
   enumId: VAPOREON_42
   name: Vaporeon
@@ -976,7 +976,7 @@ cards:
   - type: G
     value: x2
   rarity: Uncommon
-- id: 426-43
+- id: 427-43
   pioId: sm12-43
   enumId: SNEASEL_43
   name: Sneasel
@@ -996,7 +996,7 @@ cards:
   - type: M
     value: x2
   rarity: Common
-- id: 426-44
+- id: 427-44
   pioId: sm12-44
   enumId: WEAVILE_44
   name: Weavile
@@ -1019,7 +1019,7 @@ cards:
   - type: M
     value: x2
   rarity: Rare
-- id: 426-45
+- id: 427-45
   pioId: sm12-45
   enumId: WAILMER_45
   name: Wailmer
@@ -1037,7 +1037,7 @@ cards:
   - type: G
     value: x2
   rarity: Common
-- id: 426-46
+- id: 427-46
   pioId: sm12-46
   enumId: WAILORD_46
   name: Wailord
@@ -1059,7 +1059,7 @@ cards:
   - type: G
     value: x2
   rarity: Rare
-- id: 426-47
+- id: 427-47
   pioId: sm12-47
   enumId: SNORUNT_47
   name: Snorunt
@@ -1078,7 +1078,7 @@ cards:
   - type: M
     value: x2
   rarity: Common
-- id: 426-48
+- id: 427-48
   pioId: sm12-48
   enumId: GLALIE_48
   name: Glalie
@@ -1103,7 +1103,7 @@ cards:
   - type: M
     value: x2
   rarity: Rare
-- id: 426-49
+- id: 427-49
   pioId: sm12-49
   enumId: SPHEAL_49
   name: Spheal
@@ -1124,7 +1124,7 @@ cards:
   - type: M
     value: x2
   rarity: Common
-- id: 426-50
+- id: 427-50
   pioId: sm12-50
   enumId: SPHEAL_50
   name: Spheal
@@ -1143,7 +1143,7 @@ cards:
   - type: M
     value: x2
   rarity: Common
-- id: 426-51
+- id: 427-51
   pioId: sm12-51
   enumId: SEALEO_51
   name: Sealeo
@@ -1165,7 +1165,7 @@ cards:
   - type: M
     value: x2
   rarity: Uncommon
-- id: 426-52
+- id: 427-52
   pioId: sm12-52
   enumId: WALREIN_52
   name: Walrein
@@ -1192,7 +1192,7 @@ cards:
   - type: M
     value: x2
   rarity: Rare
-- id: 426-53
+- id: 427-53
   pioId: sm12-53
   enumId: KYOGRE_53
   name: Kyogre
@@ -1214,7 +1214,7 @@ cards:
   - type: G
     value: x2
   rarity: Rare
-- id: 426-54
+- id: 427-54
   pioId: sm12-54
   enumId: PIPLUP_54
   name: Piplup
@@ -1234,7 +1234,7 @@ cards:
   - type: L
     value: x2
   rarity: Common
-- id: 426-55
+- id: 427-55
   pioId: sm12-55
   enumId: PRINPLUP_55
   name: Prinplup
@@ -1258,7 +1258,7 @@ cards:
   - type: L
     value: x2
   rarity: Uncommon
-- id: 426-56
+- id: 427-56
   pioId: sm12-56
   enumId: EMPOLEON_56
   name: Empoleon
@@ -1282,7 +1282,7 @@ cards:
   - type: L
     value: x2
   rarity: Rare
-- id: 426-57
+- id: 427-57
   pioId: sm12-57
   enumId: PHIONE_57
   name: Phione
@@ -1307,7 +1307,7 @@ cards:
   - type: G
     value: x2
   rarity: Rare
-- id: 426-58
+- id: 427-58
   pioId: sm12-58
   enumId: TYMPOLE_58
   name: Tympole
@@ -1326,7 +1326,7 @@ cards:
   - type: G
     value: x2
   rarity: Common
-- id: 426-59
+- id: 427-59
   pioId: sm12-59
   enumId: DUCKLETT_59
   name: Ducklett
@@ -1348,7 +1348,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Common
-- id: 426-60
+- id: 427-60
   pioId: sm12-60
   enumId: SWANNA_60
   name: Swanna
@@ -1374,7 +1374,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Rare
-- id: 426-61
+- id: 427-61
   pioId: sm12-61
   enumId: BLACK_KYUREM_61
   name: Black Kyurem
@@ -1397,7 +1397,7 @@ cards:
   - type: M
     value: x2
   rarity: Rare Holo
-- id: 426-62
+- id: 427-62
   pioId: sm12-62
   enumId: WISHIWASHI_62
   name: Wishiwashi
@@ -1421,7 +1421,7 @@ cards:
   - type: L
     value: x2
   rarity: Rare Holo
-- id: 426-63
+- id: 427-63
   pioId: sm12-63
   enumId: WISHIWASHI_GX_63
   name: Wishiwashi-GX
@@ -1446,7 +1446,7 @@ cards:
   - type: L
     value: x2
   rarity: Ultra Rare
-- id: 426-64
+- id: 427-64
   pioId: sm12-64
   enumId: DEWPIDER_64
   name: Dewpider
@@ -1467,7 +1467,7 @@ cards:
   - type: G
     value: x2
   rarity: Common
-- id: 426-65
+- id: 427-65
   pioId: sm12-65
   enumId: ARAQUANID_65
   name: Araquanid
@@ -1491,7 +1491,7 @@ cards:
   - type: G
     value: x2
   rarity: Uncommon
-- id: 426-66
+- id: 427-66
   pioId: sm12-66
   enumId: PIKACHU_66
   name: Pikachu
@@ -1516,7 +1516,7 @@ cards:
   - type: M
     value: '-20'
   rarity: Common
-- id: 426-67
+- id: 427-67
   pioId: sm12-67
   enumId: RAICHU_67
   name: Raichu
@@ -1543,7 +1543,7 @@ cards:
   - type: M
     value: '-20'
   rarity: Rare
-- id: 426-68
+- id: 427-68
   pioId: sm12-68
   enumId: MAGNEMITE_68
   name: Magnemite
@@ -1566,7 +1566,7 @@ cards:
   - type: M
     value: '-20'
   rarity: Common
-- id: 426-69
+- id: 427-69
   pioId: sm12-69
   enumId: MAGNETON_69
   name: Magneton
@@ -1594,7 +1594,7 @@ cards:
   - type: M
     value: '-20'
   rarity: Rare Holo
-- id: 426-70
+- id: 427-70
   pioId: sm12-70
   enumId: JOLTEON_70
   name: Jolteon
@@ -1621,7 +1621,7 @@ cards:
   - type: M
     value: '-20'
   rarity: Uncommon
-- id: 426-71
+- id: 427-71
   pioId: sm12-71
   enumId: CHINCHOU_71
   name: Chinchou
@@ -1645,7 +1645,7 @@ cards:
   - type: M
     value: '-20'
   rarity: Common
-- id: 426-72
+- id: 427-72
   pioId: sm12-72
   enumId: LANTURN_72
   name: Lanturn
@@ -1673,7 +1673,7 @@ cards:
   - type: M
     value: '-20'
   rarity: Rare
-- id: 426-73
+- id: 427-73
   pioId: sm12-73
   enumId: TOGEDEMARU_73
   name: Togedemaru
@@ -1699,7 +1699,7 @@ cards:
   - type: M
     value: '-20'
   rarity: Uncommon
-- id: 426-74
+- id: 427-74
   pioId: sm12-74
   enumId: TOGEDEMARU_74
   name: Togedemaru
@@ -1721,7 +1721,7 @@ cards:
   - type: M
     value: '-20'
   rarity: Common
-- id: 426-75
+- id: 427-75
   pioId: sm12-75
   enumId: SOLGALEO_LUNALA_GX_75
   name: Solgaleo & Lunala-GX
@@ -1746,7 +1746,7 @@ cards:
   - type: P
     value: x2
   rarity: Ultra Rare
-- id: 426-76
+- id: 427-76
   pioId: sm12-76
   enumId: KOFFING_76
   name: Koffing
@@ -1771,7 +1771,7 @@ cards:
   - type: P
     value: x2
   rarity: Common
-- id: 426-77
+- id: 427-77
   pioId: sm12-77
   enumId: WEEZING_77
   name: Weezing
@@ -1797,7 +1797,7 @@ cards:
   - type: P
     value: x2
   rarity: Rare
-- id: 426-78
+- id: 427-78
   pioId: sm12-78
   enumId: NATU_78
   name: Natu
@@ -1819,7 +1819,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Common
-- id: 426-79
+- id: 427-79
   pioId: sm12-79
   enumId: XATU_79
   name: Xatu
@@ -1845,7 +1845,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Rare
-- id: 426-80
+- id: 427-80
   pioId: sm12-80
   enumId: RALTS_80
   name: Ralts
@@ -1866,7 +1866,7 @@ cards:
   - type: P
     value: x2
   rarity: Common
-- id: 426-81
+- id: 427-81
   pioId: sm12-81
   enumId: KIRLIA_81
   name: Kirlia
@@ -1888,7 +1888,7 @@ cards:
   - type: P
     value: x2
   rarity: Uncommon
-- id: 426-82
+- id: 427-82
   pioId: sm12-82
   enumId: GALLADE_82
   name: Gallade
@@ -1912,7 +1912,7 @@ cards:
   - type: P
     value: x2
   rarity: Rare Holo
-- id: 426-83
+- id: 427-83
   pioId: sm12-83
   enumId: DUSKULL_83
   name: Duskull
@@ -1939,7 +1939,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Common
-- id: 426-84
+- id: 427-84
   pioId: sm12-84
   enumId: DUSCLOPS_84
   name: Dusclops
@@ -1963,7 +1963,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Uncommon
-- id: 426-85
+- id: 427-85
   pioId: sm12-85
   enumId: DUSKNOIR_85
   name: Dusknoir
@@ -1993,7 +1993,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Rare Holo
-- id: 426-86
+- id: 427-86
   pioId: sm12-86
   enumId: ROTOM_86
   name: Rotom
@@ -2018,7 +2018,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Uncommon
-- id: 426-87
+- id: 427-87
   pioId: sm12-87
   enumId: WOOBAT_87
   name: Woobat
@@ -2043,7 +2043,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Common
-- id: 426-88
+- id: 427-88
   pioId: sm12-88
   enumId: SWOOBAT_88
   name: Swoobat
@@ -2069,7 +2069,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Rare
-- id: 426-89
+- id: 427-89
   pioId: sm12-89
   enumId: GOLETT_89
   name: Golett
@@ -2091,7 +2091,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Common
-- id: 426-90
+- id: 427-90
   pioId: sm12-90
   enumId: GOLURK_90
   name: Golurk
@@ -2118,7 +2118,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Rare
-- id: 426-91
+- id: 427-91
   pioId: sm12-91
   enumId: SKRELP_91
   name: Skrelp
@@ -2136,7 +2136,7 @@ cards:
   - type: P
     value: x2
   rarity: Common
-- id: 426-92
+- id: 427-92
   pioId: sm12-92
   enumId: DRAGALGE_92
   name: Dragalge
@@ -2159,7 +2159,7 @@ cards:
   - type: P
     value: x2
   rarity: Rare
-- id: 426-93
+- id: 427-93
   pioId: sm12-93
   enumId: PHANTUMP_93
   name: Phantump
@@ -2183,7 +2183,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Common
-- id: 426-94
+- id: 427-94
   pioId: sm12-94
   enumId: TREVENANT_94
   name: Trevenant
@@ -2211,7 +2211,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Rare
-- id: 426-95
+- id: 427-95
   pioId: sm12-95
   enumId: ORICORIO_GX_95
   name: Oricorio-GX
@@ -2243,7 +2243,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Ultra Rare
-- id: 426-96
+- id: 427-96
   pioId: sm12-96
   enumId: MIMIKYU_96
   name: Mimikyu
@@ -2263,7 +2263,7 @@ cards:
     text: Choose 2 of your opponent's Pokémon and put 2 damage counters on each of
       them.
   rarity: Uncommon
-- id: 426-97
+- id: 427-97
   pioId: sm12-97
   enumId: MIMIKYU_97
   name: Mimikyu
@@ -2284,7 +2284,7 @@ cards:
     damage: '20'
     text: Flip a coin. If heads, your opponent’s Active Pokémon is now Confused.
   rarity: Rare
-- id: 426-98
+- id: 427-98
   pioId: sm12-98
   enumId: DHELMISE_98
   name: Dhelmise
@@ -2309,7 +2309,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Uncommon
-- id: 426-99
+- id: 427-99
   pioId: sm12-99
   enumId: COSMOG_99
   name: Cosmog
@@ -2328,7 +2328,7 @@ cards:
   - type: P
     value: x2
   rarity: Common
-- id: 426-100
+- id: 427-100
   pioId: sm12-100
   enumId: COSMOG_100
   name: Cosmog
@@ -2352,7 +2352,7 @@ cards:
   - type: P
     value: x2
   rarity: Common
-- id: 426-101
+- id: 427-101
   pioId: sm12-101
   enumId: COSMOEM_101
   name: Cosmoem
@@ -2372,7 +2372,7 @@ cards:
   - type: P
     value: x2
   rarity: Uncommon
-- id: 426-102
+- id: 427-102
   pioId: sm12-102
   enumId: LUNALA_102
   name: Lunala
@@ -2400,7 +2400,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Rare Holo
-- id: 426-103
+- id: 427-103
   pioId: sm12-103
   enumId: MARSHADOW_103
   name: Marshadow
@@ -2422,7 +2422,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Rare
-- id: 426-104
+- id: 427-104
   pioId: sm12-104
   enumId: BLACEPHALON_104
   name: Blacephalon
@@ -2445,7 +2445,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Rare Holo
-- id: 426-105
+- id: 427-105
   pioId: sm12-105
   enumId: ONIX_105
   name: Onix
@@ -2467,7 +2467,7 @@ cards:
   - type: G
     value: x2
   rarity: Common
-- id: 426-106
+- id: 427-106
   pioId: sm12-106
   enumId: NOSEPASS_106
   name: Nosepass
@@ -2489,7 +2489,7 @@ cards:
   - type: G
     value: x2
   rarity: Common
-- id: 426-107
+- id: 427-107
   pioId: sm12-107
   enumId: TRAPINCH_107
   name: Trapinch
@@ -2511,7 +2511,7 @@ cards:
   - type: G
     value: x2
   rarity: Common
-- id: 426-108
+- id: 427-108
   pioId: sm12-108
   enumId: TRAPINCH_108
   name: Trapinch
@@ -2531,7 +2531,7 @@ cards:
   - type: G
     value: x2
   rarity: Common
-- id: 426-109
+- id: 427-109
   pioId: sm12-109
   enumId: VIBRAVA_109
   name: Vibrava
@@ -2555,7 +2555,7 @@ cards:
   - type: G
     value: x2
   rarity: Uncommon
-- id: 426-110
+- id: 427-110
   pioId: sm12-110
   enumId: FLYGON_GX_110
   name: Flygon-GX
@@ -2586,7 +2586,7 @@ cards:
   - type: G
     value: x2
   rarity: Ultra Rare
-- id: 426-111
+- id: 427-111
   pioId: sm12-111
   enumId: ANORITH_111
   name: Anorith
@@ -2608,7 +2608,7 @@ cards:
   - type: G
     value: x2
   rarity: Uncommon
-- id: 426-112
+- id: 427-112
   pioId: sm12-112
   enumId: ARMALDO_112
   name: Armaldo
@@ -2633,7 +2633,7 @@ cards:
   - type: G
     value: x2
   rarity: Rare
-- id: 426-113
+- id: 427-113
   pioId: sm12-113
   enumId: GROUDON_113
   name: Groudon
@@ -2655,7 +2655,7 @@ cards:
   - type: G
     value: x2
   rarity: Rare
-- id: 426-114
+- id: 427-114
   pioId: sm12-114
   enumId: DRILBUR_114
   name: Drilbur
@@ -2676,7 +2676,7 @@ cards:
   - type: G
     value: x2
   rarity: Common
-- id: 426-115
+- id: 427-115
   pioId: sm12-115
   enumId: EXCADRILL_115
   name: Excadrill
@@ -2700,7 +2700,7 @@ cards:
   - type: G
     value: x2
   rarity: Rare Holo
-- id: 426-116
+- id: 427-116
   pioId: sm12-116
   enumId: PALPITOAD_116
   name: Palpitoad
@@ -2721,7 +2721,7 @@ cards:
   - type: G
     value: x2
   rarity: Common
-- id: 426-117
+- id: 427-117
   pioId: sm12-117
   enumId: SEISMITOAD_117
   name: Seismitoad
@@ -2747,7 +2747,7 @@ cards:
   - type: G
     value: x2
   rarity: Rare
-- id: 426-118
+- id: 427-118
   pioId: sm12-118
   enumId: THROH_118
   name: Throh
@@ -2767,7 +2767,7 @@ cards:
   - type: P
     value: x2
   rarity: Uncommon
-- id: 426-119
+- id: 427-119
   pioId: sm12-119
   enumId: PANCHAM_119
   name: Pancham
@@ -2785,7 +2785,7 @@ cards:
   - type: P
     value: x2
   rarity: Common
-- id: 426-120
+- id: 427-120
   pioId: sm12-120
   enumId: PANGORO_120
   name: Pangoro
@@ -2807,7 +2807,7 @@ cards:
   - type: P
     value: x2
   rarity: Uncommon
-- id: 426-121
+- id: 427-121
   pioId: sm12-121
   enumId: CRABRAWLER_121
   name: Crabrawler
@@ -2828,7 +2828,7 @@ cards:
   - type: P
     value: x2
   rarity: Common
-- id: 426-122
+- id: 427-122
   pioId: sm12-122
   enumId: CRABOMINABLE_122
   name: Crabominable
@@ -2854,7 +2854,7 @@ cards:
   - type: P
     value: x2
   rarity: Rare
-- id: 426-123
+- id: 427-123
   pioId: sm12-123
   enumId: ROCKRUFF_123
   name: Rockruff
@@ -2875,7 +2875,7 @@ cards:
   - type: G
     value: x2
   rarity: Common
-- id: 426-124
+- id: 427-124
   pioId: sm12-124
   enumId: LYCANROC_124
   name: Lycanroc
@@ -2901,7 +2901,7 @@ cards:
   - type: G
     value: x2
   rarity: Rare Holo
-- id: 426-125
+- id: 427-125
   pioId: sm12-125
   enumId: PASSIMIAN_125
   name: Passimian
@@ -2923,7 +2923,7 @@ cards:
   - type: P
     value: x2
   rarity: Common
-- id: 426-126
+- id: 427-126
   pioId: sm12-126
   enumId: SANDYGAST_126
   name: Sandygast
@@ -2946,7 +2946,7 @@ cards:
   - type: G
     value: x2
   rarity: Common
-- id: 426-127
+- id: 427-127
   pioId: sm12-127
   enumId: PALOSSAND_127
   name: Palossand
@@ -2972,7 +2972,7 @@ cards:
   - type: G
     value: x2
   rarity: Rare
-- id: 426-128
+- id: 427-128
   pioId: sm12-128
   enumId: ALOLAN_MEOWTH_128
   name: Alolan Meowth
@@ -2996,7 +2996,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Common
-- id: 426-129
+- id: 427-129
   pioId: sm12-129
   enumId: ALOLAN_PERSIAN_GX_129
   name: Alolan Persian-GX
@@ -3029,7 +3029,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Ultra Rare
-- id: 426-130
+- id: 427-130
   pioId: sm12-130
   enumId: ALOLAN_GRIMER_130
   name: Alolan Grimer
@@ -3054,7 +3054,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Common
-- id: 426-131
+- id: 427-131
   pioId: sm12-131
   enumId: ALOLAN_MUK_131
   name: Alolan Muk
@@ -3080,7 +3080,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Rare
-- id: 426-132
+- id: 427-132
   pioId: sm12-132
   enumId: CARVANHA_132
   name: Carvanha
@@ -3103,7 +3103,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Common
-- id: 426-133
+- id: 427-133
   pioId: sm12-133
   enumId: ABSOL_133
   name: Absol
@@ -3129,7 +3129,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Uncommon
-- id: 426-134
+- id: 427-134
   pioId: sm12-134
   enumId: PAWNIARD_134
   name: Pawniard
@@ -3153,7 +3153,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Common
-- id: 426-135
+- id: 427-135
   pioId: sm12-135
   enumId: BISHARP_135
   name: Bisharp
@@ -3180,7 +3180,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Uncommon
-- id: 426-136
+- id: 427-136
   pioId: sm12-136
   enumId: GUZZLORD_136
   name: Guzzlord
@@ -3206,7 +3206,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Rare Holo
-- id: 426-137
+- id: 427-137
   pioId: sm12-137
   enumId: ALOLAN_SANDSHREW_137
   name: Alolan Sandshrew
@@ -3230,7 +3230,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Common
-- id: 426-138
+- id: 427-138
   pioId: sm12-138
   enumId: ALOLAN_SANDSLASH_138
   name: Alolan Sandslash
@@ -3259,7 +3259,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Rare
-- id: 426-139
+- id: 427-139
   pioId: sm12-139
   enumId: STEELIX_139
   name: Steelix
@@ -3287,7 +3287,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Rare Holo
-- id: 426-140
+- id: 427-140
   pioId: sm12-140
   enumId: MAWILE_140
   name: Mawile
@@ -3313,7 +3313,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Uncommon
-- id: 426-141
+- id: 427-141
   pioId: sm12-141
   enumId: PROBOPASS_141
   name: Probopass
@@ -3340,7 +3340,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Uncommon
-- id: 426-142
+- id: 427-142
   pioId: sm12-142
   enumId: SOLGALEO_142
   name: Solgaleo
@@ -3369,7 +3369,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Rare Holo
-- id: 426-143
+- id: 427-143
   pioId: sm12-143
   enumId: TOGEPI_CLEFFA_IGGLYBUFF_GX_143
   name: Togepi & Cleffa & Igglybuff-GX
@@ -3399,7 +3399,7 @@ cards:
   - type: D
     value: '-20'
   rarity: Ultra Rare
-- id: 426-144
+- id: 427-144
   pioId: sm12-144
   enumId: CLEFAIRY_144
   name: Clefairy
@@ -3422,7 +3422,7 @@ cards:
   - type: D
     value: '-20'
   rarity: Uncommon
-- id: 426-145
+- id: 427-145
   pioId: sm12-145
   enumId: ALOLAN_NINETALES_145
   name: Alolan Ninetales
@@ -3445,7 +3445,7 @@ cards:
   - type: D
     value: '-20'
   rarity: Rare Holo
-- id: 426-146
+- id: 427-146
   pioId: sm12-146
   enumId: AZURILL_146
   name: Azurill
@@ -3462,7 +3462,7 @@ cards:
       attach a basic Energy card from your discard pile to your Active Pokémon. If
       you use this Ability, your turn ends.
   rarity: Common
-- id: 426-147
+- id: 427-147
   pioId: sm12-147
   enumId: COTTONEE_147
   name: Cottonee
@@ -3485,7 +3485,7 @@ cards:
   - type: D
     value: '-20'
   rarity: Common
-- id: 426-148
+- id: 427-148
   pioId: sm12-148
   enumId: WHIMSICOTT_148
   name: Whimsicott
@@ -3512,7 +3512,7 @@ cards:
   - type: D
     value: '-20'
   rarity: Rare
-- id: 426-149
+- id: 427-149
   pioId: sm12-149
   enumId: FLABEBE_149
   name: Flabébé
@@ -3534,7 +3534,7 @@ cards:
   - type: D
     value: '-20'
   rarity: Common
-- id: 426-150
+- id: 427-150
   pioId: sm12-150
   enumId: FLABEBE_150
   name: Flabébé
@@ -3556,7 +3556,7 @@ cards:
   - type: D
     value: '-20'
   rarity: Common
-- id: 426-151
+- id: 427-151
   pioId: sm12-151
   enumId: FLOETTE_151
   name: Floette
@@ -3584,7 +3584,7 @@ cards:
   - type: D
     value: '-20'
   rarity: Uncommon
-- id: 426-152
+- id: 427-152
   pioId: sm12-152
   enumId: FLORGES_152
   name: Florges
@@ -3614,7 +3614,7 @@ cards:
   - type: D
     value: '-20'
   rarity: Rare Holo
-- id: 426-153
+- id: 427-153
   pioId: sm12-153
   enumId: SWIRLIX_153
   name: Swirlix
@@ -3637,7 +3637,7 @@ cards:
   - type: D
     value: '-20'
   rarity: Common
-- id: 426-154
+- id: 427-154
   pioId: sm12-154
   enumId: SLURPUFF_154
   name: Slurpuff
@@ -3663,7 +3663,7 @@ cards:
   - type: D
     value: '-20'
   rarity: Rare
-- id: 426-155
+- id: 427-155
   pioId: sm12-155
   enumId: SYLVEON_155
   name: Sylveon
@@ -3692,7 +3692,7 @@ cards:
   - type: D
     value: '-20'
   rarity: Rare
-- id: 426-156
+- id: 427-156
   pioId: sm12-156
   enumId: ARCEUS_DIALGA_PALKIA_GX_156
   name: Arceus & Dialga & Palkia-GX
@@ -3703,7 +3703,7 @@ cards:
   hp: 280
   retreatCost: 3
   moves:
-  - cost: [M, W, C]
+  - cost: [W, M, C]
     name: Ultimate Ray
     damage: '150'
     text: Search your deck for up to 3 basic Energy cards and attach them to your
@@ -3720,7 +3720,7 @@ cards:
   - type: Y
     value: x2
   rarity: Ultra Rare
-- id: 426-157
+- id: 427-157
   pioId: sm12-157
   enumId: RESHIRAM_ZEKROM_GX_157
   name: Reshiram & Zekrom-GX
@@ -3748,7 +3748,7 @@ cards:
   - type: Y
     value: x2
   rarity: Ultra Rare
-- id: 426-158
+- id: 427-158
   pioId: sm12-158
   enumId: NAGANADEL_GUZZLORD_GX_158
   name: Naganadel & Guzzlord-GX
@@ -3764,7 +3764,7 @@ cards:
     text: Once during your turn (before your attack), you may discard a Pokémon from
       your hand. If you do, heal 60 damage from this Pokémon.
   moves:
-  - cost: [D, P, C]
+  - cost: [P, D, C]
     name: Jet Pierce
     damage: '180'
   - cost: [C]
@@ -3777,7 +3777,7 @@ cards:
   - type: Y
     value: x2
   rarity: Ultra Rare
-- id: 426-159
+- id: 427-159
   pioId: sm12-159
   enumId: DRAMPA_159
   name: Drampa
@@ -3800,7 +3800,7 @@ cards:
   - type: Y
     value: x2
   rarity: Rare
-- id: 426-160
+- id: 427-160
   pioId: sm12-160
   enumId: JANGMO_O_160
   name: Jangmo-o
@@ -3811,7 +3811,7 @@ cards:
   hp: 60
   retreatCost: 1
   moves:
-  - cost: [F, L]
+  - cost: [L, F]
     name: Raging Claws
     damage: 20+
     text: This attack does 10 more damage for each damage counter on this Pokémon.
@@ -3819,7 +3819,7 @@ cards:
   - type: Y
     value: x2
   rarity: Common
-- id: 426-161
+- id: 427-161
   pioId: sm12-161
   enumId: JANGMO_O_161
   name: Jangmo-o
@@ -3833,14 +3833,14 @@ cards:
   - cost: [F]
     name: Gnaw
     damage: '10'
-  - cost: [F, L, C]
+  - cost: [L, F, C]
     name: Dragon Headbutt
     damage: '50'
   weaknesses:
   - type: Y
     value: x2
   rarity: Common
-- id: 426-162
+- id: 427-162
   pioId: sm12-162
   enumId: HAKAMO_O_162
   name: Hakamo-o
@@ -3857,14 +3857,14 @@ cards:
     text: If your opponent’s Active Pokémon is a Pokémon-GX or Pokémon-EX, this Pokémon
       can evolve during the turn you play it.
   moves:
-  - cost: [F, L]
+  - cost: [L, F]
     name: Dragonslice
     damage: '30'
   weaknesses:
   - type: Y
     value: x2
   rarity: Uncommon
-- id: 426-163
+- id: 427-163
   pioId: sm12-163
   enumId: KOMMO_O_163
   name: Kommo-o
@@ -3880,7 +3880,7 @@ cards:
     name: Shout of Power
     damage: '60'
     text: Attach a basic Energy card from your discard pile to 1 of your Benched Pokémon.
-  - cost: [F, L]
+  - cost: [L, F]
     name: Scaly Uppercut
     damage: 90+
     text: You may discard a Pokémon Tool card from this Pokémon. If you do, this attack
@@ -3889,7 +3889,7 @@ cards:
   - type: Y
     value: x2
   rarity: Rare Holo
-- id: 426-164
+- id: 427-164
   pioId: sm12-164
   enumId: ULTRA_NECROZMA_164
   name: Ultra Necrozma
@@ -3913,7 +3913,7 @@ cards:
   - type: Y
     value: x2
   rarity: Rare Holo
-- id: 426-165
+- id: 427-165
   pioId: sm12-165
   enumId: MEGA_LOPUNNY_JIGGLYPUFF_GX_165
   name: Mega Lopunny & Jigglypuff-GX
@@ -3940,7 +3940,7 @@ cards:
   - type: F
     value: x2
   rarity: Ultra Rare
-- id: 426-166
+- id: 427-166
   pioId: sm12-166
   enumId: EEVEE_166
   name: Eevee
@@ -3962,7 +3962,7 @@ cards:
   - type: F
     value: x2
   rarity: Common
-- id: 426-167
+- id: 427-167
   pioId: sm12-167
   enumId: EEVEE_167
   name: Eevee
@@ -3984,7 +3984,7 @@ cards:
   - type: F
     value: x2
   rarity: Common
-- id: 426-168
+- id: 427-168
   pioId: sm12-168
   enumId: IGGLYBUFF_168
   name: Igglybuff
@@ -4001,7 +4001,7 @@ cards:
       your opponent’s Active Pokémon is now Asleep. If you use this Ability, your
       turn ends.
   rarity: Uncommon
-- id: 426-169
+- id: 427-169
   pioId: sm12-169
   enumId: AIPOM_169
   name: Aipom
@@ -4024,7 +4024,7 @@ cards:
   - type: F
     value: x2
   rarity: Common
-- id: 426-170
+- id: 427-170
   pioId: sm12-170
   enumId: AMBIPOM_170
   name: Ambipom
@@ -4048,7 +4048,7 @@ cards:
   - type: F
     value: x2
   rarity: Uncommon
-- id: 426-171
+- id: 427-171
   pioId: sm12-171
   enumId: TEDDIURSA_171
   name: Teddiursa
@@ -4069,7 +4069,7 @@ cards:
   - type: F
     value: x2
   rarity: Common
-- id: 426-172
+- id: 427-172
   pioId: sm12-172
   enumId: URSARING_172
   name: Ursaring
@@ -4092,7 +4092,7 @@ cards:
   - type: F
     value: x2
   rarity: Rare
-- id: 426-173
+- id: 427-173
   pioId: sm12-173
   enumId: ZANGOOSE_173
   name: Zangoose
@@ -4115,7 +4115,7 @@ cards:
   - type: F
     value: x2
   rarity: Uncommon
-- id: 426-174
+- id: 427-174
   pioId: sm12-174
   enumId: LILLIPUP_174
   name: Lillipup
@@ -4136,7 +4136,7 @@ cards:
   - type: F
     value: x2
   rarity: Common
-- id: 426-175
+- id: 427-175
   pioId: sm12-175
   enumId: HERDIER_175
   name: Herdier
@@ -4159,7 +4159,7 @@ cards:
   - type: F
     value: x2
   rarity: Uncommon
-- id: 426-176
+- id: 427-176
   pioId: sm12-176
   enumId: STOUTLAND_176
   name: Stoutland
@@ -4187,7 +4187,7 @@ cards:
   - type: F
     value: x2
   rarity: Rare Holo
-- id: 426-177
+- id: 427-177
   pioId: sm12-177
   enumId: RUFFLET_177
   name: Rufflet
@@ -4209,7 +4209,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Common
-- id: 426-178
+- id: 427-178
   pioId: sm12-178
   enumId: BRAVIARY_178
   name: Braviary
@@ -4236,7 +4236,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Rare
-- id: 426-179
+- id: 427-179
   pioId: sm12-179
   enumId: HELIOPTILE_179
   name: Helioptile
@@ -4258,7 +4258,7 @@ cards:
   - type: F
     value: x2
   rarity: Common
-- id: 426-180
+- id: 427-180
   pioId: sm12-180
   enumId: HELIOLISK_180
   name: Heliolisk
@@ -4281,7 +4281,7 @@ cards:
   - type: F
     value: x2
   rarity: Rare
-- id: 426-181
+- id: 427-181
   pioId: sm12-181
   enumId: STUFFUL_181
   name: Stufful
@@ -4301,7 +4301,7 @@ cards:
   - type: F
     value: x2
   rarity: Common
-- id: 426-182
+- id: 427-182
   pioId: sm12-182
   enumId: BEWEAR_182
   name: Bewear
@@ -4326,7 +4326,7 @@ cards:
   - type: F
     value: x2
   rarity: Rare
-- id: 426-183
+- id: 427-183
   pioId: sm12-183
   enumId: TYPE_NULL_183
   name: 'Type: Null'
@@ -4345,7 +4345,7 @@ cards:
   - type: F
     value: x2
   rarity: Uncommon
-- id: 426-184
+- id: 427-184
   pioId: sm12-184
   enumId: SILVALLY_GX_184
   name: Silvally-GX
@@ -4375,7 +4375,7 @@ cards:
   - type: F
     value: x2
   rarity: Ultra Rare
-- id: 426-185
+- id: 427-185
   pioId: sm12-185
   enumId: BEASTITE_185
   name: Beastite
@@ -4386,7 +4386,7 @@ cards:
   text: [The attacks of the Ultra Beast this card is attached to do 10 more damage
       to your opponent’s Active Pokémon for each Prize card you have taken (before
       applying Weakness and Resistance).]
-- id: 426-186
+- id: 427-186
   pioId: sm12-186
   enumId: BELLELBA_BRYCEN_MAN_186
   name: Bellelba & Brycen-Man
@@ -4398,7 +4398,7 @@ cards:
       card, you may discard 3 other cards from your hand. If you do, each player discards
       their Benched Pokémon until they have 3 Benched Pokémon. Your opponent discards
       first.']
-- id: 426-187
+- id: 427-187
   pioId: sm12-187
   enumId: CHAOTIC_SWELL_187
   name: Chaotic Swell
@@ -4408,7 +4408,7 @@ cards:
   rarity: Uncommon
   text: ['Whenever either player plays a Stadium card from their hand, discard that
       Stadium card after discarding this one. (The new Stadium card has no effect.)']
-- id: 426-188
+- id: 427-188
   pioId: sm12-188
   enumId: CLAY_188
   name: Clay
@@ -4418,7 +4418,7 @@ cards:
   rarity: Uncommon
   text: ['Discard the top 7 cards of your deck. If any of those cards are Item cards,
       put them into your hand.']
-- id: 426-189
+- id: 427-189
   pioId: sm12-189
   enumId: CYNTHIA_CAITLIN_189
   name: Cynthia & Caitlin
@@ -4430,7 +4430,7 @@ cards:
       Cynthia & Caitlin or a card you discarded with the effect of this card., 'When
       you play this card, you may discard another card from your hand. If you do,
       draw 3 cards.']
-- id: 426-190
+- id: 427-190
   pioId: sm12-190
   enumId: DRAGONIUM_Z_DRAGON_CLAW_190
   name: 'Dragonium Z: Dragon Claw'
@@ -4439,7 +4439,7 @@ cards:
   subTypes: [ITEM, POKEMON_TOOL]
   rarity: Uncommon
   text: []
-- id: 426-191
+- id: 427-191
   pioId: sm12-191
   enumId: ERIKA_191
   name: Erika
@@ -4448,7 +4448,7 @@ cards:
   subTypes: [SUPPORTER]
   rarity: Uncommon
   text: [Each player may draw up to 3 cards. You draw first.]
-- id: 426-192
+- id: 427-192
   pioId: sm12-192
   enumId: GREAT_CATCHER_192
   name: Great Catcher
@@ -4459,7 +4459,7 @@ cards:
   text: [You can play this card only if you discard 2 other cards from your hand.,
     Switch 1 of your opponent's Benched Pokémon-GX or Pokémon-EX with their Active
       Pokémon.]
-- id: 426-193
+- id: 427-193
   pioId: sm12-193
   enumId: GUZMA_HALA_193
   name: Guzma & Hala
@@ -4471,7 +4471,7 @@ cards:
       Then, shuffle your deck.', 'When you play this card, you may discard 2 other
       cards from your hand. If you do, you may also search for a Pokémon Tool card
       and a Special Energy card in this way.']
-- id: 426-194
+- id: 427-194
   pioId: sm12-194
   enumId: ISLAND_CHALLENGE_AMULET_194
   name: Island Challenge Amulet
@@ -4482,7 +4482,7 @@ cards:
   text: ['The Pokémon-GX or Pokémon-EX this card is attached to gets -100 HP, and
       when it is Knocked Out by damage from an opponent’s attack, that player takes
       1 fewer Prize card.']
-- id: 426-195
+- id: 427-195
   pioId: sm12-195
   enumId: LANA_S_FISHING_ROD_195
   name: Lana's Fishing Rod
@@ -4492,7 +4492,7 @@ cards:
   rarity: Uncommon
   text: [Shuffle a Pokémon and a Pokémon Tool card from your discard pile into your
       deck.]
-- id: 426-196
+- id: 427-196
   pioId: sm12-196
   enumId: LILLIE_S_FULL_FORCE_196
   name: Lillie's Full Force
@@ -4503,7 +4503,7 @@ cards:
   text: [Draw 4 cards., 'At the end of this turn, if you have 3 or more cards in your
       hand, shuffle cards from your hand into your deck until you have 2 cards in
       your hand.']
-- id: 426-197
+- id: 427-197
   pioId: sm12-197
   enumId: LILLIE_S_POKE_DOLL_197
   name: Lillie's Poké Doll
@@ -4516,7 +4516,7 @@ cards:
       may discard all cards from it and put it on the bottom of your deck.', 'This
       card can''t retreat. If this card is Knocked Out, your opponent can''t take
       any Prize cards for it.']
-- id: 426-198
+- id: 427-198
   pioId: sm12-198
   enumId: MALLOW_LANA_198
   name: Mallow & Lana
@@ -4527,7 +4527,7 @@ cards:
   text: ['Switch your Active Pokémon with 1 of your Benched Pokémon. ', 'When you
       play this card, you may discard 2 other cards from your hand. If you do, heal
       120 damage from the Pokémon you moved to your Bench.']
-- id: 426-199
+- id: 427-199
   pioId: sm12-199
   enumId: MISTY_LORELEI_199
   name: Misty & Lorelei
@@ -4539,7 +4539,7 @@ cards:
       into your hand. Then, shuffle your deck.', 'When you play this card, you may
       discard 5 other cards from your hand. If you do, during this turn, your [W]
       Pokémon can use their GX attacks even if you have used your GX attack.']
-- id: 426-200
+- id: 427-200
   pioId: sm12-200
   enumId: N_S_RESOLVE_200
   name: N's Resolve
@@ -4549,7 +4549,7 @@ cards:
   rarity: Uncommon
   text: ['Discard the top 6 cards of your deck. If any of those cards are basic Energy
       cards, attach them to 1 of your Benched [N] Pokémon.']
-- id: 426-201
+- id: 427-201
   pioId: sm12-201
   enumId: PROFESSOR_OAK_S_SETUP_201
   name: Professor Oak's Setup
@@ -4558,7 +4558,7 @@ cards:
   subTypes: [SUPPORTER]
   rarity: Uncommon
   text: []
-- id: 426-202
+- id: 427-202
   pioId: sm12-202
   enumId: RED_BLUE_202
   name: Red & Blue
@@ -4572,7 +4572,7 @@ cards:
       this turn.)', 'When you play this card, you may discard 2 other cards from your
       hand. If you do, search your deck for up to 2 basic Energy cards and attach
       them to the Pokémon you evolved in this way.']
-- id: 426-203
+- id: 427-203
   pioId: sm12-203
   enumId: ROLLER_SKATER_203
   name: Roller Skater
@@ -4582,7 +4582,7 @@ cards:
   rarity: Uncommon
   text: ['Discard a card from your hand. If you do, draw 2 cards. If you discarded
       an Energy card in this way, draw 2 more cards.']
-- id: 426-204
+- id: 427-204
   pioId: sm12-204
   enumId: ROSA_204
   name: Rosa
@@ -4594,7 +4594,7 @@ cards:
       opponent's last turn., 'Search your deck for a Pokémon, a Trainer card, and
       a basic Energy card, reveal them, and put them into your hand. Then, shuffle
       your deck.']
-- id: 426-205
+- id: 427-205
   pioId: sm12-205
   enumId: ROXIE_205
   name: Roxie
@@ -4604,7 +4604,7 @@ cards:
   rarity: Uncommon
   text: [Discard up to 2 Pokémon that aren't Pokémon-GX or Pokémon-EX from your hand.
       Draw 3 cards for each card you discarded in this way.]
-- id: 426-206
+- id: 427-206
   pioId: sm12-206
   enumId: TAG_CALL_206
   name: Tag Call
@@ -4614,7 +4614,7 @@ cards:
   rarity: Uncommon
   text: ['Search your deck for up to 2 TAG TEAM cards, reveal them, and put them into
       your hand. Then, shuffle your deck.']
-- id: 426-207
+- id: 427-207
   pioId: sm12-207
   enumId: UNIDENTIFIED_FOSSIL_207
   name: Unidentified Fossil
@@ -4625,7 +4625,7 @@ cards:
   text: ['Play this card as if it were a 60-HP [C] Basic Pokémon. At any time during
       your turn (before your attack), you may discard this card from play.', This
       card can't retreat.]
-- id: 426-208
+- id: 427-208
   pioId: sm12-208
   enumId: WILL_208
   name: Will
@@ -4636,7 +4636,7 @@ cards:
   text: ['The next time you flip any number of coins for the effect of an attack,
       Ability, or Trainer card this turn, choose heads or tails for the first coin
       flip.']
-- id: 426-209
+- id: 427-209
   pioId: sm12-209
   enumId: DRAW_ENERGY_209
   name: Draw Energy
@@ -4646,7 +4646,7 @@ cards:
   rarity: Uncommon
   text: ['This card provides [C] Energy. ', 'When you attach this card from your hand
       to a Pokémon, draw a card.']
-- id: 426-210
+- id: 427-210
   pioId: sm12-210
   enumId: VENUSAUR_SNIVY_GX_210
   name: Venusaur & Snivy-GX
@@ -4676,9 +4676,9 @@ cards:
   - type: R
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-1
+  copyOf: 427-1
   copyType: Full Art
-- id: 426-211
+- id: 427-211
   pioId: sm12-211
   enumId: VILEPLUME_GX_211
   name: Vileplume-GX
@@ -4708,7 +4708,7 @@ cards:
   - type: R
     value: x2
   rarity: Ultra Rare
-- id: 426-212
+- id: 427-212
   pioId: sm12-212
   enumId: CHARIZARD_BRAIXEN_GX_212
   name: Charizard & Braixen-GX
@@ -4734,9 +4734,9 @@ cards:
   - type: W
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-22
+  copyOf: 427-22
   copyType: Full Art
-- id: 426-213
+- id: 427-213
   pioId: sm12-213
   enumId: VOLCARONA_GX_213
   name: Volcarona-GX
@@ -4766,9 +4766,9 @@ cards:
   - type: W
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-35
+  copyOf: 427-35
   copyType: Full Art
-- id: 426-214
+- id: 427-214
   pioId: sm12-214
   enumId: BLASTOISE_PIPLUP_GX_214
   name: Blastoise & Piplup-GX
@@ -4796,9 +4796,9 @@ cards:
   - type: G
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-38
+  copyOf: 427-38
   copyType: Full Art
-- id: 426-215
+- id: 427-215
   pioId: sm12-215
   enumId: BLASTOISE_PIPLUP_GX_215
   name: Blastoise & Piplup-GX
@@ -4826,9 +4826,9 @@ cards:
   - type: G
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-38
+  copyOf: 427-38
   copyType: Full Art
-- id: 426-216
+- id: 427-216
   pioId: sm12-216
   enumId: SOLGALEO_LUNALA_GX_216
   name: Solgaleo & Lunala-GX
@@ -4853,9 +4853,9 @@ cards:
   - type: P
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-75
+  copyOf: 427-75
   copyType: Full Art
-- id: 426-217
+- id: 427-217
   pioId: sm12-217
   enumId: ORICORIO_GX_217
   name: Oricorio-GX
@@ -4887,9 +4887,9 @@ cards:
   - type: F
     value: '-20'
   rarity: Ultra Rare
-  copyOf: 426-95
+  copyOf: 427-95
   copyType: Full Art
-- id: 426-218
+- id: 427-218
   pioId: sm12-218
   enumId: FLYGON_GX_218
   name: Flygon-GX
@@ -4920,9 +4920,9 @@ cards:
   - type: G
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-110
+  copyOf: 427-110
   copyType: Full Art
-- id: 426-219
+- id: 427-219
   pioId: sm12-219
   enumId: ALOLAN_PERSIAN_GX_219
   name: Alolan Persian-GX
@@ -4955,9 +4955,9 @@ cards:
   - type: P
     value: '-20'
   rarity: Ultra Rare
-  copyOf: 426-129
+  copyOf: 427-129
   copyType: Full Art
-- id: 426-220
+- id: 427-220
   pioId: sm12-220
   enumId: ARCEUS_DIALGA_PALKIA_GX_220
   name: Arceus & Dialga & Palkia-GX
@@ -4968,7 +4968,7 @@ cards:
   hp: 280
   retreatCost: 3
   moves:
-  - cost: [M, W, C]
+  - cost: [W, M, C]
     name: Ultimate Ray
     damage: '150'
     text: Search your deck for up to 3 basic Energy cards and attach them to your
@@ -4985,9 +4985,9 @@ cards:
   - type: Y
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-156
+  copyOf: 427-156
   copyType: Full Art
-- id: 426-221
+- id: 427-221
   pioId: sm12-221
   enumId: ARCEUS_DIALGA_PALKIA_GX_221
   name: Arceus & Dialga & Palkia-GX
@@ -4998,7 +4998,7 @@ cards:
   hp: 280
   retreatCost: 3
   moves:
-  - cost: [M, W, C]
+  - cost: [W, M, C]
     name: Ultimate Ray
     damage: '150'
     text: Search your deck for up to 3 basic Energy cards and attach them to your
@@ -5015,9 +5015,9 @@ cards:
   - type: Y
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-156
+  copyOf: 427-156
   copyType: Full Art
-- id: 426-222
+- id: 427-222
   pioId: sm12-222
   enumId: RESHIRAM_ZEKROM_GX_222
   name: Reshiram & Zekrom-GX
@@ -5045,9 +5045,9 @@ cards:
   - type: Y
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-157
+  copyOf: 427-157
   copyType: Full Art
-- id: 426-223
+- id: 427-223
   pioId: sm12-223
   enumId: NAGANADEL_GUZZLORD_GX_223
   name: Naganadel & Guzzlord-GX
@@ -5063,7 +5063,7 @@ cards:
     text: Once during your turn (before your attack), you may discard a Pokémon from
       your hand. If you do, heal 60 damage from this Pokémon.
   moves:
-  - cost: [D, P, C]
+  - cost: [P, D, C]
     name: Jet Pierce
     damage: '180'
   - cost: [C]
@@ -5076,9 +5076,9 @@ cards:
   - type: Y
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-158
+  copyOf: 427-158
   copyType: Full Art
-- id: 426-224
+- id: 427-224
   pioId: sm12-224
   enumId: NAGANADEL_GUZZLORD_GX_224
   name: Naganadel & Guzzlord-GX
@@ -5094,7 +5094,7 @@ cards:
     text: Once during your turn (before your attack), you may discard a Pokémon from
       your hand. If you do, heal 60 damage from this Pokémon.
   moves:
-  - cost: [D, P, C]
+  - cost: [P, D, C]
     name: Jet Pierce
     damage: '180'
   - cost: [C]
@@ -5107,9 +5107,9 @@ cards:
   - type: Y
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-158
+  copyOf: 427-158
   copyType: Full Art
-- id: 426-225
+- id: 427-225
   pioId: sm12-225
   enumId: MEGA_LOPUNNY_JIGGLYPUFF_GX_225
   name: Mega Lopunny & Jigglypuff-GX
@@ -5136,9 +5136,9 @@ cards:
   - type: F
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-165
+  copyOf: 427-165
   copyType: Full Art
-- id: 426-226
+- id: 427-226
   pioId: sm12-226
   enumId: MEGA_LOPUNNY_JIGGLYPUFF_GX_226
   name: Mega Lopunny & Jigglypuff-GX
@@ -5165,9 +5165,9 @@ cards:
   - type: F
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-165
+  copyOf: 427-165
   copyType: Full Art
-- id: 426-227
+- id: 427-227
   pioId: sm12-227
   enumId: SILVALLY_GX_227
   name: Silvally-GX
@@ -5197,9 +5197,9 @@ cards:
   - type: F
     value: x2
   rarity: Ultra Rare
-  copyOf: 426-184
+  copyOf: 427-184
   copyType: Full Art
-- id: 426-228
+- id: 427-228
   pioId: sm12-228
   enumId: CYNTHIA_CAITLIN_228
   name: Cynthia & Caitlin
@@ -5211,9 +5211,9 @@ cards:
       Cynthia & Caitlin or a card you discarded with the effect of this card., 'When
       you play this card, you may discard another card from your hand. If you do,
       draw 3 cards.']
-  copyOf: 426-189
+  copyOf: 427-189
   copyType: Full Art
-- id: 426-229
+- id: 427-229
   pioId: sm12-229
   enumId: GUZMA_HALA_229
   name: Guzma & Hala
@@ -5225,9 +5225,9 @@ cards:
       Then, shuffle your deck.', 'When you play this card, you may discard 2 other
       cards from your hand. If you do, you may also search for a Pokémon Tool card
       and a Special Energy card in this way.']
-  copyOf: 426-193
+  copyOf: 427-193
   copyType: Full Art
-- id: 426-230
+- id: 427-230
   pioId: sm12-230
   enumId: LILLIE_S_FULL_FORCE_230
   name: Lillie's Full Force
@@ -5238,9 +5238,9 @@ cards:
   text: [Draw 4 cards., 'At the end of this turn, if you have 3 or more cards in your
       hand, shuffle cards from your hand into your deck until you have 2 cards in
       your hand.']
-  copyOf: 426-196
+  copyOf: 427-196
   copyType: Full Art
-- id: 426-231
+- id: 427-231
   pioId: sm12-231
   enumId: MALLOW_LANA_231
   name: Mallow & Lana
@@ -5251,9 +5251,9 @@ cards:
   text: ['Switch your Active Pokémon with 1 of your Benched Pokémon. ', 'When you
       play this card, you may discard 2 other cards from your hand. If you do, heal
       120 damage from the Pokémon you moved to your Bench.']
-  copyOf: 426-198
+  copyOf: 427-198
   copyType: Full Art
-- id: 426-232
+- id: 427-232
   pioId: sm12-232
   enumId: N_S_RESOLVE_232
   name: N's Resolve
@@ -5263,9 +5263,9 @@ cards:
   rarity: Ultra Rare
   text: ['Discard the top 6 cards of your deck. If any of those cards are basic Energy
       cards, attach them to 1 of your Benched [N] Pokémon.']
-  copyOf: 426-200
+  copyOf: 427-200
   copyType: Full Art
-- id: 426-233
+- id: 427-233
   pioId: sm12-233
   enumId: PROFESSOR_OAK_S_SETUP_233
   name: Professor Oak's Setup
@@ -5275,7 +5275,7 @@ cards:
   rarity: Ultra Rare
   text: ['Search your deck for up to 3 Basic Pokémon of different types and put them
       onto your Bench. Then, shuffle your deck.']
-- id: 426-234
+- id: 427-234
   pioId: sm12-234
   enumId: RED_BLUE_234
   name: Red & Blue
@@ -5289,9 +5289,9 @@ cards:
       this turn.)', 'When you play this card, you may discard 2 other cards from your
       hand. If you do, search your deck for up to 2 basic Energy cards and attach
       them to the Pokémon you evolved in this way.']
-  copyOf: 426-202
+  copyOf: 427-202
   copyType: Full Art
-- id: 426-235
+- id: 427-235
   pioId: sm12-235
   enumId: ROLLER_SKATER_235
   name: Roller Skater
@@ -5301,9 +5301,9 @@ cards:
   rarity: Ultra Rare
   text: ['Discard a card from your hand. If you do, draw 2 cards. If you discarded
       an Energy card in this way, draw 2 more cards.']
-  copyOf: 426-203
+  copyOf: 427-203
   copyType: Full Art
-- id: 426-236
+- id: 427-236
   pioId: sm12-236
   enumId: ROSA_236
   name: Rosa
@@ -5315,9 +5315,9 @@ cards:
       opponent's last turn., 'Search your deck for a Pokémon, a Trainer card, and
       a basic Energy card, reveal them, and put them into your hand. Then, shuffle
       your deck.']
-  copyOf: 426-204
+  copyOf: 427-204
   copyType: Full Art
-- id: 426-237
+- id: 427-237
   pioId: sm12-237
   enumId: TORKOAL_237
   name: Torkoal
@@ -5340,9 +5340,9 @@ cards:
   - type: W
     value: x2
   rarity: Secret
-  copyOf: 426-29
+  copyOf: 427-29
   copyType: Secret Art
-- id: 426-238
+- id: 427-238
   pioId: sm12-238
   enumId: WEAVILE_238
   name: Weavile
@@ -5365,9 +5365,9 @@ cards:
   - type: M
     value: x2
   rarity: Secret
-  copyOf: 426-44
+  copyOf: 427-44
   copyType: Secret Art
-- id: 426-239
+- id: 427-239
   pioId: sm12-239
   enumId: PIPLUP_239
   name: Piplup
@@ -5387,9 +5387,9 @@ cards:
   - type: L
     value: x2
   rarity: Secret
-  copyOf: 426-54
+  copyOf: 427-54
   copyType: Secret Art
-- id: 426-240
+- id: 427-240
   pioId: sm12-240
   enumId: WISHIWASHI_240
   name: Wishiwashi
@@ -5413,9 +5413,9 @@ cards:
   - type: L
     value: x2
   rarity: Secret
-  copyOf: 426-62
+  copyOf: 427-62
   copyType: Secret Art
-- id: 426-241
+- id: 427-241
   pioId: sm12-241
   enumId: PIKACHU_241
   name: Pikachu
@@ -5440,9 +5440,9 @@ cards:
   - type: M
     value: '-20'
   rarity: Secret
-  copyOf: 426-66
+  copyOf: 427-66
   copyType: Secret Art
-- id: 426-242
+- id: 427-242
   pioId: sm12-242
   enumId: MAGNEMITE_242
   name: Magnemite
@@ -5465,9 +5465,9 @@ cards:
   - type: M
     value: '-20'
   rarity: Secret
-  copyOf: 426-68
+  copyOf: 427-68
   copyType: Secret Art
-- id: 426-243
+- id: 427-243
   pioId: sm12-243
   enumId: KOFFING_243
   name: Koffing
@@ -5492,9 +5492,9 @@ cards:
   - type: P
     value: x2
   rarity: Secret
-  copyOf: 426-76
+  copyOf: 427-76
   copyType: Secret Art
-- id: 426-244
+- id: 427-244
   pioId: sm12-244
   enumId: GALLADE_244
   name: Gallade
@@ -5518,9 +5518,9 @@ cards:
   - type: P
     value: x2
   rarity: Secret
-  copyOf: 426-82
+  copyOf: 427-82
   copyType: Secret Art
-- id: 426-245
+- id: 427-245
   pioId: sm12-245
   enumId: MIMIKYU_245
   name: Mimikyu
@@ -5540,9 +5540,9 @@ cards:
     text: Choose 2 of your opponent's Pokémon and put 2 damage counters on each of
       them.
   rarity: Secret
-  copyOf: 426-96
+  copyOf: 427-96
   copyType: Secret Art
-- id: 426-246
+- id: 427-246
   pioId: sm12-246
   enumId: EXCADRILL_246
   name: Excadrill
@@ -5566,9 +5566,9 @@ cards:
   - type: G
     value: x2
   rarity: Secret
-  copyOf: 426-115
+  copyOf: 427-115
   copyType: Secret Art
-- id: 426-247
+- id: 427-247
   pioId: sm12-247
   enumId: STEELIX_247
   name: Steelix
@@ -5596,9 +5596,9 @@ cards:
   - type: P
     value: '-20'
   rarity: Secret
-  copyOf: 426-139
+  copyOf: 427-139
   copyType: Secret Art
-- id: 426-248
+- id: 427-248
   pioId: sm12-248
   enumId: STOUTLAND_248
   name: Stoutland
@@ -5626,9 +5626,9 @@ cards:
   - type: F
     value: x2
   rarity: Secret
-  copyOf: 426-176
+  copyOf: 427-176
   copyType: Secret Art
-- id: 426-249
+- id: 427-249
   pioId: sm12-249
   enumId: VENUSAUR_SNIVY_GX_249
   name: Venusaur & Snivy-GX
@@ -5658,9 +5658,9 @@ cards:
   - type: R
     value: x2
   rarity: Secret
-  copyOf: 426-1
+  copyOf: 427-1
   copyType: Secret Art
-- id: 426-250
+- id: 427-250
   pioId: sm12-250
   enumId: VILEPLUME_GX_250
   name: Vileplume-GX
@@ -5690,9 +5690,9 @@ cards:
   - type: R
     value: x2
   rarity: Secret
-  copyOf: 426-211
+  copyOf: 427-211
   copyType: Secret Art
-- id: 426-251
+- id: 427-251
   pioId: sm12-251
   enumId: CHARIZARD_BRAIXEN_GX_251
   name: Charizard & Braixen-GX
@@ -5718,9 +5718,9 @@ cards:
   - type: W
     value: x2
   rarity: Secret
-  copyOf: 426-22
+  copyOf: 427-22
   copyType: Secret Art
-- id: 426-252
+- id: 427-252
   pioId: sm12-252
   enumId: VOLCARONA_GX_252
   name: Volcarona-GX
@@ -5750,9 +5750,9 @@ cards:
   - type: W
     value: x2
   rarity: Secret
-  copyOf: 426-35
+  copyOf: 427-35
   copyType: Secret Art
-- id: 426-253
+- id: 427-253
   pioId: sm12-253
   enumId: BLASTOISE_PIPLUP_GX_253
   name: Blastoise & Piplup-GX
@@ -5780,9 +5780,9 @@ cards:
   - type: G
     value: x2
   rarity: Secret
-  copyOf: 426-38
+  copyOf: 427-38
   copyType: Secret Art
-- id: 426-254
+- id: 427-254
   pioId: sm12-254
   enumId: SOLGALEO_LUNALA_GX_254
   name: Solgaleo & Lunala-GX
@@ -5807,9 +5807,9 @@ cards:
   - type: P
     value: x2
   rarity: Secret
-  copyOf: 426-75
+  copyOf: 427-75
   copyType: Secret Art
-- id: 426-255
+- id: 427-255
   pioId: sm12-255
   enumId: ORICORIO_GX_255
   name: Oricorio-GX
@@ -5841,9 +5841,9 @@ cards:
   - type: F
     value: '-20'
   rarity: Secret
-  copyOf: 426-95
+  copyOf: 427-95
   copyType: Secret Art
-- id: 426-256
+- id: 427-256
   pioId: sm12-256
   enumId: FLYGON_GX_256
   name: Flygon-GX
@@ -5874,9 +5874,9 @@ cards:
   - type: G
     value: x2
   rarity: Secret
-  copyOf: 426-110
+  copyOf: 427-110
   copyType: Secret Art
-- id: 426-257
+- id: 427-257
   pioId: sm12-257
   enumId: ALOLAN_PERSIAN_GX_257
   name: Alolan Persian-GX
@@ -5909,9 +5909,9 @@ cards:
   - type: P
     value: '-20'
   rarity: Secret
-  copyOf: 426-129
+  copyOf: 427-129
   copyType: Secret Art
-- id: 426-258
+- id: 427-258
   pioId: sm12-258
   enumId: ARCEUS_DIALGA_PALKIA_GX_258
   name: Arceus & Dialga & Palkia-GX
@@ -5922,7 +5922,7 @@ cards:
   hp: 280
   retreatCost: 3
   moves:
-  - cost: [M, W, C]
+  - cost: [W, M, C]
     name: Ultimate Ray
     damage: '150'
     text: Search your deck for up to 3 basic Energy cards and attach them to your
@@ -5939,9 +5939,9 @@ cards:
   - type: Y
     value: x2
   rarity: Secret
-  copyOf: 426-156
+  copyOf: 427-156
   copyType: Secret Art
-- id: 426-259
+- id: 427-259
   pioId: sm12-259
   enumId: RESHIRAM_ZEKROM_GX_259
   name: Reshiram & Zekrom-GX
@@ -5969,9 +5969,9 @@ cards:
   - type: Y
     value: x2
   rarity: Secret
-  copyOf: 426-157
+  copyOf: 427-157
   copyType: Secret Art
-- id: 426-260
+- id: 427-260
   pioId: sm12-260
   enumId: NAGANADEL_GUZZLORD_GX_260
   name: Naganadel & Guzzlord-GX
@@ -5987,7 +5987,7 @@ cards:
     text: Once during your turn (before your attack), you may discard a Pokémon from
       your hand. If you do, heal 60 damage from this Pokémon.
   moves:
-  - cost: [D, P, C]
+  - cost: [P, D, C]
     name: Jet Pierce
     damage: '180'
   - cost: [C]
@@ -6000,9 +6000,9 @@ cards:
   - type: Y
     value: x2
   rarity: Secret
-  copyOf: 426-158
+  copyOf: 427-158
   copyType: Secret Art
-- id: 426-261
+- id: 427-261
   pioId: sm12-261
   enumId: MEGA_LOPUNNY_JIGGLYPUFF_GX_261
   name: Mega Lopunny & Jigglypuff-GX
@@ -6029,9 +6029,9 @@ cards:
   - type: F
     value: x2
   rarity: Secret
-  copyOf: 426-165
+  copyOf: 427-165
   copyType: Secret Art
-- id: 426-262
+- id: 427-262
   pioId: sm12-262
   enumId: SILVALLY_GX_262
   name: Silvally-GX
@@ -6061,9 +6061,9 @@ cards:
   - type: F
     value: x2
   rarity: Secret
-  copyOf: 426-184
+  copyOf: 427-184
   copyType: Secret Art
-- id: 426-263
+- id: 427-263
   pioId: sm12-263
   enumId: GIANT_HEARTH_263
   name: Giant Hearth
@@ -6075,7 +6075,7 @@ cards:
       hand. If they do, that player searches their deck for up to 2 [R] Energy cards,
       reveals them, and puts them into their hand. Then, that player shuffles their
       deck.']
-- id: 426-264
+- id: 427-264
   pioId: sm12-264
   enumId: GREAT_CATCHER_264
   name: Great Catcher
@@ -6086,9 +6086,9 @@ cards:
   text: [You can play this card only if you discard 2 other cards from your hand.,
     Switch 1 of your opponent's Benched Pokémon-GX or Pokémon-EX with their Active
       Pokémon.]
-  copyOf: 426-192
+  copyOf: 427-192
   copyType: Secret Art
-- id: 426-265
+- id: 427-265
   pioId: sm12-265
   enumId: ISLAND_CHALLENGE_AMULET_265
   name: Island Challenge Amulet
@@ -6099,9 +6099,9 @@ cards:
   text: ['The Pokémon-GX or Pokémon-EX this card is attached to gets -100 HP, and
       when it is Knocked Out by damage from an opponent’s attack, that player takes
       1 fewer Prize card.']
-  copyOf: 426-194
+  copyOf: 427-194
   copyType: Secret Art
-- id: 426-266
+- id: 427-266
   pioId: sm12-266
   enumId: LANA_S_FISHING_ROD_266
   name: Lana's Fishing Rod
@@ -6111,9 +6111,9 @@ cards:
   rarity: Secret
   text: [Shuffle a Pokémon and a Pokémon Tool card from your discard pile into your
       deck.]
-  copyOf: 426-195
+  copyOf: 427-195
   copyType: Secret Art
-- id: 426-267
+- id: 427-267
   pioId: sm12-267
   enumId: LILLIE_S_POKE_DOLL_267
   name: Lillie's Poké Doll
@@ -6126,9 +6126,9 @@ cards:
       may discard all cards from it and put it on the bottom of your deck.', 'This
       card can''t retreat. If this card is Knocked Out, your opponent can''t take
       any Prize cards for it.']
-  copyOf: 426-197
+  copyOf: 427-197
   copyType: Secret Art
-- id: 426-268
+- id: 427-268
   pioId: sm12-268
   enumId: MARTIAL_ARTS_DOJO_268
   name: Martial Arts Dojo
@@ -6141,7 +6141,7 @@ cards:
       Active Pokémon (before applying Weakness and Resistance). If the attacking player
       has more Prize cards remaining than their opponent, those attacks do 40 more
       damage instead.']
-- id: 426-269
+- id: 427-269
   pioId: sm12-269
   enumId: POWER_PLANT_269
   name: Power Plant
@@ -6151,7 +6151,7 @@ cards:
   rarity: Secret
   text: [Pokémon-GX and Pokémon-EX in play (both yours and your opponent's) have no
       Abilities.]
-- id: 426-270
+- id: 427-270
   pioId: sm12-270
   enumId: TAG_CALL_270
   name: Tag Call
@@ -6161,9 +6161,9 @@ cards:
   rarity: Secret
   text: ['Search your deck for up to 2 TAG TEAM cards, reveal them, and put them into
       your hand. Then, shuffle your deck.']
-  copyOf: 426-206
+  copyOf: 427-206
   copyType: Secret Art
-- id: 426-271
+- id: 427-271
   pioId: sm12-271
   enumId: DRAW_ENERGY_271
   name: Draw Energy
@@ -6173,5 +6173,5 @@ cards:
   rarity: Secret
   text: ['This card provides [C] Energy. ', 'When you attach this card from your hand
       to a Pokémon, draw a card.']
-  copyOf: 426-209
+  copyOf: 427-209
   copyType: Secret Art


### PR DESCRIPTION
Cosmic Eclipse's IDs were all set to 426 instead of 427. Surprised it didn't throw any errors, but I suppose it wasn't a massive deal. Also fixes certain Tag Teams/Dragon Pokemon that have incorrect attack costs. Not that they were inherently wrong, just that the cost orders were incorrect compared to the card.