### PR TITLE
Fix Sword & Shield promos and update formats.yaml

### DIFF
--- a/src/main/resources/cards/429-sword_shield_promos.yaml
+++ b/src/main/resources/cards/429-sword_shield_promos.yaml
@@ -5,11 +5,11 @@ set:
   enumId: SWORD_SHIELD_PROMOS
   abbr: SWSH
 cards:
-- id: 429-SWSH01
-  pioId: swsh-SWSH01
+- id: 429-SWSH001
+  pioId: swsh-SWSH001
   enumId: GROOKEY_SWSH01
   name: Grookey
-  number: SWSH01
+  number: SWSH001
   types: [G]
   superType: POKEMON
   subTypes: [BASIC]
@@ -23,8 +23,8 @@ cards:
   - type: R
     value: x2
   rarity: Promo
-- id: 429-SWSH02
-  pioId: swsh-SWSH02
+- id: 429-SWSH002
+  pioId: swsh-SWSH002
   enumId: SCORBUNNY_SWSH02
   name: Scorbunny
   number: SWSH02
@@ -42,8 +42,8 @@ cards:
   - type: W
     value: x2
   rarity: Promo
-- id: 429-SWSH03
-  pioId: swsh-SWSH03
+- id: 429-SWSH003
+  pioId: swsh-SWSH003
   enumId: SOBBLE_SWSH03
   name: Sobble
   number: SWSH03
@@ -61,11 +61,11 @@ cards:
   - type: L
     value: x2
   rarity: Promo
-- id: 429-SWSH04
-  pioId: swsh-SWSH04
+- id: 429-SWSH004
+  pioId: swsh-SWSH004
   enumId: MEOWTH_V_SWSH04
   name: Meowth V
-  number: SWSH04
+  number: SWSH004
   types: [C]
   superType: POKEMON
   subTypes: [BASIC, POKEMON_V]
@@ -83,11 +83,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH05
-  pioId: swsh-SWSH05
+- id: 429-SWSH005
+  pioId: swsh-SWSH005
   enumId: MEOWTH_VMAX_SWSH05
   name: Meowth VMAX
-  number: SWSH05
+  number: SWSH005
   types: [C]
   superType: POKEMON
   subTypes: [EVOLUTION, VMAX]
@@ -102,11 +102,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH06
-  pioId: swsh-SWSH06
+- id: 429-SWSH006
+  pioId: swsh-SWSH006
   enumId: RILLABOOM_SWSH06
   name: Rillaboom
-  number: SWSH06
+  number: SWSH006
   types: [G]
   superType: POKEMON
   subTypes: [EVOLUTION, STAGE2]
@@ -126,11 +126,11 @@ cards:
   - type: R
     value: x2
   rarity: Promo
-- id: 429-SWSH07
-  pioId: swsh-SWSH07
+- id: 429-SWSH007
+  pioId: swsh-SWSH007
   enumId: FROSMOTH_SWSH07
   name: Frosmoth
-  number: SWSH07
+  number: SWSH007
   types: [W]
   superType: POKEMON
   subTypes: [EVOLUTION, STAGE1]
@@ -150,11 +150,11 @@ cards:
   - type: M
     value: x2
   rarity: Promo
-- id: 429-SWSH08
-  pioId: swsh-SWSH08
+- id: 429-SWSH008
+  pioId: swsh-SWSH008
   enumId: GALARIAN_PERRSERKER_SWSH08
   name: Galarian Perrserker
-  number: SWSH08
+  number: SWSH008
   types: [M]
   superType: POKEMON
   subTypes: [EVOLUTION, STAGE1]
@@ -177,11 +177,11 @@ cards:
   - type: G
     value: '-30'
   rarity: Promo
-- id: 429-SWSH09
-  pioId: swsh-SWSH09
+- id: 429-SWSH009
+  pioId: swsh-SWSH009
   enumId: CINCCINO_SWSH09
   name: Cinccino
-  number: SWSH09
+  number: SWSH009
   types: [C]
   superType: POKEMON
   subTypes: [EVOLUTION, STAGE1]
