### PR TITLE
Fix damage output of Super Singe in Scorbunny (SWSH002)

### DIFF
--- a/src/main/resources/cards/429-sword_shield_promos.yaml
+++ b/src/main/resources/cards/429-sword_shield_promos.yaml
@@ -36,7 +36,7 @@ cards:
   moves:
   - cost: [R]
     name: Super Singe
-    damage: '30'
+    damage: '10'
     text: Flip a coin. If heads, your opponent's Active Pokémon is now Burned.
   weaknesses:
   - type: W


### PR DESCRIPTION
Should be 10, not 30.