@@ -202,11 +202,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH10
-  pioId: swsh-SWSH10
+- id: 429-SWSH010
+  pioId: swsh-SWSH010
   enumId: GOSSIFLEUR_SWSH10
   name: Gossifleur
-  number: SWSH10
+  number: SWSH010
   types: [G]
   superType: POKEMON
   subTypes: [BASIC]
@@ -220,11 +220,11 @@ cards:
   - type: R
     value: x2
   rarity: Promo
-- id: 429-SWSH11
-  pioId: swsh-SWSH11
+- id: 429-SWSH011
+  pioId: swsh-SWSH011
   enumId: WOOLOO_SWSH11
   name: Wooloo
-  number: SWSH11
+  number: SWSH011
   types: [C]
   superType: POKEMON
   subTypes: [BASIC]
@@ -241,11 +241,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH12
-  pioId: swsh-SWSH12
+- id: 429-SWSH012
+  pioId: swsh-SWSH012
   enumId: MORPEKO_SWSH12
   name: Morpeko
-  number: SWSH12
+  number: SWSH012
   types: [L]
   superType: POKEMON
   subTypes: [BASIC]
@@ -260,11 +260,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH13
-  pioId: swsh-SWSH13
+- id: 429-SWSH013
+  pioId: swsh-SWSH013
   enumId: GALARIAN_PONYTA_SWSH13
   name: Galarian Ponyta
-  number: SWSH13
+  number: SWSH013
   types: [P]
   superType: POKEMON
   subTypes: [BASIC]
@@ -284,11 +284,11 @@ cards:
   - type: F
     value: '-30'
   rarity: Promo
-- id: 429-SWSH14
-  pioId: swsh-SWSH14
+- id: 429-SWSH014
+  pioId: swsh-SWSH014
   enumId: RILLABOOM_V_SWSH14
   name: Rillaboom V
-  number: SWSH14
+  number: SWSH014
   types: [G]
   superType: POKEMON
   subTypes: [BASIC, POKEMON_V]
@@ -307,11 +307,11 @@ cards:
   - type: R
     value: x2
   rarity: Promo
-- id: 429-SWSH15
-  pioId: swsh-SWSH15
+- id: 429-SWSH015
+  pioId: swsh-SWSH015
   enumId: CINDERACE_V_SWSH15
   name: Cinderace V
-  number: SWSH15
+  number: SWSH015
   types: [R]
   superType: POKEMON
   subTypes: [BASIC, POKEMON_V]
@@ -329,11 +329,11 @@ cards:
   - type: W
     value: x2
   rarity: Promo
-- id: 429-SWSH16
-  pioId: swsh-SWSH16
+- id: 429-SWSH016
+  pioId: swsh-SWSH016
   enumId: INTELEON_V_SWSH16
   name: Inteleon V
-  number: SWSH16
+  number: SWSH016
   types: [W]
   superType: POKEMON
   subTypes: [BASIC, POKEMON_V]
@@ -352,11 +352,11 @@ cards:
   - type: L
     value: x2
   rarity: Promo
-- id: 429-SWSH17
-  pioId: swsh-SWSH17
+- id: 429-SWSH017
+  pioId: swsh-SWSH017
   enumId: TOXTRICITY_V_SWSH17
   name: Toxtricity V
-  number: SWSH17
+  number: SWSH017
   types: [L]
   superType: POKEMON
   subTypes: [BASIC, POKEMON_V]
@@ -374,11 +374,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH18
-  pioId: swsh-SWSH18
+- id: 429-SWSH018
+  pioId: swsh-SWSH018
   enumId: ZACIAN_V_SWSH18
   name: Zacian V
-  number: SWSH18
+  number: SWSH018
   types: [M]
   superType: POKEMON
   subTypes: [BASIC, POKEMON_V]
@@ -402,11 +402,11 @@ cards:
   - type: G
     value: '-30'
   rarity: Promo
-- id: 429-SWSH19
-  pioId: swsh-SWSH19
+- id: 429-SWSH019
+  pioId: swsh-SWSH019
   enumId: ZAMAZENTA_V_SWSH19
   name: Zamazenta V
-  number: SWSH19
+  number: SWSH019
   types: [M]
   superType: POKEMON
   subTypes: [BASIC, POKEMON_V]
@@ -428,11 +428,11 @@ cards:
   - type: G
     value: '-30'
   rarity: Promo
-- id: 429-SWSH20
-  pioId: swsh-SWSH20
+- id: 429-SWSH020
+  pioId: swsh-SWSH020
   enumId: PIKACHU_SWSH20
   name: Pikachu
-  number: SWSH20
+  number: SWSH020
   types: [L]
   superType: POKEMON
   subTypes: [BASIC]
@@ -450,11 +450,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH21
-  pioId: swsh-SWSH21
+- id: 429-SWSH021
+  pioId: swsh-SWSH021
   enumId: POLTEAGEIST_V_SWSH21
   name: Polteageist V
-  number: SWSH21
+  number: SWSH021
   types: [P]
   superType: POKEMON
   subTypes: [BASIC, POKEMON_V]
@@ -478,11 +478,11 @@ cards:
   - type: F
     value: '-30'
   rarity: Promo
-- id: 429-SWSH22
-  pioId: swsh-SWSH22
+- id: 429-SWSH022
+  pioId: swsh-SWSH022
   enumId: FLAPPLE_SWSH22
   name: Flapple
-  number: SWSH22
+  number: SWSH022
   types: [G]
   superType: POKEMON
   subTypes: [EVOLUTION, STAGE1]
@@ -504,11 +504,11 @@ cards:
   - type: R
     value: x2
   rarity: Promo
-- id: 429-SWSH23
-  pioId: swsh-SWSH23
+- id: 429-SWSH023
+  pioId: swsh-SWSH023
   enumId: LUXRAY_SWSH23
   name: Luxray
-  number: SWSH23
+  number: SWSH023
   types: [L]
   superType: POKEMON
   subTypes: [EVOLUTION, STAGE2]
@@ -528,11 +528,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH24
-  pioId: swsh-SWSH24
+- id: 429-SWSH024
+  pioId: swsh-SWSH024
   enumId: COALOSSAL_SWSH24
   name: Coalossal
-  number: SWSH24
+  number: SWSH024
   types: [F]
   superType: POKEMON
   subTypes: [EVOLUTION, STAGE2]
@@ -552,11 +552,11 @@ cards:
   - type: G
     value: x2
   rarity: Promo
-- id: 429-SWSH25
-  pioId: swsh-SWSH25
+- id: 429-SWSH025
+  pioId: swsh-SWSH025
   enumId: GARBODOR_SWSH25
   name: Garbodor
-  number: SWSH25
+  number: SWSH025
   types: [D]
   superType: POKEMON
   subTypes: [EVOLUTION, STAGE1]
@@ -576,11 +576,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH26
-  pioId: swsh-SWSH26
+- id: 429-SWSH026
+  pioId: swsh-SWSH026
   enumId: MANTINE_SWSH26
   name: Mantine
-  number: SWSH26
+  number: SWSH026
   types: [W]
   superType: POKEMON
   subTypes: [BASIC]
@@ -598,11 +598,11 @@ cards:
   - type: L
     value: x2
   rarity: Promo
-- id: 429-SWSH27
-  pioId: swsh-SWSH27
+- id: 429-SWSH027
+  pioId: swsh-SWSH027
   enumId: NOCTOWL_SWSH27
   name: Noctowl
-  number: SWSH27
+  number: SWSH027
   types: [C]
   superType: POKEMON
   subTypes: [EVOLUTION, STAGE1]
@@ -625,11 +625,11 @@ cards:
   - type: F
     value: '-30'
   rarity: Promo
-- id: 429-SWSH28
-  pioId: swsh-SWSH28
+- id: 429-SWSH028
+  pioId: swsh-SWSH028
   enumId: DURALUDON_SWSH28
   name: Duraludon
-  number: SWSH28
+  number: SWSH028
   types: [M]
   superType: POKEMON
   subTypes: [BASIC]
@@ -649,11 +649,11 @@ cards:
   - type: G
     value: '-30'
   rarity: Promo
-- id: 429-SWSH29
-  pioId: swsh-SWSH29
+- id: 429-SWSH029
+  pioId: swsh-SWSH029
   enumId: RAYQUAZA_SWSH29
   name: Rayquaza
-  number: SWSH29
+  number: SWSH029
   types: [C]
   superType: POKEMON
   subTypes: [BASIC]
@@ -674,11 +674,11 @@ cards:
   - type: F
     value: '-30'
   rarity: Promo
-- id: 429-SWSH30
-  pioId: swsh-SWSH30
+- id: 429-SWSH030
+  pioId: swsh-SWSH030
   enumId: COPPERAJAH_V_SWSH30
   name: Copperajah V
-  number: SWSH30
+  number: SWSH030
   types: [M]
   superType: POKEMON
   subTypes: [BASIC, POKEMON_V]
@@ -700,11 +700,11 @@ cards:
   - type: G
     value: '-30'
   rarity: Promo
-- id: 429-SWSH31
-  pioId: swsh-SWSH31
+- id: 429-SWSH031
+  pioId: swsh-SWSH031
   enumId: MORPEKO_SWSH31
   name: Morpeko
-  number: SWSH31
+  number: SWSH031
   types: [L]
   superType: POKEMON
   subTypes: [BASIC]
@@ -722,11 +722,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH32
-  pioId: swsh-SWSH32
+- id: 429-SWSH032
+  pioId: swsh-SWSH032
   enumId: SNORLAX_SWSH32
   name: Snorlax
-  number: SWSH32
+  number: SWSH032
   types: [C]
   superType: POKEMON
   subTypes: [BASIC]
@@ -743,11 +743,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH33
-  pioId: swsh-SWSH33
+- id: 429-SWSH033
+  pioId: swsh-SWSH033
   enumId: ZACIAN_SWSH33
   name: Zacian
-  number: SWSH33
+  number: SWSH033
   types: [M]
   superType: POKEMON
   subTypes: [BASIC]
@@ -770,11 +770,11 @@ cards:
   - type: G
     value: '-30'
   rarity: Promo
-- id: 429-SWSH34
-  pioId: swsh-SWSH34
+- id: 429-SWSH034
+  pioId: swsh-SWSH034
   enumId: ZAMAZENTA_SWSH34
   name: Zamazenta
-  number: SWSH34
+  number: SWSH034
   types: [M]
   superType: POKEMON
   subTypes: [BASIC]
@@ -796,11 +796,11 @@ cards:
   - type: G
     value: '-30'
   rarity: Promo
-- id: 429-SWSH35
-  pioId: swsh-SWSH35
-  enumId: DECIDUEYE_35
+- id: 429-SWSH035
+  pioId: swsh-SWSH035
+  enumId: DECIDUEYE_SWSH35
   name: Decidueye
-  number: '35'
+  number: SWSH035
   types: [G]
   superType: POKEMON
   subTypes: [EVOLUTION, STAGE2]
@@ -822,11 +822,11 @@ cards:
   - type: R
     value: x2
   rarity: Promo
-- id: 429-SWSH36
-  pioId: swsh-SWSH36
-  enumId: ARCTOZOLT_36
+- id: 429-SWSH036
+  pioId: swsh-SWSH036
+  enumId: ARCTOZOLT_SWSH36
   name: Arctozolt
-  number: '36'
+  number: SWSH036
   types: [L]
   superType: POKEMON
   subTypes: [EVOLUTION, STAGE1]
@@ -846,11 +846,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH37
-  pioId: swsh-37
-  enumId: HYDREIGON_37
+- id: 429-SWSH037
+  pioId: swsh-SWSH037
+  enumId: HYDREIGON_SWSH37
   name: Hydreigon
-  number: '37'
+  number: SWSH037
   types: [D]
   superType: POKEMON
   subTypes: [EVOLUTION, STAGE2]
@@ -870,11 +870,11 @@ cards:
   - type: G
     value: x2
   rarity: Promo
-- id: 429-SWSH38
-  pioId: swsh-38
-  enumId: KANGASKHAN_38
+- id: 429-SWSH038
+  pioId: swsh-SWSH038
+  enumId: KANGASKHAN_SWSH38
   name: Kangaskhan
-  number: '38'
+  number: SWSH038
   types: [C]
   superType: POKEMON
   subTypes: [BASIC]
@@ -893,11 +893,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH39
-  pioId: swsh-39
-  enumId: PIKACHU_39
+- id: 429-SWSH039
+  pioId: swsh-SWSH039
+  enumId: PIKACHU_SWSH39
   name: Pikachu
-  number: '39'
+  number: SWSH039
   types: [L]
   superType: POKEMON
   subTypes: [BASIC]
@@ -914,11 +914,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH40
-  pioId: swsh-40
-  enumId: PIKACHU_40
+- id: 429-SWSH040
+  pioId: swsh-SWSH040
+  enumId: HATENNA_SWSH40
   name: Hatenna
-  number: '40'
+  number: SWSH040
   types: [P]
   superType: POKEMON
   subTypes: [BASIC]
@@ -938,11 +938,11 @@ cards:
   - type: F
     value: '-30'
   rarity: Promo
-- id: 429-SWSH41
-  pioId: swsh-41
-  enumId: FLAREON_41
+- id: 429-SWSH041
+  pioId: swsh-SWSH041
+  enumId: FLAREON_SWSH41
   name: Flareon
-  number: '41'
+  number: SWSH041
   types: [R]
   superType: POKEMON
   subTypes: [EVOLUTION, STAGE1]
@@ -961,11 +961,11 @@ cards:
   - type: W
     value: x2
   rarity: Promo
-- id: 429-SWSH42
-  pioId: swsh-42
-  enumId: EEVEE_42
+- id: 429-SWSH042
+  pioId: swsh-SWSH042
+  enumId: EEVEE_SWSH42
   name: Eevee
-  number: '42'
+  number: SWSH042
   types: [C]
   superType: POKEMON
   subTypes: [BASIC]
@@ -983,11 +983,11 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-- id: 429-SWSH43
-  pioId: swsh-43
-  enumId: GALARIAN_SIRFETCH_D_V_43
+- id: 429-SWSH043
+  pioId: swsh-SWSH043
+  enumId: GALARIAN_SIRFETCH_D_V_SWSH43
   name: Galarian Sirfetch'd V
-  number: '43'
+  number: SWSH043
   types: [F]
   superType: POKEMON
   subTypes: [BASIC, POKEMON_V]
@@ -1007,11 +1007,11 @@ cards:
   - type: P
     value: x2
   rarity: Promo
-- id: 429-SWSH44
-  pioId: swsh-44
-  enumId: ETERNATUS_V_44
+- id: 429-SWSH044
+  pioId: swsh-SWSH044
+  enumId: ETERNATUS_V_SWSH44
   name: Eternatus V
-  number: '44'
+  number: SWSH044
   types: [D]
   superType: POKEMON
   subTypes: [BASIC, POKEMON_V]

--- a/src/main/resources/formats.yaml
+++ b/src/main/resources/formats.yaml
@@ -1,40 +1,49 @@
-- name: Standard
-  seoName: standard
-  enumId: STANDARD_19
-  description: '2019–2020 UPR-on Standard Format'
-  sets: [416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 430, 431]
-  includes: [410-SM16, 410-SM17, 410-SM66, 410-SM67, 410-SM68, 410-SM78, 410-SM91, 410-SM94..410-SM243, 429-SWSH01..429-SWSH32]
-  excludes: [426-SV2, 426-SV3, 426-SV4, 426-SV8, 426-SV15, 426-SV20, 426-SV25, 426-SV30, 426-SV31, 426-SV34, 426-SV35, 426-SV36, 426-SV41, 426-SV43, 426-SV44, 426-SV45, 426-SV47, 426-SV48, 426-SV49, 426-SV50, 426-SV52, 426-SV53, 426-SV59, 426-SV60, 426-SV62, 426-SV66, 426-SV68, 426-SV69, 426-SV70, 426-SV71, 426-SV73, 426-SV75, 426-SV76, 426-SV78, 426-SV79, 426-SV80, 426-SV84, 426-SV87, 426-SV88, 426-SV91, 426-SV92, 426-SV93, 426-SV94]
+- name: Standard (20-21)
+  seoName: standard20-21
+  enumId: STANDARD_20
+  description: '2020–2021 TEU-on Standard Format'
+  sets: [421, 422, 423, 424, 425, 427, 430, 431]
+  includes: [410-SM158..410-SM244, 426-SV67, 429-SWSH001..429-SWSH044]
+  excludes: [423-78, 427-186]
   ruleSet: RULES_20
   flags: [quickplay]
 - name: Expanded
   seoName: expanded
   enumId: EXPANDED_14
   description: '2014-2020 Season Expanded Format'
-  sets: [310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 429, 430, 431]
+  sets: [310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 429, 430, 431, 432]
   includes: []
   excludes: [313-67, 315-110, 320-101, 320-115, 361-124, 364-99, 364-118, 365-133, 365-158, 367-94, 367-107, 368-74, 368-75, 370-109, 370-98, 371-71, 371-RC27, 410-SM85, 414-45, 415-96, 415-110, 416-153, 417-83, 420-90, 420-91, 423-78, 423-165, 423-178, 424-206, 424-253, 425-58, 425-60, 425-68, 427-194, 427-265]
   ruleSet: RULES_20
   flags: [quickplay]
-- name: Unlimited
-  seoName: unlimited
-  enumId: UNLIMITED
-  description: 'The classic Unlimited format from Base until Gen 3 sets. It will be expanded with all sets once they are ready.'
-  sets: [111, 112, 113, 114, 115, 121, 122, 131, 132, 133, 161, 162, 163, 164, 171, 172, 173, 211, 212, 213, 214, 215, 216, 217]
-  includes: []
-  excludes: []
-  ruleSet: EX_RULES
+- name: Standard (19-20)
+  seoName: standard19-20
+  enumId: STANDARD_19
+  description: '2019–2020 UPR-RCL Standard Format'
+  sets: [416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 430, 431]
+  includes: [410-SM16, 410-SM17, 410-SM66, 410-SM67, 410-SM68, 410-SM78, 410-SM91, 410-SM94..410-SM244, 429-SWSH001..429-SWSH034]
+  excludes: [426-SV2, 426-SV3, 426-SV4, 426-SV8, 426-SV15, 426-SV20, 426-SV25, 426-SV30, 426-SV31, 426-SV34, 426-SV35, 426-SV36, 426-SV41, 426-SV43, 426-SV44, 426-SV45, 426-SV47, 426-SV48, 426-SV49, 426-SV50, 426-SV52, 426-SV53, 426-SV59, 426-SV60, 426-SV62, 426-SV66, 426-SV68, 426-SV69, 426-SV70, 426-SV71, 426-SV73, 426-SV75, 426-SV76, 426-SV78, 426-SV79, 426-SV80, 426-SV84, 426-SV87, 426-SV88, 426-SV91, 426-SV92, 426-SV93, 426-SV94]
+  ruleSet: RULES_20
   flags: [quickplay]
-- name: SUM-on (18-19)
-  seoName: sum-on
+- name: Standard (18-19)
+  seoName: standard18-19
   enumId: STANDARD_18
-  description: '2018-2019 SUM-on Standard format'
+  description: '2018-2019 SUM-UNB Standard format'
   sets: [411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423]
   includes: [410-SM01..410-SM190, 410-SM194..410-SM201, 410-SM208..410-SM209]
   excludes: []
   ruleSet: SM_RULES
   flags: [quickplay]
-- name: BKT-on (17-18)
+- name: SUM (17-19)
+  seoName: sum-all
+  enumId: SUM_ALL
+  description: 'Block format for Sun and Moon series'
+  sets: [410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427]
+  includes: []
+  excludes: []
+  ruleSet: SM_RULES
+  flags: [quickplay]
+- name: Standard (17-18)
   seoName: bkt-on
   enumId: STANDARD_17
   description: '2017-2018 BKT-on Standard format'
@@ -79,10 +88,10 @@
   excludes: [364-99, 364-118] # Lysandre's Trump Card
   ruleSet: NXD_RULES
   flags: [quickplay]
-- name: BW–on (12–13)
-  seoName: bw-on
+- name: BLW–on (12–13)
+  seoName: blw-on
   enumId: BLW_ON
-  description: '2012-2013 BW-on Modified Format'
+  description: '2012-2013 BLW-on Modified Format'
   sets: [311, 312, 313, 314, 315, 316, 317, 318, 319, 320] # Missing: McDonald’s Collection 2011, McDonald’s Collection 2012, and Black & White Trainer Kit
   includes: [310-BW01..310-BW95]
   excludes: []
@@ -90,7 +99,7 @@
   flags: [quickplay]
 - name: HGSS-on
   seoName: hgss-on
-  enumId: HGGS_ON # Typo was intentional
+  enumId: HGGS_ON # Leave this typo, this is the internal name for it
   description: 'HGSS-on featuring HGSS to Call of Legends!'
   sets: [271, 272, 273, 274, 275]
   includes: [] # Missing: HGSS Promo Cards HGSS01–HGSS0025, Victory Medal Promo Card (HGSS version)
@@ -98,8 +107,8 @@
   ruleSet: EX_RULES
   flags: [quickplay]
 - name: EX (04-07)
-  seoName: rs-on
-  enumId: EX_SERIES
+  seoName: ex-all
+  enumId: EX_ALL
   description: 'The 2004-2005 Worlds format.'
   sets: [211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 281, 282, 283, 284, 285] # Missing: EX Trainer Kit, EX Trainer Kit 2
   includes: [] # Missing Nintendo Promos 1–40
@@ -116,7 +125,7 @@
   ruleSet: EX_RULES
   flags: [quickplay]
 - name: Worlds (03-04)
-  seoName: worlds-03-04
+  seoName: worlds03-04
   enumId: MODIFIED_2003_2004
   description: 'The popular Worlds 2003-2004 format. Available in Career.'
   sets: [171, 172, 173, 211, 212, 213, 214, 215]
@@ -134,7 +143,7 @@
   ruleSet: CLASSIC_RULES
   flags: [quickplay]
 - name: E-Card
-  seoName: ecard
+  seoName: e-card
   enumId: ECARD_SERIES
   description: 'E-cards! The last sets printed by Wizards of the Coast.'
   sets: [171, 172, 173]
@@ -213,6 +222,15 @@
   includes: []
   excludes: [181-78, 181-93, 184-107, 184-120, 201-146, 181-71, 184-101, 201-30, 201-68, 201-143] # First section is Green tabs, second section is Computer Search
   ruleSet: CLASSIC_RULES
+  flags: [quickplay]
+- name: Unlimited
+  seoName: unlimited
+  enumId: UNLIMITED
+  description: 'The classic Unlimited format from Base until Gen 3 sets. It will be expanded with all sets once they are ready.'
+  sets: [111, 112, 113, 114, 115, 121, 122, 131, 132, 133, 161, 162, 163, 164, 171, 172, 173, 211, 212, 213, 214, 215, 216, 217]
+  includes: []
+  excludes: []
+  ruleSet: EX_RULES
   flags: [quickplay]
 
 # TODO: Legacy (2010-2013), Indo/China/TW format


### PR DESCRIPTION
The `enumId` for the new promos were all wrong and missing SWSH markers before the number. Also fixed all promos' numbers to be triple zero padded as per the SWSH promo numberings (which fixes the images, since they're currently named to triple zero pads). I left all original enumIds to not have zero padding as they are not marked like this internally, but changed all pioIds, ids, and numbers as such