### PR TITLE
Celebrations - Lost Origins updates

### DIFF
--- a/data/src/main/resources/cards/429-sword_shield_promos.yaml
+++ b/data/src/main/resources/cards/429-sword_shield_promos.yaml
@@ -1730,3 +1730,4366 @@ cards:
   - type: R
     value: x2
   rarity: Promo
+- id: 429-SWSH079
+  pioId: swshp-SWSH079
+  enumId: GALARIAN_MR_RIME_SWSH079
+  name: Galarian Mr. Rime
+  number: SWSH079
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Galarian Mr. Mime
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Shuffle Dance
+    text: Once during your turn, you may switch 1 of your opponent's face-down Prize
+      cards with the top card of their deck. (The cards stay face down.)
+  moves:
+  - cost: [W, C, C]
+    name: Mad Party
+    damage: 20x
+    text: This attack does 20 damage for each Pokémon in your discard pile that has
+      the Mad Party attack.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Promo
+  artist: KEIICHIRO ITO
+- id: 429-SWSH080
+  pioId: swshp-SWSH080
+  enumId: DEDENNE_SWSH080
+  name: Dedenne
+  number: SWSH080
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [P, C, C]
+    name: Mad Party
+    damage: 20x
+    text: This attack does 20 damage for each Pokémon in your discard pile that has
+      the Mad Party attack.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Promo
+  artist: Yuu Nishida
+- id: 429-SWSH081
+  pioId: swshp-SWSH081
+  enumId: POLTEAGEIST_SWSH081
+  name: Polteageist
+  number: SWSH081
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Sinistea
+  hp: 60
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Tea Break
+    text: You must discard a Pokémon that has the Mad Party attack from your hand
+      in order to use this Ability. Once during your turn, you may draw 2 cards.
+  moves:
+  - cost: [C, C]
+    name: Mad Party
+    damage: 20x
+    text: This attack does 20 damage for each Pokémon in your discard pile that has
+      the Mad Party attack.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Misa Tsutsui
+- id: 429-SWSH082
+  pioId: swshp-SWSH082
+  enumId: BUNNELBY_SWSH082
+  name: Bunnelby
+  number: SWSH082
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Diggersby]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Mad Party
+    damage: 20x
+    text: This attack does 20 damage for each Pokémon in your discard pile that has
+      the Mad Party attack.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: sowsow
+- id: 429-SWSH083
+  pioId: swshp-SWSH083
+  enumId: ALAKAZAM_V_SWSH083
+  name: Alakazam V
+  number: SWSH083
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Zen Spoon
+    text: Put 3 damage counters on your opponent's Pokémon in any way you like.
+  - cost: [P, P]
+    name: Mind Ruler
+    damage: 30x
+    text: This attack does 30 damage for each card in your opponent's hand.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Ayaka Yoshida
+- id: 429-SWSH084
+  pioId: swshp-SWSH084
+  enumId: ELDEGOSS_V_SWSH084
+  name: Eldegoss V
+  number: SWSH084
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 180
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Happy Match
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may put a Supporter card from your discard pile into your hand.
+  moves:
+  - cost: [C, C]
+    name: Float Up
+    damage: '50'
+    text: You may shuffle this Pokémon and all attached cards into your deck.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH085
+  pioId: swshp-SWSH085
+  enumId: BOLTUND_V_SWSH085
+  name: Boltund V
+  number: SWSH085
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 2
+  moves:
+  - cost: [L]
+    name: Electrify
+    text: Search your deck for up to 2 [L] Energy cards and attach them to your Benched
+      Pokémon in any way you like. Then, shuffle your deck.
+  - cost: [L, C]
+    name: Bolt Storm
+    damage: 10+
+    text: This attack does 30 more damage for each [L] Energy attached to all of your
+      Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+- id: 429-SWSH086
+  pioId: swshp-SWSH086
+  enumId: CRAMORANT_V_SWSH086
+  name: Cramorant V
+  number: SWSH086
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Beak Catch
+    text: Search your deck for up to 2 cards and put them into your hand. Then, shuffle
+      your deck.
+  - cost: [C, C, C]
+    name: Spit Shot
+    text: Discard all Energy from this Pokémon. This attack does 160 damage to 1 of
+      your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+- id: 429-SWSH087
+  pioId: swshp-SWSH087
+  enumId: EEVEE_VMAX_SWSH087
+  name: Eevee VMAX
+  number: SWSH087
+  types: [C]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Eevee V
+  evolvesTo: [Vaporeon, Jolteon, Flareon, Sylveon, Espeon, Umbreon, Leafeon, Glaceon]
+  hp: 300
+  retreatCost: 2
+  moves:
+  - cost: [C, C, C]
+    name: G-Max Cuddle
+    damage: '150'
+    text: During your opponent's next turn, if the Defending Pokémon tries to attack,
+      your opponent flips a coin. If tails, that attack doesn't happen.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: PLANETA Mochizuki
+- id: 429-SWSH088
+  pioId: swshp-SWSH088
+  enumId: CHERRIM_SWSH088
+  name: Cherrim
+  number: SWSH088
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Cherubi
+  hp: 80
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Spring Bloom
+    text: As often as you like during your turn, you may attach a [G] Energy card
+      from your hand to 1 of your Pokémon that doesn't have a Rule Box (Pokémon V,
+      Pokémon-GX, etc. have Rule Boxes).
+  moves:
+  - cost: [G, C, C]
+    name: Seed Bomb
+    damage: '70'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: Tika Matsuno
+- id: 429-SWSH089
+  pioId: swshp-SWSH089
+  enumId: OCTILLERY_SWSH089
+  name: Octillery
+  number: SWSH089
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION, RAPID_STRIKE]
+  evolvesFrom: Remoraid
+  hp: 110
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Rapid Strike Search
+    text: Once during your turn, you may search your deck for a Rapid Strike card,
+      reveal it, and put it into your hand. Then, shuffle your deck. You can't use
+      more than 1 Rapid Strike Search Ability each turn.
+  moves:
+  - cost: [W, C, C]
+    name: Waterfall
+    damage: '50'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: KIYOTAKA OSHIYAMA
+- id: 429-SWSH090
+  pioId: swshp-SWSH090
+  enumId: HOUNDOOM_SWSH090
+  name: Houndoom
+  number: SWSH090
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION, SINGLE_STRIKE]
+  evolvesFrom: Houndour
+  hp: 130
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Single Strike Roar
+    text: Once during your turn, you may search your deck for a Single Strike Energy
+      card and attach it to 1 of your Single Strike Pokémon. Then, shuffle your deck.
+      If you attached Energy to a Pokémon in this way, put 2 damage counters on that
+      Pokémon.
+  moves:
+  - cost: [D, C]
+    name: Darkness Fang
+    damage: '50'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: Uta
+- id: 429-SWSH091
+  pioId: swshp-SWSH091
+  enumId: BRONZONG_SWSH091
+  name: Bronzong
+  number: SWSH091
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Bronzor
+  hp: 110
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Metal Transfer
+    text: As often as you like during your turn, you may move a [M] Energy from 1
+      of your Pokémon to another of your Pokémon.
+  moves:
+  - cost: [M, C, C]
+    name: Zen Headbutt
+    damage: '70'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Promo
+  artist: Atsushi Furusawa
+- id: 429-SWSH092
+  pioId: swshp-SWSH092
+  enumId: CHARMANDER_SWSH092
+  name: Charmander
+  number: SWSH092
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Charmeleon]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Collect
+    text: Draw a card.
+  - cost: [R, R]
+    name: Flare
+    damage: '30'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+  artist: Uta
+- id: 429-SWSH093
+  pioId: swshp-SWSH093
+  enumId: ARROKUDA_SWSH093
+  name: Arrokuda
+  number: SWSH093
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Barraskewda]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Flock
+    text: Search your deck for up to 2 Arrokuda and put them onto your Bench. Then,
+      shuffle your deck.
+  - cost: [W, C]
+    name: Peck
+    damage: '20'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: tetsuya koizumi
+- id: 429-SWSH094
+  pioId: swshp-SWSH094
+  enumId: JOLTEON_SWSH094
+  name: Jolteon
+  number: SWSH094
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Eevee
+  hp: 100
+  moves:
+  - cost: [L]
+    name: Energize
+    text: Attach a [L] Energy card from your discard pile to this Pokémon.
+  - cost: [L, L, C]
+    name: Thunder
+    damage: '160'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Yuu Nishida
+- id: 429-SWSH095
+  pioId: swshp-SWSH095
+  enumId: EEVEE_SWSH095
+  name: Eevee
+  number: SWSH095
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Vaporeon, Jolteon, Flareon, Sylveon, Espeon, Umbreon, Leafeon, Glaceon]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: First Step
+    text: Draw a card.
+  - cost: [C, C, C]
+    name: Tail Whap
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Naoki Saito
+- id: 429-SWSH096
+  pioId: swshp-SWSH096
+  enumId: DRAGAPULT_V_SWSH096
+  name: Dragapult V
+  number: SWSH096
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Bite
+    damage: '30'
+  - cost: [P, P]
+    name: Jet Assault
+    damage: 60+
+    text: If this Pokémon moved from your Bench to the Active Spot this turn, this
+      attack does 80 more damage.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+- id: 429-SWSH097
+  pioId: swshp-SWSH097
+  enumId: DRAGAPULT_VMAX_SWSH097
+  name: Dragapult VMAX
+  number: SWSH097
+  types: [P]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Dragapult V
+  hp: 320
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Shred
+    damage: '60'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon.
+  - cost: [P, P]
+    name: Max Phantom
+    damage: '130'
+    text: Put 5 damage counters on your opponent's Benched Pokémon in any way you
+      like.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: aky CG Works
+- id: 429-SWSH098
+  pioId: swshp-SWSH098
+  enumId: CROBAT_V_SWSH098
+  name: Crobat V
+  number: SWSH098
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 180
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Dark Asset
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may draw cards until you have 6 cards in your hand. You can't use more than
+      1 Dark Asset Ability each turn.
+  moves:
+  - cost: [D, C]
+    name: Venomous Fang
+    damage: '70'
+    text: Your opponent's Active Pokémon is now Poisoned.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: 429-SWSH099
+  pioId: swshp-SWSH099
+  enumId: CROBAT_VMAX_SWSH099
+  name: Crobat VMAX
+  number: SWSH099
+  types: [D]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Crobat V
+  hp: 300
+  retreatCost: 1
+  moves:
+  - cost: [D, C]
+    name: Stealth Poison
+    damage: '70'
+    text: Your opponent's Active Pokémon is now Poisoned. Switch this Pokémon with
+      1 of your Benched Pokémon.
+  - cost: [D, D, C]
+    name: Max Cutter
+    damage: '180'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: PLANETA Tsuji
+- id: 429-SWSH100
+  pioId: swshp-SWSH100
+  enumId: VENUSAUR_V_SWSH100
+  name: Venusaur V
+  number: SWSH100
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [G, C]
+    name: Leaf Drain
+    damage: '50'
+    text: Heal 30 damage from this Pokémon.
+  - cost: [G, G, C]
+    name: Double-Edge
+    damage: '190'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+- id: 429-SWSH101
+  pioId: swshp-SWSH101
+  enumId: BLASTOISE_V_SWSH101
+  name: Blastoise V
+  number: SWSH101
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [W]
+    name: Water Gun
+    damage: '30'
+  - cost: [W, W, W]
+    name: Torrential Cannon
+    damage: '200'
+    text: During your next turn, this Pokémon can't use Torrential Cannon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH102
+  pioId: swshp-SWSH102
+  enumId: VENUSAUR_VMAX_SWSH102
+  name: Venusaur VMAX
+  number: SWSH102
+  types: [G]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Venusaur V
+  hp: 330
+  retreatCost: 4
+  moves:
+  - cost: [C, C]
+    name: Forest Storm
+    damage: 30x
+    text: This attack does 30 damage for each [G] Energy attached to all of your Pokémon.
+  - cost: [G, G, C, C]
+    name: G-Max Bloom
+    damage: '210'
+    text: Heal 30 damage from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: aky CG Works
+- id: 429-SWSH103
+  pioId: swshp-SWSH103
+  enumId: BLASTOISE_VMAX_SWSH103
+  name: Blastoise VMAX
+  number: SWSH103
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Blastoise V
+  hp: 330
+  retreatCost: 3
+  moves:
+  - cost: [W, W, W]
+    name: Grand Falls
+    damage: '120'
+    text: Search your deck for up to 3 [W] Energy cards and attach them to your Benched
+      Pokémon in any way you like. Then, shuffle your deck.
+  - cost: [W, W, W, W]
+    name: G-Max Bombard
+    damage: '220'
+    text: This attack also does 30 damage to 2 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH104
+  pioId: swshp-SWSH104
+  enumId: VICTINI_V_SWSH104
+  name: Victini V
+  number: SWSH104
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Spreading Flames
+    text: Attach up to 3 [R] Energy cards from your discard pile to your Pokémon in
+      any way you like.
+  - cost: [R, R]
+    name: Energy Burst
+    damage: 30x
+    text: This attack does 30 damage for each Energy attached to both Active Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH105
+  pioId: swshp-SWSH105
+  enumId: GARDEVOIR_V_SWSH105
+  name: Gardevoir V
+  number: SWSH105
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [P]
+    name: Magical Shot
+    damage: '30'
+  - cost: [P, P, C]
+    name: Swelling Pulse
+    damage: 120+
+    text: If this Pokémon was healed during this turn, this attack does 80 more damage.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH106
+  pioId: swshp-SWSH106
+  enumId: SINGLE_STRIKE_URSHIFU_V_SWSH106
+  name: Single Strike Urshifu V
+  number: SWSH106
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, SINGLE_STRIKE]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Low Kick
+    damage: '30'
+  - cost: [F, F, F, F]
+    name: Brawny Knuckle
+    damage: '180'
+    text: This attack's damage isn't affected by Resistance.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH107
+  pioId: swshp-SWSH107
+  enumId: RAPID_STRIKE_URSHIFU_V_SWSH107
+  name: Rapid Strike Urshifu V
+  number: SWSH107
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, RAPID_STRIKE]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [F, C]
+    name: Spiral Kick
+    damage: '40'
+  - cost: [F, F, C]
+    name: Sonic Legs
+    damage: '90'
+    text: This attack also does 20 damage to 2 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH108
+  pioId: swshp-SWSH108
+  enumId: EMPOLEON_V_SWSH108
+  name: Empoleon V
+  number: SWSH108
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, RAPID_STRIKE]
+  hp: 210
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Emperor's Eyes
+    text: As long as this Pokémon is in the Active Spot, your opponent's Basic Pokémon
+      in play have no Abilities, except for Pokémon with a Rule Box (Pokémon V, Pokémon-GX,
+      etc. have Rule Boxes).
+  moves:
+  - cost: [W, C, C]
+    name: Swirling Slice
+    damage: '130'
+    text: Move an Energy from this Pokémon to 1 of your Benched Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: 429-SWSH109
+  pioId: swshp-SWSH109
+  enumId: TYRANITAR_V_SWSH109
+  name: Tyranitar V
+  number: SWSH109
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, SINGLE_STRIKE]
+  hp: 230
+  retreatCost: 3
+  moves:
+  - cost: [D, C, C]
+    name: Cragalanche
+    damage: '60'
+    text: Discard the top 2 cards of your opponent's deck.
+  - cost: [D, D, C, C]
+    name: Single Strike Crush
+    damage: '240'
+    text: Discard the top 4 cards of your deck.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Tsuji
+- id: 429-SWSH110
+  pioId: swshp-SWSH110
+  enumId: CROBAT_V_SWSH110
+  name: Crobat V
+  number: SWSH110
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 180
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Dark Asset
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may draw cards until you have 6 cards in your hand. You can't use more than
+      1 Dark Asset Ability each turn.
+  moves:
+  - cost: [D, C]
+    name: Venomous Fang
+    damage: '70'
+    text: Your opponent's Active Pokémon is now Poisoned.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+  variantOf: FILL_THIS-SWSH098
+  variantType: Reprint
+- id: 429-SWSH111
+  pioId: swshp-SWSH111
+  enumId: GALARIAN_RAPIDASH_V_SWSH111
+  name: Galarian Rapidash V
+  number: SWSH111
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Libra Horn
+    text: Put damage counters on 1 of your opponent's Pokémon until its remaining
+      HP is 100.
+  - cost: [P, P]
+    name: Psychic
+    damage: 60+
+    text: This attack does 30 more damage for each Energy attached to your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Saki Hayashiro
+- id: 429-SWSH112
+  pioId: swshp-SWSH112
+  enumId: CINDERACE_SWSH112
+  name: Cinderace
+  number: SWSH112
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION, SINGLE_STRIKE]
+  evolvesFrom: Raboot
+  hp: 170
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Crisis Power
+    text: This Pokémon's attacks do 30 more damage to your opponent's Active Pokémon
+      for each Prize card your opponent has taken (before applying Weakness and Resistance).
+  moves:
+  - cost: [R, C]
+    name: Fireball Shot
+    damage: '150'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+  artist: Anesaki Dynamic
+- id: 429-SWSH113
+  pioId: swshp-SWSH113
+  enumId: INTELEON_SWSH113
+  name: Inteleon
+  number: SWSH113
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION, RAPID_STRIKE]
+  evolvesFrom: Drizzile
+  hp: 150
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Quick Shooting
+    text: Once during your turn, you may put 2 damage counters on 1 of your opponent's
+      Pokémon.
+  moves:
+  - cost: [C, C]
+    name: Waterfall
+    damage: '70'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: AKIRA EGAWA
+- id: 429-SWSH114
+  pioId: swshp-SWSH114
+  enumId: CRESSELIA_SWSH114
+  name: Cresselia
+  number: SWSH114
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Crescent Glow
+    text: Search your deck for a [P] Energy card and attach it to 1 of your Pokémon.
+      If you go second and it's your first turn, instead search for up to 3 [P] Energy
+      cards and attach them to 1 of your Pokémon. Then, shuffle your deck.
+  - cost: [P, P]
+    name: Photon Laser
+    damage: 30+
+    text: If you have at least 5 Energy in play, this attack does 90 more damage.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 429-SWSH115
+  pioId: swshp-SWSH115
+  enumId: PASSIMIAN_SWSH115
+  name: Passimian
+  number: SWSH115
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE]
+  hp: 110
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Throwing Coach
+    text: Your Rapid Strike Pokémon's attacks do 30 more damage to your opponent's
+      Benched Pokémon V and Benched Pokémon-GX (before applying Weakness and Resistance).
+      You can't apply more than 1 Throwing Coach Ability at a time.
+  moves:
+  - cost: [F]
+    name: Fling
+    text: This attack does 20 damage to 1 of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Teeziro
+- id: 429-SWSH116
+  pioId: swshp-SWSH116
+  enumId: MORPEKO_SWSH116
+  name: Morpeko
+  number: SWSH116
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Famished
+    text: Draw a card.
+  - cost: [L, C]
+    name: Thunder Shock
+    damage: '40'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Atsushi Furusawa
+  variantOf: FILL_THIS-SWSH031
+  variantType: Reprint
+- id: 429-SWSH117
+  pioId: swshp-SWSH117
+  enumId: PHANPY_SWSH117
+  name: Phanpy
+  number: SWSH117
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Donphan]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Stampede
+    damage: '10'
+  - cost: [F, C]
+    name: Strike Back
+    damage: 30x
+    text: This attack does 30 damage for each damage counter on this Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 429-SWSH118
+  pioId: swshp-SWSH118
+  enumId: EEVEE_SWSH118
+  name: Eevee
+  number: SWSH118
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Vaporeon, Jolteon, Flareon, Sylveon, Espeon, Umbreon, Leafeon, Glaceon]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Signs of Evolution
+    text: Search your deck for a card that evolves from Eevee, reveal it, and put
+      it into your hand. Then, shuffle your deck.
+  - cost: [C, C]
+    name: Wild Kick
+    damage: '30'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Yuu Nishida
+  variantOf: FILL_THIS-SWSH042
+  variantType: Reprint
+- id: 429-SWSH119
+  pioId: swshp-SWSH119
+  enumId: SNORLAX_SWSH119
+  name: Snorlax
+  number: SWSH119
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, SINGLE_STRIKE]
+  hp: 140
+  retreatCost: 4
+  moves:
+  - cost: [C, C]
+    name: Slap Push
+    damage: '30'
+  - cost: [C, C, C]
+    name: Single Strike Tackle
+    damage: '120'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Yuya Oka
+- id: 429-SWSH120
+  pioId: swshp-SWSH120
+  enumId: MARNIE_SWSH120
+  name: Marnie
+  number: SWSH120
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Promo
+  text:
+  - Each player shuffles their hand and puts it on the bottom of their deck. If either
+    player put any cards on the bottom of their deck in this way, you draw 5 cards,
+    and your opponent draws 4 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Sanosuke Sakuma
+- id: 429-SWSH121
+  pioId: swshp-SWSH121
+  enumId: MARNIE_SWSH121
+  name: Marnie
+  number: SWSH121
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Promo
+  text:
+  - Each player shuffles their hand and puts it on the bottom of their deck. If either
+    player put any cards on the bottom of their deck in this way, you draw 5 cards,
+    and your opponent draws 4 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Naoki Saito
+  variantOf: FILL_THIS-SWSH120
+  variantType: Reprint
+- id: 429-SWSH122
+  pioId: swshp-SWSH122
+  enumId: FLAAFFY_SWSH122
+  name: Flaaffy
+  number: SWSH122
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Mareep
+  evolvesTo: [Ampharos]
+  hp: 90
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Dynamotor
+    text: Once during your turn (before your attack), you may attach a [L] Energy
+      card from your discard pile to 1 of your Benched Pokémon.
+  moves:
+  - cost: [L, L, C]
+    name: Electro Ball
+    damage: '50'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Pani Kobayashi
+- id: 429-SWSH123
+  pioId: swshp-SWSH123
+  enumId: GALARIAN_ARTICUNO_SWSH123
+  name: Galarian Articuno
+  number: SWSH123
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Cruel Charge
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may attach up to 2 [P] Energy cards from your hand to this Pokémon.
+  moves:
+  - cost: [P, P, C]
+    name: Psylaser
+    text: Discard all [P] Energy from this Pokémon. This attack does 120 damage to
+      1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched
+      Pokémon.)
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Shin Nagasawa
+- id: 429-SWSH124
+  pioId: swshp-SWSH124
+  enumId: GALARIAN_ZAPDOS_SWSH124
+  name: Galarian Zapdos
+  number: SWSH124
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  abilities:
+  - type: Ability
+    name: Strong Legs Charge
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may attach up to 2 [F] Energy cards from your hand to this Pokémon.
+  moves:
+  - cost: [F, F, C]
+    name: Zapper Kick
+    damage: '70'
+    text: You may discard all Energy from this Pokémon. If you do, your opponent's
+      Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Oswaldo KATO
+- id: 429-SWSH125
+  pioId: swshp-SWSH125
+  enumId: GALARIAN_MOLTRES_SWSH125
+  name: Galarian Moltres
+  number: SWSH125
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Malevolent Charge
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may attach up to 2 [D] Energy cards from your hand to this Pokémon.
+  moves:
+  - cost: [D, D, C]
+    name: Fiery Wrath
+    damage: 20+
+    text: This attack does 50 more damage for each Prize card your opponent has taken.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: KEIICHIRO ITO
+- id: 429-SWSH126
+  pioId: swshp-SWSH126
+  enumId: GALARIAN_SLOWPOKE_SWSH126
+  name: Galarian Slowpoke
+  number: SWSH126
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Slowbro, Slowking]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Everyone Laze Around
+    text: Heal 10 damage from each of your Pokémon.
+  - cost: [C, C, C]
+    name: Tail Whap
+    damage: '30'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: sowsow
+- id: 429-SWSH127
+  pioId: swshp-SWSH127
+  enumId: EEVEE_SWSH127
+  name: Eevee
+  number: SWSH127
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Vaporeon, Jolteon, Flareon, Sylveon, Espeon, Umbreon, Leafeon, Glaceon]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Be Prepared
+    text: Attach a basic Energy card from your hand to this Pokémon.
+  - cost: [C, C, C]
+    name: Bite
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Souichirou Gunjima
+- id: 429-SWSH128
+  pioId: swshp-SWSH128
+  enumId: EISCUE_SWSH128
+  name: Eiscue
+  number: SWSH128
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Ice Bonus
+    text: Discard a [W] Energy card from your hand. If you do, draw 3 cards.
+  - cost: [W, W, C]
+    name: Headbutt Bounce
+    damage: '100'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Promo
+  artist: kirisAki
+- id: 429-SWSH129
+  pioId: swshp-SWSH129
+  enumId: UMBREON_SWSH129
+  name: Umbreon
+  number: SWSH129
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Eevee
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Blindside
+    text: This attack does 60 damage to 1 of your opponent's Pokémon that has any
+      damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [D, C, C]
+    name: Moon Mirage
+    damage: '80'
+    text: Your opponent's Active Pokémon is now Confused.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: Souichirou Gunjima
+- id: 429-SWSH130
+  pioId: swshp-SWSH130
+  enumId: ICE_RIDER_CALYREX_V_SWSH130
+  name: Ice Rider Calyrex V
+  number: SWSH130
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [W, C]
+    name: Blizzard
+    damage: '40'
+    text: This attack also does 10 damage to each of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [W, W, C]
+    name: Frost Stamp
+    damage: '140'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH131
+  pioId: swshp-SWSH131
+  enumId: SHADOW_RIDER_CALYREX_V_SWSH131
+  name: Shadow Rider Calyrex V
+  number: SWSH131
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [P]
+    name: Cloak in Shadows
+    text: Attach a [P] Energy card from your discard pile to this Pokémon.
+  - cost: [P, P, C]
+    name: Hollow Binding
+    damage: '130'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH132
+  pioId: swshp-SWSH132
+  enumId: DRAGAPULT_SWSH132
+  name: Dragapult
+  number: SWSH132
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Drakloak
+  hp: 150
+  moves:
+  - cost: [P]
+    name: Mach Turn
+    damage: '60'
+    text: You may switch this Pokémon with 1 of your Benched Pokémon.
+  - cost: [P, P, C]
+    name: Diving Swipe
+    damage: '150'
+    text: Discard a random card from your opponent's hand.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - (This card cannot be used at official tournaments.)
+  artist: 5ban Graphics
+- id: 429-SWSH133
+  pioId: swshp-SWSH133
+  enumId: LANCE_S_CHARIZARD_V_SWSH133
+  name: Lance's Charizard V
+  number: SWSH133
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [R, R, C]
+    name: Flamethrower
+    damage: '200'
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Hideki Ishikawa
+- id: 429-SWSH134
+  pioId: swshp-SWSH134
+  enumId: DARK_SYLVEON_V_SWSH134
+  name: Dark Sylveon V
+  number: SWSH134
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 180
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Disarming Voice
+    damage: '30'
+    text: Your opponent's Active Pokémon is now Confused.
+  - cost: [P, C, C]
+    name: Tricky Ribbon
+    damage: '100'
+    text: Choose a random card from your opponent's hand. Your opponent reveals that
+      card and shuffles it into their deck.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Ryuta Fuse
+- id: 429-SWSH135
+  pioId: swshp-SWSH135
+  enumId: ZACIAN_LV_X_SWSH135
+  name: Zacian LV.X
+  number: SWSH135
+  types: [M]
+  superType: POKEMON
+  subTypes: [EVOLUTION, LVL_X]
+  hp: 160
+  retreatCost: 2
+  abilities:
+  - type: Poké-Body
+    name: Bladed Armament
+    text: Damage from this Pokémon's attacks isn't affected by any effects on your
+      opponent's Active Pokémon.
+  moves:
+  - cost: [M, M, C]
+    name: Brave Blade
+    damage: '240'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Promo
+  text:
+  - (This card cannot be used at official tournaments.)
+  - Put this card onto your Active Zacian. Zacian LV.X can use any attack, Poké-Power,
+    or Poké-Body from its previous Level.
+  artist: 5ban Graphics
+- id: 429-SWSH136
+  pioId: swshp-SWSH136
+  enumId: MIMIKYU_Δ_SWSH136
+  name: Mimikyu δ
+  number: SWSH136
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Filch
+    text: Draw 2 cards.
+  - cost: [W, C]
+    name: Wet Claw
+    damage: '40'
+    text: Put an Energy attached to your opponent's Active Pokémon into their hand.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  text:
+  - (This card cannot be used at official tournaments.)
+  artist: Hasuno
+- id: 429-SWSH137
+  pioId: swshp-SWSH137
+  enumId: LIGHT_TOXTRICITY_SWSH137
+  name: Light Toxtricity
+  number: SWSH137
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Toxel
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Slow Ballad
+    text: Heal 30 damage from both Active Pokémon.
+  - cost: [L, L, C]
+    name: Beatdown Smash
+    damage: '160'
+    text: During your next turn, this Pokémon can't use Beatdown Smash.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - (This card cannot be used at official tournaments.)
+  artist: Naoyo Kimura
+- id: 429-SWSH138
+  pioId: swshp-SWSH138
+  enumId: HYDREIGON_C_SWSH138
+  name: Hydreigon C
+  number: SWSH138
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Bite
+    damage: '30'
+  - cost: [D, D, C]
+    name: Berserker Blade
+    damage: '100'
+    text: This attack also does 20 damage to 2 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  text:
+  - (This card cannot be used at official tournaments.)
+  artist: kawayoo
+- id: 429-SWSH139
+  pioId: swshp-SWSH139
+  enumId: PIKACHU_V_UNION_SWSH139
+  name: Pikachu V-UNION
+  number: SWSH139
+  types: [L]
+  superType: POKEMON
+  subTypes: [VUNION]
+  evolvesTo: [Raichu]
+  hp: 300
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [L] Energy cards from your discard pile to this Pokémon.
+  - cost: [L, C]
+    name: Shocking Shock
+    damage: '120'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [L, L, C]
+    name: Disconnect
+    damage: '150'
+    text: During your opponent's next turn, they can't play any Item cards from their
+      hand.
+  - cost: [L, L, C]
+    name: Electro Ball Together
+    damage: '250'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Pikachu V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: n/a
+- id: 429-SWSH140
+  pioId: swshp-SWSH140
+  enumId: PIKACHU_V_UNION_SWSH140
+  name: Pikachu V-UNION
+  number: SWSH140
+  types: [L]
+  superType: POKEMON
+  subTypes: [VUNION]
+  evolvesTo: [Raichu]
+  hp: 300
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [L] Energy cards from your discard pile to this Pokémon.
+  - cost: [L, C]
+    name: Shocking Shock
+    damage: '120'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [L, L, C]
+    name: Disconnect
+    damage: '150'
+    text: During your opponent's next turn, they can't play any Item cards from their
+      hand.
+  - cost: [L, L, C]
+    name: Electro Ball Together
+    damage: '250'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Pikachu V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: n/a
+  variantOf: FILL_THIS-SWSH139
+  variantType: Reprint
+- id: 429-SWSH141
+  pioId: swshp-SWSH141
+  enumId: PIKACHU_V_UNION_SWSH141
+  name: Pikachu V-UNION
+  number: SWSH141
+  types: [L]
+  superType: POKEMON
+  subTypes: [VUNION]
+  evolvesTo: [Raichu]
+  hp: 300
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [L] Energy cards from your discard pile to this Pokémon.
+  - cost: [L, C]
+    name: Shocking Shock
+    damage: '120'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [L, L, C]
+    name: Disconnect
+    damage: '150'
+    text: During your opponent's next turn, they can't play any Item cards from their
+      hand.
+  - cost: [L, L, C]
+    name: Electro Ball Together
+    damage: '250'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Pikachu V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: n/a
+  variantOf: FILL_THIS-SWSH139
+  variantType: Reprint
+- id: 429-SWSH142
+  pioId: swshp-SWSH142
+  enumId: PIKACHU_V_UNION_SWSH142
+  name: Pikachu V-UNION
+  number: SWSH142
+  types: [L]
+  superType: POKEMON
+  subTypes: [VUNION]
+  evolvesTo: [Raichu]
+  hp: 300
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [L] Energy cards from your discard pile to this Pokémon.
+  - cost: [L, C]
+    name: Shocking Shock
+    damage: '120'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [L, L, C]
+    name: Disconnect
+    damage: '150'
+    text: During your opponent's next turn, they can't play any Item cards from their
+      hand.
+  - cost: [L, L, C]
+    name: Electro Ball Together
+    damage: '250'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Pikachu V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: n/a
+  variantOf: FILL_THIS-SWSH139
+  variantType: Reprint
+- id: 429-SWSH143
+  pioId: swshp-SWSH143
+  enumId: PIKACHU_V_SWSH143
+  name: Pikachu V
+  number: SWSH143
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  evolvesTo: [Raichu]
+  hp: 190
+  retreatCost: 1
+  moves:
+  - cost: [L, L, C]
+    name: Volt Tackle
+    damage: '210'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: HYOGONOSUKE
+- id: 429-SWSH144
+  pioId: swshp-SWSH144
+  enumId: GRENINJA_STAR_SWSH144
+  name: Greninja Star
+  number: SWSH144
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 1
+  abilities:
+  - type: Poké-Power
+    name: Shadow Knife
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may put 1 damage counter on 1 of your opponent's Pokémon.
+  moves:
+  - cost: [D, C, C]
+    name: Mist Slash
+    damage: '100'
+    text: This attack's damage isn't affected by Weakness or Resistance, or by any
+      effects on your opponent's Active Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  text:
+  - You can't have more than 1 Pokémon Star in your deck.
+  - (This card cannot be used at official tournaments.)
+  artist: Masakazu Fukuda
+- id: 429-SWSH145
+  pioId: swshp-SWSH145
+  enumId: PIKACHU_V_SWSH145
+  name: Pikachu V
+  number: SWSH145
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  evolvesTo: [Raichu]
+  hp: 190
+  retreatCost: 1
+  moves:
+  - cost: [L, L, C]
+    name: Volt Tackle
+    damage: '210'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-SWSH143
+  variantType: Reprint
+- id: 429-SWSH146
+  pioId: swshp-SWSH146
+  enumId: POKE_BALL_SWSH146
+  name: Poké Ball
+  number: SWSH146
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Promo
+  text:
+  - Flip a coin. If heads, search your deck for a Pokémon, show it to your opponent,
+    and put it into your hand. Shuffle your deck afterward.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: 5ban Graphics
+- id: 429-SWSH147
+  pioId: swshp-SWSH147
+  enumId: RAYQUAZA_V_SWSH147
+  name: Rayquaza V
+  number: SWSH147
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, RAPID_STRIKE]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [L]
+    name: Dragon Pulse
+    damage: '40'
+    text: Discard the top 2 cards of your deck.
+  - cost: [R, L]
+    name: Spiral Burst
+    damage: 20+
+    text: You may discard up to 2 basic [R] Energy or up to 2 basic [L] Energy from
+      this Pokémon. This attack does 80 more damage for each card you discarded in
+      this way.
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: 429-SWSH148
+  pioId: swshp-SWSH148
+  enumId: NOIVERN_V_SWSH148
+  name: Noivern V
+  number: SWSH148
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  moves:
+  - cost: [P]
+    name: Boomburst
+    text: This attack does 20 damage to each of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  - cost: [P, D]
+    name: Synchro Loud
+    damage: 60+
+    text: If you have the same number of cards in your hand as your opponent, this
+      attack does 120 more damage.
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Yamashita
+- id: 429-SWSH149
+  pioId: swshp-SWSH149
+  enumId: FLAREON_V_SWSH149
+  name: Flareon V
+  number: SWSH149
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, SINGLE_STRIKE]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Flaming Breath
+    damage: '20'
+    text: Search your deck for a [R] Energy card and attach it to this Pokémon. Then,
+      shuffle your deck.
+  - cost: [R, R, C]
+    name: Scorching Column
+    damage: '120'
+    text: Your opponent's Active Pokémon is now Burned.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH150
+  pioId: swshp-SWSH150
+  enumId: VAPOREON_V_SWSH150
+  name: Vaporeon V
+  number: SWSH150
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, RAPID_STRIKE]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Triple Draw
+    text: Draw 3 cards.
+  - cost: [W, W, C]
+    name: Splash Jump
+    damage: '90'
+    text: Switch this Pokémon with 1 of your Benched Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH151
+  pioId: swshp-SWSH151
+  enumId: JOLTEON_V_SWSH151
+  name: Jolteon V
+  number: SWSH151
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  moves:
+  - cost: [C]
+    name: Thunder Spear
+    text: This attack does 20 damage to 1 of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  - cost: [L, C, C]
+    name: Pin Missile
+    damage: 60x
+    text: Flip 4 coins. This attack does 60 damage for each heads.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH152
+  pioId: swshp-SWSH152
+  enumId: PROFESSOR_S_RESEARCH_SWSH152
+  name: Professor's Research
+  number: SWSH152
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Promo
+  text:
+  - Discard your hand and draw 7 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yuu Nishida
+- id: 429-SWSH154
+  pioId: swshp-SWSH154
+  enumId: DRAGONITE_V_SWSH154
+  name: Dragonite V
+  number: SWSH154
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 230
+  retreatCost: 3
+  moves:
+  - cost: [C, C]
+    name: Shred
+    damage: '50'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon.
+  - cost: [W, W, L]
+    name: Dragon Gale
+    damage: '250'
+    text: This attack also does 20 damage to each of your Benched Pokémon. (Don't
+      apply Weakness and Resistance for Benched Pokémon.)
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Saki Hayashiro
+- id: 429-SWSH155
+  pioId: swshp-SWSH155
+  enumId: GRENINJA_V_UNION_SWSH155
+  name: Greninja V-UNION
+  number: SWSH155
+  types: [W]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 300
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Ninja Body
+    text: Whenever your opponent plays an Item card from their hand, prevent all effects
+      of that card done to this Pokémon.
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [W] Energy cards from your discard pile to this Pokémon.
+  - cost: [W]
+    name: Aqua Edge
+    damage: '130'
+  - cost: [W, W, C]
+    name: Twister Shuriken
+    damage: '130'
+    text: This attack does 100 damage to each of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [W, W, C]
+    name: Waterfall Blind
+    damage: '180'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Greninja V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: Shin Nagasawa
+- id: 429-SWSH156
+  pioId: swshp-SWSH156
+  enumId: GRENINJA_V_UNION_SWSH156
+  name: Greninja V-UNION
+  number: SWSH156
+  types: [W]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 300
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Ninja Body
+    text: Whenever your opponent plays an Item card from their hand, prevent all effects
+      of that card done to this Pokémon.
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [W] Energy cards from your discard pile to this Pokémon.
+  - cost: [W]
+    name: Aqua Edge
+    damage: '130'
+  - cost: [W, W, C]
+    name: Twister Shuriken
+    damage: '130'
+    text: This attack does 100 damage to each of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [W, W, C]
+    name: Waterfall Blind
+    damage: '180'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Greninja V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: Shin Nagasawa
+  variantOf: FILL_THIS-SWSH155
+  variantType: Reprint
+- id: 429-SWSH157
+  pioId: swshp-SWSH157
+  enumId: GRENINJA_V_UNION_SWSH157
+  name: Greninja V-UNION
+  number: SWSH157
+  types: [W]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 300
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Ninja Body
+    text: Whenever your opponent plays an Item card from their hand, prevent all effects
+      of that card done to this Pokémon.
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [W] Energy cards from your discard pile to this Pokémon.
+  - cost: [W]
+    name: Aqua Edge
+    damage: '130'
+  - cost: [W, W, C]
+    name: Twister Shuriken
+    damage: '130'
+    text: This attack does 100 damage to each of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [W, W, C]
+    name: Waterfall Blind
+    damage: '180'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Greninja V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: Shin Nagasawa
+  variantOf: FILL_THIS-SWSH155
+  variantType: Reprint
+- id: 429-SWSH158
+  pioId: swshp-SWSH158
+  enumId: GRENINJA_V_UNION_SWSH158
+  name: Greninja V-UNION
+  number: SWSH158
+  types: [W]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 300
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Ninja Body
+    text: Whenever your opponent plays an Item card from their hand, prevent all effects
+      of that card done to this Pokémon.
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [W] Energy cards from your discard pile to this Pokémon.
+  - cost: [W]
+    name: Aqua Edge
+    damage: '130'
+  - cost: [W, W, C]
+    name: Twister Shuriken
+    damage: '130'
+    text: This attack does 100 damage to each of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [W, W, C]
+    name: Waterfall Blind
+    damage: '180'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Greninja V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: Shin Nagasawa
+  variantOf: FILL_THIS-SWSH155
+  variantType: Reprint
+- id: 429-SWSH159
+  pioId: swshp-SWSH159
+  enumId: MEWTWO_V_UNION_SWSH159
+  name: Mewtwo V-UNION
+  number: SWSH159
+  types: [P]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 300
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Photon Barrier
+    text: Prevent all effects of attacks from your opponent's Pokémon done to this
+      Pokémon. (Damage is not an effect.)
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [P] Energy cards from your discard pile to this Pokémon.
+  - cost: [P, P, C]
+    name: Super Regeneration
+    text: Heal 200 damage from this Pokémon.
+  - cost: [P, P, C]
+    name: Psysplosion
+    text: Put 16 damage counters on your opponent's Pokémon in any way you like.
+  - cost: [P, P, P, C]
+    name: Final Burn
+    damage: '300'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Mewtwo V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: AKIRA EGAWA
+- id: 429-SWSH160
+  pioId: swshp-SWSH160
+  enumId: MEWTWO_V_UNION_SWSH160
+  name: Mewtwo V-UNION
+  number: SWSH160
+  types: [P]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 300
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Photon Barrier
+    text: Prevent all effects of attacks from your opponent's Pokémon done to this
+      Pokémon. (Damage is not an effect.)
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [P] Energy cards from your discard pile to this Pokémon.
+  - cost: [P, P, C]
+    name: Super Regeneration
+    text: Heal 200 damage from this Pokémon.
+  - cost: [P, P, C]
+    name: Psysplosion
+    text: Put 16 damage counters on your opponent's Pokémon in any way you like.
+  - cost: [P, P, P, C]
+    name: Final Burn
+    damage: '300'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Mewtwo V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: AKIRA EGAWA
+  variantOf: FILL_THIS-SWSH159
+  variantType: Reprint
+- id: 429-SWSH161
+  pioId: swshp-SWSH161
+  enumId: MEWTWO_V_UNION_SWSH161
+  name: Mewtwo V-UNION
+  number: SWSH161
+  types: [P]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 300
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Photon Barrier
+    text: Prevent all effects of attacks from your opponent's Pokémon done to this
+      Pokémon. (Damage is not an effect.)
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [P] Energy cards from your discard pile to this Pokémon.
+  - cost: [P, P, C]
+    name: Super Regeneration
+    text: Heal 200 damage from this Pokémon.
+  - cost: [P, P, C]
+    name: Psysplosion
+    text: Put 16 damage counters on your opponent's Pokémon in any way you like.
+  - cost: [P, P, P, C]
+    name: Final Burn
+    damage: '300'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Mewtwo V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: AKIRA EGAWA
+  variantOf: FILL_THIS-SWSH159
+  variantType: Reprint
+- id: 429-SWSH162
+  pioId: swshp-SWSH162
+  enumId: MEWTWO_V_UNION_SWSH162
+  name: Mewtwo V-UNION
+  number: SWSH162
+  types: [P]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 300
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Photon Barrier
+    text: Prevent all effects of attacks from your opponent's Pokémon done to this
+      Pokémon. (Damage is not an effect.)
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [P] Energy cards from your discard pile to this Pokémon.
+  - cost: [P, P, C]
+    name: Super Regeneration
+    text: Heal 200 damage from this Pokémon.
+  - cost: [P, P, C]
+    name: Psysplosion
+    text: Put 16 damage counters on your opponent's Pokémon in any way you like.
+  - cost: [P, P, P, C]
+    name: Final Burn
+    damage: '300'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Mewtwo V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: AKIRA EGAWA
+  variantOf: FILL_THIS-SWSH159
+  variantType: Reprint
+- id: 429-SWSH163
+  pioId: swshp-SWSH163
+  enumId: ZACIAN_V_UNION_SWSH163
+  name: Zacian V-UNION
+  number: SWSH163
+  types: [M]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 320
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [M] Energy cards from your discard pile to this Pokémon.
+  - cost: [M, M, C]
+    name: Dance of the Crowned Sword
+    damage: '150'
+    text: During your opponent's next turn, the Defending Pokémon's attacks do 150
+      less damage (before applying Weakness and Resistance).
+  - cost: [M, M, C]
+    name: Steel Cut
+    damage: '200'
+  - cost: [M, M, M, C]
+    name: Master Blade
+    damage: '340'
+    text: Discard 3 Energy from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Zacian V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: PLANETA Tsuji
+- id: 429-SWSH164
+  pioId: swshp-SWSH164
+  enumId: ZACIAN_V_UNION_SWSH164
+  name: Zacian V-UNION
+  number: SWSH164
+  types: [M]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 320
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [M] Energy cards from your discard pile to this Pokémon.
+  - cost: [M, M, C]
+    name: Dance of the Crowned Sword
+    damage: '150'
+    text: During your opponent's next turn, the Defending Pokémon's attacks do 150
+      less damage (before applying Weakness and Resistance).
+  - cost: [M, M, C]
+    name: Steel Cut
+    damage: '200'
+  - cost: [M, M, M, C]
+    name: Master Blade
+    damage: '340'
+    text: Discard 3 Energy from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Zacian V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: PLANETA Tsuji
+  variantOf: FILL_THIS-SWSH163
+  variantType: Reprint
+- id: 429-SWSH165
+  pioId: swshp-SWSH165
+  enumId: ZACIAN_V_UNION_SWSH165
+  name: Zacian V-UNION
+  number: SWSH165
+  types: [M]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 320
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [M] Energy cards from your discard pile to this Pokémon.
+  - cost: [M, M, C]
+    name: Dance of the Crowned Sword
+    damage: '150'
+    text: During your opponent's next turn, the Defending Pokémon's attacks do 150
+      less damage (before applying Weakness and Resistance).
+  - cost: [M, M, C]
+    name: Steel Cut
+    damage: '200'
+  - cost: [M, M, M, C]
+    name: Master Blade
+    damage: '340'
+    text: Discard 3 Energy from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Zacian V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: PLANETA Tsuji
+  variantOf: FILL_THIS-SWSH163
+  variantType: Reprint
+- id: 429-SWSH166
+  pioId: swshp-SWSH166
+  enumId: ZACIAN_V_UNION_SWSH166
+  name: Zacian V-UNION
+  number: SWSH166
+  types: [M]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 320
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [M] Energy cards from your discard pile to this Pokémon.
+  - cost: [M, M, C]
+    name: Dance of the Crowned Sword
+    damage: '150'
+    text: During your opponent's next turn, the Defending Pokémon's attacks do 150
+      less damage (before applying Weakness and Resistance).
+  - cost: [M, M, C]
+    name: Steel Cut
+    damage: '200'
+  - cost: [M, M, M, C]
+    name: Master Blade
+    damage: '340'
+    text: Discard 3 Energy from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Zacian V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: PLANETA Tsuji
+  variantOf: FILL_THIS-SWSH163
+  variantType: Reprint
+- id: 429-SWSH167
+  pioId: swshp-SWSH167
+  enumId: PROFESSOR_BURNET_SWSH167
+  name: Professor Burnet
+  number: SWSH167
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Promo
+  text:
+  - Search your deck for up to 2 cards and discard them. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Ryuta Fuse
+- id: 429-SWSH167
+  pioId: swshp-SWSH167
+  enumId: PROFESSOR_BURNET_SWSH167
+  name: Professor Burnet
+  number: SWSH167
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Promo
+  text:
+  - Search your deck for up to 2 cards and discard them. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Ryuta Fuse
+  variantOf: FILL_THIS-SWSH167
+  variantType: Reprint
+- id: 429-SWSH168
+  pioId: swshp-SWSH168
+  enumId: ORICORIO_SWSH168
+  name: Oricorio
+  number: SWSH168
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Lesson in Zeal
+    text: All of your Fusion Strike Pokémon take 20 less damage from attacks from
+      your opponent's Pokémon (after applying Weakness and Resistance). You can't
+      apply more than 1 Lesson in Zeal Ability at a time.
+  moves:
+  - cost: [R, C]
+    name: Glistening Droplets
+    text: Put 5 damage counters on your opponent's Pokémon in any way you like.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+  artist: otumami
+- id: 429-SWSH169
+  pioId: swshp-SWSH169
+  enumId: PYUKUMUKU_SWSH169
+  name: Pyukumuku
+  number: SWSH169
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 80
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Pitch a Pyukumuku
+    text: Once during your turn, if this Pokémon is in your hand, you may reveal it
+      and put it on the bottom of your deck. If you do, draw a card. You can't use
+      more than 1 Pitch a Pyukumuku Ability each turn.
+  moves:
+  - cost: [W, C, C]
+    name: Knuckle Punch
+    damage: '50'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Narumi Sato
+- id: 429-SWSH170
+  pioId: swshp-SWSH170
+  enumId: DEOXYS_SWSH170
+  name: Deoxys
+  number: SWSH170
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE, SINGLE_STRIKE]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [C, C, C]
+    name: Photon Boost
+    damage: 80+
+    text: If this Pokémon has any Fusion Strike Energy attached, this attack does
+      80 more damage.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Souichirou Gunjima
+- id: 429-SWSH171
+  pioId: swshp-SWSH171
+  enumId: LATIAS_SWSH171
+  name: Latias
+  number: SWSH171
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Red Assist
+    text: Once during your turn, you may attach a [P] Energy card from your hand to
+      1 of your Latios.
+  moves:
+  - cost: [R, P, C]
+    name: Dyna Barrier
+    damage: '70'
+    text: During your opponent's next turn, prevent all damage done to this Pokémon
+      by attacks from Pokémon VMAX.
+  rarity: Promo
+  artist: takuyoa
+- id: 429-SWSH172
+  pioId: swshp-SWSH172
+  enumId: TEPIG_SWSH172
+  name: Tepig
+  number: SWSH172
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, SINGLE_STRIKE]
+  evolvesTo: [Pignite]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Ram
+    damage: '20'
+  - cost: [R, R, C]
+    name: Combustion
+    damage: '50'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+  artist: Eri Yamaki
+- id: 429-SWSH173
+  pioId: swshp-SWSH173
+  enumId: BLITZLE_SWSH173
+  name: Blitzle
+  number: SWSH173
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE]
+  evolvesTo: [Zebstrika]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Thunder Spear
+    text: This attack does 10 damage to 1 of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Oswaldo KATO
+- id: 429-SWSH174
+  pioId: swshp-SWSH174
+  enumId: ESPEON_SWSH174
+  name: Espeon
+  number: SWSH174
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Eevee
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Psy Bolt
+    damage: '20'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [P, C]
+    name: Psychic
+    damage: 10+
+    text: This attack does 40 more damage for each Energy attached to your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Tika Matsuno
+- id: 429-SWSH175
+  pioId: swshp-SWSH175
+  enumId: EEVEE_SWSH175
+  name: Eevee
+  number: SWSH175
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Vaporeon, Jolteon, Flareon, Sylveon, Espeon, Umbreon, Leafeon, Glaceon]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Be Prepared
+    text: Attach a basic Energy card from your hand to this Pokémon.
+  - cost: [C, C, C]
+    name: Bite
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Tika Matsuno
+  variantOf: FILL_THIS-SWSH127
+  variantType: Reprint
+- id: 429-SWSH176
+  pioId: swshp-SWSH176
+  enumId: HOOPA_V_SWSH176
+  name: Hoopa V
+  number: SWSH176
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Two-Faced
+    text: As long as this Pokémon is in play, it is Psychic and Darkness type.
+  moves:
+  - cost: [D, D, C]
+    name: Shadow Impact
+    damage: '170'
+    text: Put 3 damage counters on 1 of your Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: takuyoa
+- id: 429-SWSH177
+  pioId: swshp-SWSH177
+  enumId: SPECIAL_DELIVERY_BIDOOF_SWSH177
+  name: Special Delivery Bidoof
+  number: SWSH177
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Happy Delivery
+    text: Search your deck for an Item card, reveal it, and put it into your hand.
+      Then, shuffle your deck.
+  - cost: [C, C, C]
+    name: Rock Smash
+    damage: 30+
+    text: Flip a coin. If heads, this attack does 30 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: The Pokémon Company Art Team
+- id: 429-SWSH178
+  pioId: swshp-SWSH178
+  enumId: PROFESSOR_S_RESEARCH_SWSH178
+  name: Professor's Research
+  number: SWSH178
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Promo
+  text:
+  - Discard your hand and draw 7 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yusuke Kozaki
+  variantOf: FILL_THIS-SWSH152
+  variantType: Reprint
+- id: 429-SWSH179
+  pioId: swshp-SWSH179
+  enumId: FLAREON_V_SWSH179
+  name: Flareon V
+  number: SWSH179
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, SINGLE_STRIKE]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Flaming Breath
+    damage: '20'
+    text: Search your deck for a [R] Energy card and attach it to this Pokémon. Then,
+      shuffle your deck.
+  - cost: [R, R, C]
+    name: Scorching Column
+    damage: '120'
+    text: Your opponent's Active Pokémon is now Burned.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Souichirou Gunjima
+  variantOf: FILL_THIS-SWSH149
+  variantType: Reprint
+- id: 429-SWSH180
+  pioId: swshp-SWSH180
+  enumId: FLAREON_VMAX_SWSH180
+  name: Flareon VMAX
+  number: SWSH180
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX, SINGLE_STRIKE]
+  evolvesFrom: Flareon V
+  hp: 320
+  retreatCost: 2
+  moves:
+  - cost: [R, C, C]
+    name: Max Detonate
+    damage: 100x
+    text: Discard the top 5 cards of your deck. This attack does 100 damage for each
+      Energy card you discarded in this way.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: OKACHEKE
+- id: 429-SWSH181
+  pioId: swshp-SWSH181
+  enumId: VAPOREON_V_SWSH181
+  name: Vaporeon V
+  number: SWSH181
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, RAPID_STRIKE]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Triple Draw
+    text: Draw 3 cards.
+  - cost: [W, W, C]
+    name: Splash Jump
+    damage: '90'
+    text: Switch this Pokémon with 1 of your Benched Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Tika Matsuno
+  variantOf: FILL_THIS-SWSH150
+  variantType: Reprint
+- id: 429-SWSH182
+  pioId: swshp-SWSH182
+  enumId: VAPOREON_VMAX_SWSH182
+  name: Vaporeon VMAX
+  number: SWSH182
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX, RAPID_STRIKE]
+  evolvesFrom: Vaporeon V
+  hp: 320
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Bubble Pod
+    text: Put a [W] Pokémon from your discard pile onto your Bench. If you do, attach
+      up to 3 [W] Energy cards from your discard pile to that Pokémon.
+  - cost: [W, C, C]
+    name: Max Torrent
+    damage: 100+
+    text: If your opponent's Active Pokémon already has any damage counters on it,
+      this attack does 100 more damage.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: Atsushi Furusawa
+- id: 429-SWSH183
+  pioId: swshp-SWSH183
+  enumId: JOLTEON_V_SWSH183
+  name: Jolteon V
+  number: SWSH183
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  moves:
+  - cost: [C]
+    name: Thunder Spear
+    text: This attack does 20 damage to 1 of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  - cost: [L, C, C]
+    name: Pin Missile
+    damage: 60x
+    text: Flip 4 coins. This attack does 60 damage for each heads.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: nagimiso
+  variantOf: FILL_THIS-SWSH151
+  variantType: Reprint
+- id: 429-SWSH184
+  pioId: swshp-SWSH184
+  enumId: JOLTEON_VMAX_SWSH184
+  name: Jolteon VMAX
+  number: SWSH184
+  types: [L]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Jolteon V
+  hp: 300
+  moves:
+  - cost: [L, C]
+    name: Max Thunder Rumble
+    damage: '100'
+    text: This attack also does 100 damage to 1 of your opponent's Benched Pokémon
+      that has any damage counters on it. (Don't apply Weakness and Resistance for
+      Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: Hasuno
+- id: 429-SWSH185
+  pioId: swshp-SWSH185
+  enumId: MOLTRES_SWSH185
+  name: Moltres
+  number: SWSH185
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Inferno Wings
+    damage: 20+
+    text: If this Pokémon has any damage counters on it, this attack does 70 more.
+      This attack's damage isn't affected by Weakness.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+  artist: Shinji Kanda
+- id: 429-SWSH186
+  pioId: swshp-SWSH186
+  enumId: LUCARIO_SWSH186
+  name: Lucario
+  number: SWSH186
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Riolu
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Roaring Resolve
+    text: Once during your turn, you may put 2 damage counters on this Pokémon. If
+      you do, search your deck for a [F] Energy card and attach it to this Pokémon.
+      Then, shuffle your deck.
+  moves:
+  - cost: [F, F]
+    name: Aura Sphere Volley
+    damage: 10+
+    text: Discard all [F] Energy from this Pokémon. This attack does 60 more damage
+      for each card you discarded in this way.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: NC Empire
+- id: 429-SWSH187
+  pioId: swshp-SWSH187
+  enumId: LIEPARD_SWSH187
+  name: Liepard
+  number: SWSH187
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Purrloin
+  hp: 100
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Trade
+    text: You must discard a card from your hand in order to use this Ability. Once
+      during your turn, you may draw 2 cards.
+  moves:
+  - cost: [C, C]
+    name: Slash
+    damage: '60'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: saino misaki
+- id: 429-SWSH188
+  pioId: swshp-SWSH188
+  enumId: BIBAREL_SWSH188
+  name: Bibarel
+  number: SWSH188
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Bidoof
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Industrious Incisors
+    text: Once during your turn, you may draw cards until you have 5 cards in your
+      hand.
+  moves:
+  - cost: [C, C, C]
+    name: Tail Smash
+    damage: '100'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Misa Tsutsui
+- id: 429-SWSH189
+  pioId: swshp-SWSH189
+  enumId: FLAPPLE_SWSH189
+  name: Flapple
+  number: SWSH189
+  types: [N]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Applin
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Flight Up
+    text: Attach up to 3 basic Energy cards from your discard pile to 1 of your Benched
+      Pokémon.
+  - cost: [G, R]
+    name: Corrosive Acid
+    damage: '70'
+    text: Your opponent's Active Pokémon is now Burned.
+  rarity: Promo
+  artist: nagimiso
+- id: 429-SWSH190
+  pioId: swshp-SWSH190
+  enumId: EEVEE_SWSH190
+  name: Eevee
+  number: SWSH190
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Vaporeon, Jolteon, Flareon, Sylveon, Espeon, Umbreon, Leafeon, Glaceon]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Be Prepared
+    text: Attach a basic Energy card from your hand to this Pokémon.
+  - cost: [C, C, C]
+    name: Bite
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: OKACHEKE
+  variantOf: FILL_THIS-SWSH127
+  variantType: Reprint
+- id: 429-SWSH191
+  pioId: swshp-SWSH191
+  enumId: LEAFEON_SWSH191
+  name: Leafeon
+  number: SWSH191
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Eevee
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Leaf Guard
+    damage: '30'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  - cost: [G, C]
+    name: Grass Knot
+    damage: 50+
+    text: This attack does 30 more damage for each [C] in your opponent's Active Pokémon's
+      Retreat Cost.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: OKACHEKE
+- id: 429-SWSH192
+  pioId: swshp-SWSH192
+  enumId: GLACEON_SWSH192
+  name: Glaceon
+  number: SWSH192
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Eevee
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Hail
+    text: This attack does 20 damage to each of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  - cost: [W, C, C]
+    name: Frosty Typhoon
+    damage: '120'
+    text: During your next turn, this Pokémon can't use Frosty Typhoon.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Promo
+  artist: OKACHEKE
+- id: 429-SWSH193
+  pioId: swshp-SWSH193
+  enumId: GALARIAN_OBSTAGOON_SWSH193
+  name: Galarian Obstagoon
+  number: SWSH193
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Galarian Linoone
+  hp: 170
+  retreatCost: 2
+  moves:
+  - cost: [D, D, C]
+    name: Rampaging Kick
+    damage: '180'
+    text: Discard 2 [D] Energy from this Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: Megumi Higuchi
+- id: 429-SWSH194
+  pioId: swshp-SWSH194
+  enumId: LEAFEON_V_SWSH194
+  name: Leafeon V
+  number: SWSH194
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [G]
+    name: Leaf Guard
+    damage: '30'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  - cost: [G, G, C]
+    name: Slashing Strike
+    damage: '180'
+    text: During your next turn, this Pokémon can't use Slashing Strike.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Yamashita
+- id: 429-SWSH195
+  pioId: swshp-SWSH195
+  enumId: LEAFEON_VSTAR_SWSH195
+  name: Leafeon VSTAR
+  number: SWSH195
+  types: [G]
+  superType: POKEMON
+  subTypes: [VSTAR]
+  evolvesFrom: Leafeon V
+  hp: 260
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Ivy Star
+    text: During your turn, you may switch 1 of your opponent's Benched Pokémon with
+      their Active Pokémon. (You can't use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [G, G, C]
+    name: Leaf Guard
+    damage: '180'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH196
+  pioId: swshp-SWSH196
+  enumId: GLACEON_V_SWSH196
+  name: Glaceon V
+  number: SWSH196
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Frost Charge
+    damage: '30'
+    text: Search your deck for a [W] Energy card and attach it to this Pokémon. Then,
+      shuffle your deck.
+  - cost: [W, W, C]
+    name: Freezing Wind
+    damage: '130'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Yamashita
+- id: 429-SWSH197
+  pioId: swshp-SWSH197
+  enumId: GLACEON_VSTAR_SWSH197
+  name: Glaceon VSTAR
+  number: SWSH197
+  types: [W]
+  superType: POKEMON
+  subTypes: [VSTAR]
+  evolvesFrom: Glaceon V
+  hp: 260
+  retreatCost: 2
+  moves:
+  - cost: [W, W, C]
+    name: Icicle Shot
+    damage: '180'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  - cost: [W, W, C]
+    name: Crystal Star
+    damage: '220'
+    text: During your opponent's next turn, prevent all damage from and effects of
+      attacks done to this Pokémon. (You can't use more than 1 VSTAR Power in a game.)
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Promo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH198
+  pioId: swshp-SWSH198
+  enumId: PIKACHU_V_SWSH198
+  name: Pikachu V
+  number: SWSH198
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  evolvesTo: [Raichu]
+  hp: 190
+  retreatCost: 1
+  moves:
+  - cost: [L, L, C]
+    name: Lightning Blast
+    damage: 100+
+    text: You may discard all [L] Energy from this Pokémon. If you do, this attack
+      does 120 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH199
+  pioId: swshp-SWSH199
+  enumId: LYCANROC_V_SWSH199
+  name: Lycanroc V
+  number: SWSH199
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Rock Throw
+    damage: '40'
+  - cost: [F, F, C]
+    name: Crashing Fangs
+    damage: '200'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: 429-SWSH200
+  pioId: swshp-SWSH200
+  enumId: CORVIKNIGHT_V_SWSH200
+  name: Corviknight V
+  number: SWSH200
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [M]
+    name: Clutch
+    damage: '30'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  - cost: [M, M, C]
+    name: Sky Hurricane
+    damage: '190'
+    text: During your next turn, this Pokémon can't use Sky Hurricane.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: 429-SWSH201
+  pioId: swshp-SWSH201
+  enumId: ESPEON_V_SWSH201
+  name: Espeon V
+  number: SWSH201
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Zen Shot
+    text: This attack does 60 damage to 1 of your opponent's Pokémon V. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  - cost: [P, C, C]
+    name: Super Psy Bolt
+    damage: '120'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH202
+  pioId: swshp-SWSH202
+  enumId: SYLVEON_V_SWSH202
+  name: Sylveon V
+  number: SWSH202
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, RAPID_STRIKE]
+  hp: 200
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Dream Gift
+    text: Once during your turn, you may search your deck for an Item card, reveal
+      it, and put it into your hand. Then, shuffle your deck. If you use this Ability,
+      your turn ends.
+  moves:
+  - cost: [C, C]
+    name: Magical Shot
+    damage: '60'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+- id: 429-SWSH203
+  pioId: swshp-SWSH203
+  enumId: UMBREON_V_SWSH203
+  name: Umbreon V
+  number: SWSH203
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, SINGLE_STRIKE]
+  hp: 200
+  retreatCost: 2
+  moves:
+  - cost: [D]
+    name: Mean Look
+    damage: '30'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  - cost: [D, C, C]
+    name: Moonlight Blade
+    damage: 80+
+    text: If this Pokémon has any damage counters on it, this attack does 80 more
+      damage.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH204
+  pioId: swshp-SWSH204
+  enumId: ARCEUS_V_SWSH204
+  name: Arceus V
+  number: SWSH204
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Trinity Charge
+    text: Search your deck for up to 3 basic Energy cards and attach them to your
+      Pokémon V in any way you like. Then, shuffle your deck.
+  - cost: [C, C, C]
+    name: Power Edge
+    damage: '130'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Atsushi Furusawa
+- id: 429-SWSH205
+  pioId: swshp-SWSH205
+  enumId: HISUIAN_BASCULEGION_SWSH205
+  name: Hisuian Basculegion
+  number: SWSH205
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Hisuian Basculin
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Grudge Dive
+    damage: 30+
+    text: If any of your Pokémon were Knocked Out by damage from an attack from your
+      opponent's Pokémon during their last turn, this attack does 90 more damage,
+      and your opponent's Active Pokémon is now Confused.
+  - cost: [W, C, C]
+    name: Jet Headbutt
+    damage: '80'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Pani Kobayashi
+- id: 429-SWSH206
+  pioId: swshp-SWSH206
+  enumId: WYRDEER_SWSH206
+  name: Wyrdeer
+  number: SWSH206
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Stantler
+  hp: 140
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Hurried Gait
+    text: Once during your turn, you may draw a card.
+  moves:
+  - cost: [C, C]
+    name: Extrasensory
+    damage: 40+
+    text: If you have the same number of cards in your hand as your opponent, this
+      attack does 80 more damage.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Eri Yamaki
+- id: 429-SWSH207
+  pioId: swshp-SWSH207
+  enumId: HISUIAN_SAMUROTT_SWSH207
+  name: Hisuian Samurott
+  number: SWSH207
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Dewott
+  hp: 170
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Wily Stance
+    text: You must discard a card from your hand in order to use this Ability. Once
+      during your turn, you may draw 3 cards.
+  moves:
+  - cost: [D, C, C]
+    name: Dark Mastery
+    damage: 60+
+    text: This attack does 20 more damage for each Energy attached to all of your
+      Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: Oswaldo KATO
+- id: 429-SWSH208
+  pioId: swshp-SWSH208
+  enumId: MAGNEZONE_SWSH208
+  name: Magnezone
+  number: SWSH208
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Magneton
+  hp: 150
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Giga Magnet
+    text: Once during your turn, you may look at the top 6 cards of your deck and
+      attach any number of [M] Energy cards you find there to your Pokémon in any
+      way you like. Shuffle the other cards back into your deck.
+  moves:
+  - cost: [M, C, C]
+    name: Power Beam
+    damage: '120'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Promo
+  artist: zig
+- id: 429-SWSH209
+  pioId: swshp-SWSH209
+  enumId: TOXEL_SWSH209
+  name: Toxel
+  number: SWSH209
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Toxtricity]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Growl
+    text: During your opponent's next turn, the Defending Pokémon's attacks do 30
+      less damage (before applying Weakness and Resistance).
+  - cost: [L]
+    name: Tiny Bolt
+    damage: '10'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Souichirou Gunjima
+- id: 429-SWSH210
+  pioId: swshp-SWSH210
+  enumId: ORICORIO_SWSH210
+  name: Oricorio
+  number: SWSH210
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Mixed Call
+    text: Search your deck for a Pokémon and a Supporter card, reveal them, and put
+      them into your hand. Then, shuffle your deck.
+  - cost: [P, C, C]
+    name: Razor Wing
+    damage: '80'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Ryuta Fuse
+- id: 429-SWSH211
+  pioId: swshp-SWSH211
+  enumId: SYLVEON_SWSH211
+  name: Sylveon
+  number: SWSH211
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Eevee
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Time Out Kick
+    damage: '30'
+    text: You may put an Energy attached to your opponent's Active Pokémon into their
+      hand.
+  - cost: [P, C, C]
+    name: Symphony Whip
+    damage: 70+
+    text: If you played a Supporter card from your hand during this turn, this attack
+      does 70 more damage.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Promo
+  artist: Mizue
+- id: 429-SWSH212
+  pioId: swshp-SWSH212
+  enumId: EEVEE_SWSH212
+  name: Eevee
+  number: SWSH212
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Vaporeon, Jolteon, Flareon, Sylveon, Espeon, Umbreon, Leafeon, Glaceon]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Be Prepared
+    text: Attach a basic Energy card from your hand to this Pokémon.
+  - cost: [C, C, C]
+    name: Bite
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Mizue
+  variantOf: FILL_THIS-SWSH127
+  variantType: Reprint
+- id: 429-SWSH213
+  pioId: swshp-SWSH213
+  enumId: LUCARIO_V_SWSH213
+  name: Lucario V
+  number: SWSH213
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Crushing Punch
+    damage: '50'
+    text: Discard a Special Energy from your opponent's Active Pokémon.
+  - cost: [F, C, C]
+    name: Cyclone Kick
+    damage: '120'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: takuyoa
+- id: 429-SWSH214
+  pioId: swshp-SWSH214
+  enumId: LUCARIO_VSTAR_SWSH214
+  name: Lucario VSTAR
+  number: SWSH214
+  types: [F]
+  superType: POKEMON
+  subTypes: [VSTAR]
+  evolvesFrom: Lucario V
+  hp: 270
+  retreatCost: 2
+  moves:
+  - cost: [F, C, C]
+    name: Fighting Knuckle
+    damage: 120+
+    text: If your opponent's Active Pokémon is a Pokémon V, this attack does 120 more
+      damage.
+  - cost: [F, C]
+    name: Aura Star
+    damage: 70x
+    text: This attack does 70 damage for each Energy attached to all of your opponent's
+      Pokémon. (You can't use more than 1 VSTAR Power in a game.)
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: aky CG Works
+- id: 429-SWSH215
+  pioId: swshp-SWSH215
+  enumId: MORPEKO_V_UNION_SWSH215
+  name: Morpeko V-UNION
+  number: SWSH215
+  types: [L]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 310
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [L] Energy cards from your discard pile to this Pokémon.
+  - cost: [C, C]
+    name: All You Can Eat
+    text: Draw cards until you have 10 cards in your hand.
+  - cost: [L, C, C]
+    name: Burst Wheel
+    damage: 100x
+    text: Discard all energy from this Pokémon. This attack does 100 damage for each
+      card you discarded in this way.
+  - cost: [L, C, C]
+    name: Electric Ball
+    damage: '160'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Morpeko V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: Mitsuhiro Arita
+- id: 429-SWSH216
+  pioId: swshp-SWSH216
+  enumId: MORPEKO_V_UNION_SWSH216
+  name: Morpeko V-UNION
+  number: SWSH216
+  types: [L]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 310
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [L] Energy cards from your discard pile to this Pokémon.
+  - cost: [C, C]
+    name: All You Can Eat
+    text: Draw cards until you have 10 cards in your hand.
+  - cost: [L, C, C]
+    name: Burst Wheel
+    damage: 100x
+    text: Discard all energy from this Pokémon. This attack does 100 damage for each
+      card you discarded in this way.
+  - cost: [L, C, C]
+    name: Electric Ball
+    damage: '160'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Morpeko V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: Mitsuhiro Arita
+  variantOf: FILL_THIS-SWSH215
+  variantType: Reprint
+- id: 429-SWSH217
+  pioId: swshp-SWSH217
+  enumId: MORPEKO_V_UNION_SWSH217
+  name: Morpeko V-UNION
+  number: SWSH217
+  types: [L]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 310
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [L] Energy cards from your discard pile to this Pokémon.
+  - cost: [C, C]
+    name: All You Can Eat
+    text: Draw cards until you have 10 cards in your hand.
+  - cost: [L, C, C]
+    name: Burst Wheel
+    damage: 100x
+    text: Discard all energy from this Pokémon. This attack does 100 damage for each
+      card you discarded in this way.
+  - cost: [L, C, C]
+    name: Electric Ball
+    damage: '160'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Morpeko V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: Mitsuhiro Arita
+  variantOf: FILL_THIS-SWSH215
+  variantType: Reprint
+- id: 429-SWSH218
+  pioId: swshp-SWSH218
+  enumId: MORPEKO_V_UNION_SWSH218
+  name: Morpeko V-UNION
+  number: SWSH218
+  types: [L]
+  superType: POKEMON
+  subTypes: [VUNION]
+  hp: 310
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Union Gain
+    text: Attach up to 2 [L] Energy cards from your discard pile to this Pokémon.
+  - cost: [C, C]
+    name: All You Can Eat
+    text: Draw cards until you have 10 cards in your hand.
+  - cost: [L, C, C]
+    name: Burst Wheel
+    damage: 100x
+    text: Discard all energy from this Pokémon. This attack does 100 damage for each
+      card you discarded in this way.
+  - cost: [L, C, C]
+    name: Electric Ball
+    damage: '160'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'How to play a Pokémon V-UNION: Once per game during your turn, combine 4 different
+    Morpeko V-UNION from your discard pile and put them onto your Bench.'
+  - 'V-UNION rule: When your Pokémon V-UNION is Knocked Out, your opponent takes 3
+    Prize cards.'
+  artist: Mitsuhiro Arita
+  variantOf: FILL_THIS-SWSH215
+  variantType: Reprint
+- id: 429-SWSH219
+  pioId: swshp-SWSH219
+  enumId: BOLTUND_V_SWSH219
+  name: Boltund V
+  number: SWSH219
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Smash Turn
+    damage: '30'
+    text: You may switch this Pokémon with 1 of your Benched Pokémon.
+  - cost: [L, L, C]
+    name: Electrobullet
+    damage: '120'
+    text: This attack also does 30 damage to 1 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Ayaka Yoshida
+- id: 429-SWSH220
+  pioId: swshp-SWSH220
+  enumId: ROWLET_SWSH220
+  name: Rowlet
+  number: SWSH220
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Dartrix]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Jump On
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 10 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: sowsow
+- id: 429-SWSH221
+  pioId: swshp-SWSH221
+  enumId: CYNDAQUIL_SWSH221
+  name: Cyndaquil
+  number: SWSH221
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Quilava]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Charge Energy
+    text: Search your deck for up to 2 basic Energy cards, reveal them, and put them
+      into your hand. Then, shuffle your deck.
+  - cost: [C]
+    name: Live Coal
+    damage: '10'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+  artist: Teeziro
+- id: 429-SWSH222
+  pioId: swshp-SWSH222
+  enumId: OSHAWOTT_SWSH222
+  name: Oshawott
+  number: SWSH222
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Dewott]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Beat
+    damage: '10'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: kurumitsu
+- id: 429-SWSH223
+  pioId: swshp-SWSH223
+  enumId: MEWTWO_V_SWSH223
+  name: Mewtwo V
+  number: SWSH223
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [P, C]
+    name: Super Psy Bolt
+    damage: '50'
+  - cost: [P, P, C]
+    name: Transfer Break
+    damage: '160'
+    text: Move an Energy from this Pokémon to 1 of your Benched Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: 429-SWSH224
+  pioId: swshp-SWSH224
+  enumId: MELMETAL_V_SWSH224
+  name: Melmetal V
+  number: SWSH224
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [M, M]
+    name: Arm Charge
+    damage: '50'
+    text: You may attach a [M] Energy card from your hand to this Pokémon.
+  - cost: [M, M, M]
+    name: Mega Punch
+    damage: '140'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: sadaji
+- id: 429-SWSH225
+  pioId: swshp-SWSH225
+  enumId: ALOLAN_EXEGGUTOR_V_SWSH225
+  name: Alolan Exeggutor V
+  number: SWSH225
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 240
+  retreatCost: 3
+  moves:
+  - cost: [G]
+    name: Growing Tall
+    text: Flip a coin. If heads, search your deck for up to 5 [G] Energy cards and
+      attach them to your Pokémon in any way you like. Then, shuffle your deck.
+  - cost: [C, C, C]
+    name: Head Swing
+    text: This attack does 30 damage to 1 of your opponent's Pokémon for each [G]
+      Energy attached to this Pokémon. (Don't apply Weakness and Resistance for Benched
+      Pokémon.)
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: MUGENUP
+- id: 429-SWSH226
+  pioId: swshp-SWSH226
+  enumId: SPARK_SWSH226
+  name: Spark
+  number: SWSH226
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Promo
+  text:
+  - Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach
+    a [L] Energy card from your discard pile to 1 of your Benched Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Naoki Saito
+- id: 429-SWSH227
+  pioId: swshp-SWSH227
+  enumId: BLANCHE_SWSH227
+  name: Blanche
+  number: SWSH227
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Promo
+  text:
+  - Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach
+    a [W] Energy card from your discard pile to 1 of your Benched Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Anesaki Dynamic
+- id: 429-SWSH228
+  pioId: swshp-SWSH228
+  enumId: CANDELA_SWSH228
+  name: Candela
+  number: SWSH228
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Promo
+  text:
+  - Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach
+    a [R] Energy card from your discard pile to 1 of your Benched Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Ryuta Fuse
+- id: 429-SWSH229
+  pioId: swshp-SWSH229
+  enumId: MEWTWO_V_SWSH229
+  name: Mewtwo V
+  number: SWSH229
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [P, C]
+    name: Super Psy Bolt
+    damage: '50'
+  - cost: [P, P, C]
+    name: Transfer Break
+    damage: '160'
+    text: Move an Energy from this Pokémon to 1 of your Benched Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+  variantOf: FILL_THIS-SWSH223
+  variantType: Reprint
+- id: 429-SWSH230
+  pioId: swshp-SWSH230
+  enumId: RADIANT_EEVEE_SWSH230
+  name: Radiant Eevee
+  number: SWSH230
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Vaporeon, Jolteon, Flareon, Sylveon, Espeon, Umbreon, Leafeon, Glaceon]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Twinkle Gathering
+    text: Search your deck for a number of cards up to the number of different types
+      of Pokémon you have in play and put them into your hand. Then, shuffle your
+      deck.
+  - cost: [C, C, C]
+    name: Boost Dash
+    damage: '50'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text:
+  - 'Radiant Pokémon Rule: You cant have more than 1 Radiant Pokémon in your deck.'
+  artist: Souichirou Gunjima
+- id: 429-SWSH231
+  pioId: swshp-SWSH231
+  enumId: BULBASAUR_SWSH231
+  name: Bulbasaur
+  number: SWSH231
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Ivysaur]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [G]
+    name: Vine Whip
+    damage: '10'
+  - cost: [G, C]
+    name: Razor Leaf
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+- id: 429-SWSH232
+  pioId: swshp-SWSH232
+  enumId: CHARMANDER_SWSH232
+  name: Charmander
+  number: SWSH232
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Charmeleon]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Tail on Fire
+    damage: '10'
+    text: Search your deck for a [R] Energy card and attach it to this Pokémon. Then,
+      shuffle your deck.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 429-SWSH233
+  pioId: swshp-SWSH233
+  enumId: SQUIRTLE_SWSH233
+  name: Squirtle
+  number: SWSH233
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Wartortle]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Water Gun
+    damage: '20'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+- id: 429-SWSH234
+  pioId: swshp-SWSH234
+  enumId: PIKACHU_SWSH234
+  name: Pikachu
+  number: SWSH234
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raichu]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Gift Delivery
+    text: Flip a coin. If heads, search your deck for an Item card, reveal it, and
+      put it into your hand. Then, shuffle your deck.
+  - cost: [L, C, C]
+    name: Pika Ball
+    damage: '50'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 429-SWSH237
+  pioId: swshp-SWSH237
+  enumId: HISUIAN_TYPHLOSION_V_SWSH237
+  name: Hisuian Typhlosion V
+  number: SWSH237
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Singe
+    text: Your opponent's Active Pokémon is now Burned.
+  - cost: [P, P, C]
+    name: Petrifying Flame
+    damage: '120'
+    text: Choose a random card from your opponent's hand. Your opponent reveals that
+      card and shuffles it into their deck.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH238
+  pioId: swshp-SWSH238
+  enumId: HISUIAN_DECIDUEYE_V_SWSH238
+  name: Hisuian Decidueye V
+  number: SWSH238
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Mountain Hunt
+    text: Search your deck for up to 2 cards and put them into your hand. Then, shuffle
+      your deck.
+  - cost: [F, C, C]
+    name: Close-Quarters Shooting
+    damage: '100'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH239
+  pioId: swshp-SWSH239
+  enumId: HISUIAN_SAMUROTT_V_SWSH239
+  name: Hisuian Samurott V
+  number: SWSH239
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [D]
+    name: Basket Crash
+    text: Discard up to 2 Pokémon Tools from your opponent's Pokémon.
+  - cost: [D, D, D]
+    name: Shadow Slash
+    damage: '180'
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH248
+  pioId: swshp-SWSH248
+  enumId: KLEAVOR_V_SWSH248
+  name: Kleavor V
+  number: SWSH248
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Cut
+    damage: '40'
+  - cost: [F, F, C]
+    name: Axe Slash
+    damage: '150'
+    text: Discard an Energy from this Pokémon. If you do, discard an Energy from your
+      opponent's Active Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH249
+  pioId: swshp-SWSH249
+  enumId: KLEAVOR_VSTAR_SWSH249
+  name: Kleavor VSTAR
+  number: SWSH249
+  types: [F]
+  superType: POKEMON
+  subTypes: [VSTAR]
+  evolvesFrom: Kleavor V
+  hp: 270
+  retreatCost: 2
+  moves:
+  - cost: [F, C]
+    name: Axe Break
+    damage: '120'
+    text: This attack also does 60 damage to 1 of your opponent's Benched Pokémon
+      V. (Don't apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [F]
+    name: Rampaging Star
+    damage: 30x
+    text: This attack does 30 damage for each Pokémon in your discard pile. (You can't
+      use more than 1 VSTAR Power in a game.)
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: 429-SWSH250
+  pioId: swshp-SWSH250
+  enumId: LUMINEON_V_SWSH250
+  name: Lumineon V
+  number: SWSH250
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 170
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Luminous Sign
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may search your deck for a Supporter card, reveal it, and put it into your
+      hand. Then, shuffle your deck.
+  moves:
+  - cost: [W, C, C]
+    name: Aqua Return
+    damage: '120'
+    text: Shuffle this Pokémon and all attached cards into your deck.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Tsuji

--- a/data/src/main/resources/cards/439-celebrations.yaml
+++ b/data/src/main/resources/cards/439-celebrations.yaml
@@ -579,7 +579,7 @@ cards:
 - id: 439-23
   pioId: cel25-23
   enumId: PROFESSOR_S_RESEARCH_23
-  name: Professor’s Research
+  name: Professor's Research
   number: '23'
   superType: TRAINER
   subTypes: [SUPPORTER]
@@ -590,7 +590,7 @@ cards:
 - id: 439-24
   pioId: cel25-24
   enumId: PROFESSOR_S_RESEARCH_24
-  name: Professor’s Research
+  name: Professor's Research
   number: '24'
   superType: TRAINER
   subTypes: [SUPPORTER]
@@ -628,5 +628,5 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Saki Hayashiro
-  variantOf: 430-178
+  variantOf: 439-11
   variantType: Reprint

--- a/data/src/main/resources/cards/439-celebrations.yaml
+++ b/data/src/main/resources/cards/439-celebrations.yaml
@@ -1,0 +1,631 @@
+id: FILL_THIS
+name: cel25
+enumId: FILL_THIS
+abbr: FILL_THIS
+pioId: cel25
+cards:
+- id: FILL_THIS-1
+  pioId: cel25-1
+  enumId: HO_OH_1
+  name: Ho-Oh
+  number: '1'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [R, C]
+    name: Sacred Fire
+    text: This attack does 50 damage to 1 of your opponent’s Pokémon. (Don’t apply
+      Weakness and Resistance for Benched Pokémon.)
+  - cost: [R, R, C]
+    name: Fire Blast
+    damage: '120'
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Kouki Saitou
+- id: FILL_THIS-2
+  pioId: cel25-2
+  enumId: RESHIRAM_2
+  name: Reshiram
+  number: '2'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [C, C]
+    name: Scorching Wind
+    text: This attack does 20 damage to each of your opponent’s Benched Pokémon. (Don’t
+      apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [R, R, C]
+    name: Black Flame
+    damage: 80+
+    text: If Zekrom is on your Bench, this attack does 80 more damage.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare
+  artist: Aya Kusube
+- id: FILL_THIS-3
+  pioId: cel25-3
+  enumId: KYOGRE_3
+  name: Kyogre
+  number: '3'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [W, W, C]
+    name: Aqua Storm
+    text: Discard the top 5 cards of your deck, and then choose 2 of your opponent’s
+      Benched Pokémon. This attack does 50 damage for each Energy card you discarded
+      in this way to each of those Pokémon. (Don’t apply Weakness and Resistance for
+      Benched Pokémon.)
+  - cost: [W, W, C, C]
+    name: Surf
+    damage: '120'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare
+  artist: Ryuta Fuse
+- id: FILL_THIS-4
+  pioId: cel25-4
+  enumId: PALKIA_4
+  name: Palkia
+  number: '4'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Absolute Space
+    text: As long as this Pokémon is in the Active Spot, your opponent can’t play
+      any Stadium cards from their hand.
+  moves:
+  - cost: [W, C, C]
+    name: Overdrive Smash
+    damage: 80+
+    text: During your next turn, this Pokémon’s Overdrive Smash attack does 80 more
+      damage (before applying Weakness and Resistance).
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare
+  artist: 5ban Graphics
+- id: FILL_THIS-5
+  pioId: cel25-5
+  enumId: PIKACHU_5
+  name: Pikachu
+  number: '5'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raichu]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Gnaw
+    damage: '10'
+  - cost: [L, C]
+    name: Thunder Jolt
+    damage: '30'
+    text: Flip a coin. If tails, this Pokémon also does 10 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: Mitsuhiro Arita
+- id: FILL_THIS-6
+  pioId: cel25-6
+  enumId: FLYING_PIKACHU_V_6
+  name: Flying Pikachu V
+  number: '6'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  evolvesTo: [Raichu]
+  hp: 190
+  moves:
+  - cost: [L]
+    name: Thunder Shock
+    damage: '20'
+    text: Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed.
+  - cost: [C, C, C]
+    name: Fly
+    damage: '120'
+    text: Flip a coin. If tails, this attack does nothing. If heads, during your opponent’s
+      next turn, prevent all damage from and effects of attacks done to this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+- id: FILL_THIS-7
+  pioId: cel25-7
+  enumId: FLYING_PIKACHU_VMAX_7
+  name: Flying Pikachu VMAX
+  number: '7'
+  types: [L]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Flying Pikachu V
+  evolvesTo: [Raichu]
+  hp: 310
+  moves:
+  - cost: [L, C, C]
+    name: Max Balloon
+    damage: '160'
+    text: During your opponent’s next turn, prevent all damage done to this Pokémon
+      by attacks from Basic Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: aky CG Works
+- id: FILL_THIS-8
+  pioId: cel25-8
+  enumId: SURFING_PIKACHU_V_8
+  name: Surfing Pikachu V
+  number: '8'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  evolvesTo: [Raichu]
+  hp: 200
+  retreatCost: 1
+  moves:
+  - cost: [W, W, W]
+    name: Surf
+    damage: '150'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+- id: FILL_THIS-9
+  pioId: cel25-9
+  enumId: SURFING_PIKACHU_VMAX_9
+  name: Surfing Pikachu VMAX
+  number: '9'
+  types: [L]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Surfing Pikachu V
+  evolvesTo: [Raichu]
+  hp: 310
+  retreatCost: 1
+  moves:
+  - cost: [W, W, W]
+    name: Max Surfer
+    damage: '160'
+    text: This attack also does 30 damage to each of your opponent’s Benched Pokémon.
+      (Don’t apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: aky CG Works
+- id: FILL_THIS-10
+  pioId: cel25-10
+  enumId: ZEKROM_10
+  name: Zekrom
+  number: '10'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [C, C]
+    name: Field Crush
+    damage: '30'
+    text: If your opponent has a Stadium in play, discard it.
+  - cost: [L, L, C]
+    name: White Thunder
+    damage: 80+
+    text: If Reshiram is on your Bench, this attack does 80 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Aya Kusube
+- id: FILL_THIS-11
+  pioId: cel25-11
+  enumId: MEW_11
+  name: Mew
+  number: '11'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Mysterious Tail
+    text: Once during your turn, if this Pokémon is in the Active Spot, you may look
+      at the top 6 cards of your deck, reveal an Item card you find there, and put
+      it into your hand. Shuffle the other cards back into your deck.
+  moves:
+  - cost: [P, C]
+    name: Psyshot
+    damage: '30'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: Yuu Nishida
+- id: FILL_THIS-12
+  pioId: cel25-12
+  enumId: XERNEAS_12
+  name: Xerneas
+  number: '12'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Breath of Life
+    text: Search your deck for up to 3 basic Energy cards of different types and attach
+      them to your Pokémon in any way you like. Then, shuffle your deck.
+  - cost: [P, C, C]
+    name: Aurora Horns
+    damage: '100'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare
+  artist: AKIRA EGAWA
+- id: FILL_THIS-13
+  pioId: cel25-13
+  enumId: COSMOG_13
+  name: Cosmog
+  number: '13'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Cosmoem]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Star Protection
+    text: Flip a coin. If heads, during your opponent’s next turn, prevent all damage
+      done to this Pokémon by attacks.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: kirisAki
+- id: FILL_THIS-14
+  pioId: cel25-14
+  enumId: COSMOEM_14
+  name: Cosmoem
+  number: '14'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Cosmog
+  evolvesTo: [Solgaleo, Lunala]
+  hp: 90
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Star Protection
+    text: Flip a coin. If heads, during your opponent’s next turn, prevent all damage
+      done to this Pokémon by attacks.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: kirisAki
+- id: FILL_THIS-15
+  pioId: cel25-15
+  enumId: LUNALA_15
+  name: Lunala
+  number: '15'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Cosmoem
+  hp: 160
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Lunar Pain
+    text: Double the number of damage counters on each of your opponent’s Pokémon.
+  - cost: [P, C, C]
+    name: Psychic Shot
+    damage: '130'
+    text: This attack also does 30 damage to 1 of your opponent’s Benched Pokémon.
+      (Don’t apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: kirisAki
+- id: FILL_THIS-16
+  pioId: cel25-16
+  enumId: ZACIAN_V_16
+  name: Zacian V
+  number: '16'
+  types: [P]
+  superType: POKEMON
+  subTypes: []
+  hp: 220
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Roar of the Sword
+    text: Once during your turn, you may search your deck for a [P] Energy card and
+      attach it to 1 of your Pokémon. Then, shuffle your deck. If you use this Ability,
+      your turn ends.
+  moves:
+  - cost: [C, C, C]
+    name: Storm Slash
+    damage: 60+
+    text: This attack does 30 more damage for each [P] Energy attached to this Pokémon.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Mitsuhiro Arita
+- id: FILL_THIS-17
+  pioId: cel25-17
+  enumId: GROUDON_17
+  name: Groudon
+  number: '17'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [F, F, C]
+    name: Magma Volcano
+    damage: 80x
+    text: Discard the top 5 cards of your deck. This attack does 80 damage for each
+      Energy card you discarded in this way.
+  - cost: [F, F, C, C]
+    name: Massive Rend
+    damage: '120'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: Ryuta Fuse
+- id: FILL_THIS-18
+  pioId: cel25-18
+  enumId: ZAMAZENTA_V_18
+  name: Zamazenta V
+  number: '18'
+  types: [F]
+  superType: POKEMON
+  subTypes: []
+  hp: 220
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Growl of the Shield
+    text: All of your [F] Pokémon take 20 less damage from attacks from your opponent’s
+      Pokémon VMAX (after applying Weakness and Resistance). You can’t apply more
+      than 1 Growl of the Shield Ability at a time.
+  moves:
+  - cost: [F, F, C]
+    name: Heavy Impact
+    damage: '150'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Mitsuhiro Arita
+- id: FILL_THIS-19
+  pioId: cel25-19
+  enumId: YVELTAL_19
+  name: Yveltal
+  number: '19'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Cry of Destruction
+    text: Discard up to 3 Special Energy from your opponent’s Pokémon.
+  - cost: [D, C, C]
+    name: Dark Feather
+    damage: '100'
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: AKIRA EGAWA
+- id: FILL_THIS-20
+  pioId: cel25-20
+  enumId: DIALGA_20
+  name: Dialga
+  number: '20'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [M]
+    name: Temporal Backflow
+    text: Put a card from your discard pile into your hand.
+  - cost: [C, C, C]
+    name: Metal Blast
+    damage: 60+
+    text: This attack does 20 more damage for each [M] Energy attached to this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare
+  artist: 5ban Graphics
+- id: FILL_THIS-21
+  pioId: cel25-21
+  enumId: SOLGALEO_21
+  name: Solgaleo
+  number: '21'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Cosmoem
+  hp: 170
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Rush In
+    text: Once during your turn, if this Pokémon is on your Bench, you may switch
+      it with your Active Pokémon.
+  moves:
+  - cost: [C, C]
+    name: Solar Geyser
+    damage: '100'
+    text: Attach up to 2 basic Energy cards from your discard pile to 1 of your Benched
+      Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  artist: kirisAki
+- id: FILL_THIS-22
+  pioId: cel25-22
+  enumId: LUGIA_22
+  name: Lugia
+  number: '22'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Aero Ball
+    damage: 20x
+    text: This attack does 20 damage for each Energy attached to both Active Pokémon.
+  - cost: [C, C, C, C]
+    name: Deep Crush
+    damage: '160'
+    text: During your next turn, this Pokémon can’t attack.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Kouki Saitou
+- id: FILL_THIS-23
+  pioId: cel25-23
+  enumId: PROFESSOR_S_RESEARCH_PROFESSOR_OAK__23
+  name: Professor’s Research (Professor Oak)
+  number: '23'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Rare Holo
+  text:
+  - Discard your hand and draw 7 cards.
+  artist: KIYOTAKA OSHIYAMA
+- id: FILL_THIS-24
+  pioId: cel25-24
+  enumId: PROFESSOR_S_RESEARCH_PROFESSOR_OAK__24
+  name: Professor’s Research (Professor Oak)
+  number: '24'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Discard your hand and draw 7 cards.
+  artist: Ken Sugimori
+  variantOf: FILL_THIS-23
+  variantType: Full Art
+- id: FILL_THIS-25
+  pioId: cel25-25
+  enumId: MEW_25
+  name: Mew
+  number: '25'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Mysterious Tail
+    text: Once during your turn, if this Pokémon is in the Active Spot, you may look
+      at the top 6 cards of your deck, reveal an Item card you find there, and put
+      it into your hand. Shuffle the other cards back into your deck.
+  moves:
+  - cost: [P, C]
+    name: Psyshot
+    damage: '30'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: Saki Hayashiro
+  variantOf: FILL_THIS-11
+  variantType: Reprint

--- a/data/src/main/resources/cards/439-celebrations.yaml
+++ b/data/src/main/resources/cards/439-celebrations.yaml
@@ -587,6 +587,8 @@ cards:
   text:
   - Discard your hand and draw 7 cards.
   artist: KIYOTAKA OSHIYAMA
+  variantOf: 430-178
+  variantType: Reprint
 - id: 439-24
   pioId: cel25-24
   enumId: PROFESSOR_S_RESEARCH_24
@@ -629,4 +631,4 @@ cards:
   rarity: Rare Holo
   artist: Saki Hayashiro
   variantOf: 439-11
-  variantType: Reprint
+  variantType: Secret Art

--- a/data/src/main/resources/cards/439-celebrations.yaml
+++ b/data/src/main/resources/cards/439-celebrations.yaml
@@ -578,8 +578,8 @@ cards:
   artist: Kouki Saitou
 - id: 439-23
   pioId: cel25-23
-  enumId: PROFESSOR_S_RESEARCH_PROFESSOR_OAK__23
-  name: Professor’s Research (Professor Oak)
+  enumId: PROFESSOR_S_RESEARCH_23
+  name: Professor’s Research
   number: '23'
   superType: TRAINER
   subTypes: [SUPPORTER]
@@ -589,8 +589,8 @@ cards:
   artist: KIYOTAKA OSHIYAMA
 - id: 439-24
   pioId: cel25-24
-  enumId: PROFESSOR_S_RESEARCH_PROFESSOR_OAK__24
-  name: Professor’s Research (Professor Oak)
+  enumId: PROFESSOR_S_RESEARCH_24
+  name: Professor’s Research
   number: '24'
   superType: TRAINER
   subTypes: [SUPPORTER]

--- a/data/src/main/resources/cards/439-celebrations.yaml
+++ b/data/src/main/resources/cards/439-celebrations.yaml
@@ -1,10 +1,11 @@
-id: FILL_THIS
+schema: E2
+id: '439'
 name: cel25
-enumId: FILL_THIS
-abbr: FILL_THIS
+enumId: CELEBRATIONS
+abbr: CEL
 pioId: cel25
 cards:
-- id: FILL_THIS-1
+- id: 439-1
   pioId: cel25-1
   enumId: HO_OH_1
   name: Ho-Oh
@@ -31,7 +32,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Kouki Saitou
-- id: FILL_THIS-2
+- id: 439-2
   pioId: cel25-2
   enumId: RESHIRAM_2
   name: Reshiram
@@ -55,7 +56,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Aya Kusube
-- id: FILL_THIS-3
+- id: 439-3
   pioId: cel25-3
   enumId: KYOGRE_3
   name: Kyogre
@@ -80,7 +81,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Ryuta Fuse
-- id: FILL_THIS-4
+- id: 439-4
   pioId: cel25-4
   enumId: PALKIA_4
   name: Palkia
@@ -106,7 +107,7 @@ cards:
     value: x2
   rarity: Rare
   artist: 5ban Graphics
-- id: FILL_THIS-5
+- id: 439-5
   pioId: cel25-5
   enumId: PIKACHU_5
   name: Pikachu
@@ -130,7 +131,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Mitsuhiro Arita
-- id: FILL_THIS-6
+- id: 439-6
   pioId: cel25-6
   enumId: FLYING_PIKACHU_V_6
   name: Flying Pikachu V
@@ -160,7 +161,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: aky CG Works
-- id: FILL_THIS-7
+- id: 439-7
   pioId: cel25-7
   enumId: FLYING_PIKACHU_VMAX_7
   name: Flying Pikachu VMAX
@@ -188,7 +189,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: aky CG Works
-- id: FILL_THIS-8
+- id: 439-8
   pioId: cel25-8
   enumId: SURFING_PIKACHU_V_8
   name: Surfing Pikachu V
@@ -210,7 +211,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: aky CG Works
-- id: FILL_THIS-9
+- id: 439-9
   pioId: cel25-9
   enumId: SURFING_PIKACHU_VMAX_9
   name: Surfing Pikachu VMAX
@@ -236,7 +237,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: aky CG Works
-- id: FILL_THIS-10
+- id: 439-10
   pioId: cel25-10
   enumId: ZEKROM_10
   name: Zekrom
@@ -260,7 +261,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Aya Kusube
-- id: FILL_THIS-11
+- id: 439-11
   pioId: cel25-11
   enumId: MEW_11
   name: Mew
@@ -288,7 +289,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Yuu Nishida
-- id: FILL_THIS-12
+- id: 439-12
   pioId: cel25-12
   enumId: XERNEAS_12
   name: Xerneas
@@ -311,7 +312,7 @@ cards:
     value: x2
   rarity: Rare
   artist: AKIRA EGAWA
-- id: FILL_THIS-13
+- id: 439-13
   pioId: cel25-13
   enumId: COSMOG_13
   name: Cosmog
@@ -335,7 +336,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: kirisAki
-- id: FILL_THIS-14
+- id: 439-14
   pioId: cel25-14
   enumId: COSMOEM_14
   name: Cosmoem
@@ -360,7 +361,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: kirisAki
-- id: FILL_THIS-15
+- id: 439-15
   pioId: cel25-15
   enumId: LUNALA_15
   name: Lunala
@@ -388,7 +389,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: kirisAki
-- id: FILL_THIS-16
+- id: 439-16
   pioId: cel25-16
   enumId: ZACIAN_V_16
   name: Zacian V
@@ -416,7 +417,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Mitsuhiro Arita
-- id: FILL_THIS-17
+- id: 439-17
   pioId: cel25-17
   enumId: GROUDON_17
   name: Groudon
@@ -440,7 +441,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Ryuta Fuse
-- id: FILL_THIS-18
+- id: 439-18
   pioId: cel25-18
   enumId: ZAMAZENTA_V_18
   name: Zamazenta V
@@ -467,7 +468,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Mitsuhiro Arita
-- id: FILL_THIS-19
+- id: 439-19
   pioId: cel25-19
   enumId: YVELTAL_19
   name: Yveltal
@@ -492,7 +493,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: AKIRA EGAWA
-- id: FILL_THIS-20
+- id: 439-20
   pioId: cel25-20
   enumId: DIALGA_20
   name: Dialga
@@ -518,7 +519,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: 5ban Graphics
-- id: FILL_THIS-21
+- id: 439-21
   pioId: cel25-21
   enumId: SOLGALEO_21
   name: Solgaleo
@@ -548,7 +549,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: kirisAki
-- id: FILL_THIS-22
+- id: 439-22
   pioId: cel25-22
   enumId: LUGIA_22
   name: Lugia
@@ -575,7 +576,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Kouki Saitou
-- id: FILL_THIS-23
+- id: 439-23
   pioId: cel25-23
   enumId: PROFESSOR_S_RESEARCH_PROFESSOR_OAK__23
   name: Professor’s Research (Professor Oak)
@@ -586,7 +587,7 @@ cards:
   text:
   - Discard your hand and draw 7 cards.
   artist: KIYOTAKA OSHIYAMA
-- id: FILL_THIS-24
+- id: 439-24
   pioId: cel25-24
   enumId: PROFESSOR_S_RESEARCH_PROFESSOR_OAK__24
   name: Professor’s Research (Professor Oak)
@@ -597,9 +598,9 @@ cards:
   text:
   - Discard your hand and draw 7 cards.
   artist: Ken Sugimori
-  variantOf: FILL_THIS-23
+  variantOf: 430-178
   variantType: Full Art
-- id: FILL_THIS-25
+- id: 439-25
   pioId: cel25-25
   enumId: MEW_25
   name: Mew
@@ -627,5 +628,5 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Saki Hayashiro
-  variantOf: FILL_THIS-11
+  variantOf: 430-178
   variantType: Reprint

--- a/data/src/main/resources/cards/439-celebrations.yaml
+++ b/data/src/main/resources/cards/439-celebrations.yaml
@@ -1,6 +1,6 @@
 schema: E2
 id: '439'
-name: cel25
+name: Celebrations
 enumId: CELEBRATIONS
 abbr: CEL
 pioId: cel25

--- a/data/src/main/resources/cards/440-fusion_strike.yaml
+++ b/data/src/main/resources/cards/440-fusion_strike.yaml
@@ -1,10 +1,10 @@
-id: FILL_THIS
+id: '440'
 name: swsh8
-enumId: FILL_THIS
-abbr: FILL_THIS
+enumId: FUSION_STRIKE
+abbr: FST
 pioId: swsh8
 cards:
-- id: FILL_THIS-1
+- id: 440-1
   pioId: swsh8-1
   enumId: CATERPIE_1
   name: Caterpie
@@ -28,7 +28,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mitsuhiro Arita
-- id: FILL_THIS-2
+- id: 440-2
   pioId: swsh8-2
   enumId: METAPOD_2
   name: Metapod
@@ -54,7 +54,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Saya Tsuruta
-- id: FILL_THIS-3
+- id: 440-3
   pioId: swsh8-3
   enumId: BUTTERFREE_3
   name: Butterfree
@@ -80,7 +80,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: ryoma uratsuka
-- id: FILL_THIS-4
+- id: 440-4
   pioId: swsh8-4
   enumId: SHROOMISH_4
   name: Shroomish
@@ -103,7 +103,7 @@ cards:
     value: x2
   rarity: Common
   artist: Naoyo Kimura
-- id: FILL_THIS-5
+- id: 440-5
   pioId: swsh8-5
   enumId: BRELOOM_5
   name: Breloom
@@ -127,7 +127,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Yukiko Baba
-- id: FILL_THIS-6
+- id: 440-6
   pioId: swsh8-6
   enumId: BRELOOM_V_6
   name: Breloom V
@@ -153,7 +153,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Mochizuki
-- id: FILL_THIS-7
+- id: 440-7
   pioId: swsh8-7
   enumId: PANSAGE_7
   name: Pansage
@@ -173,7 +173,7 @@ cards:
     value: x2
   rarity: Common
   artist: Nagomi Nijo
-- id: FILL_THIS-8
+- id: 440-8
   pioId: swsh8-8
   enumId: SIMISAGE_8
   name: Simisage
@@ -197,7 +197,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Akira Komayama
-- id: FILL_THIS-9
+- id: 440-9
   pioId: swsh8-9
   enumId: SEWADDLE_9
   name: Sewaddle
@@ -218,7 +218,7 @@ cards:
     value: x2
   rarity: Common
   artist: Akira Komayama
-- id: FILL_THIS-10
+- id: 440-10
   pioId: swsh8-10
   enumId: SWADLOON_10
   name: Swadloon
@@ -243,7 +243,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: '0313'
-- id: FILL_THIS-11
+- id: 440-11
   pioId: swsh8-11
   enumId: LEAVANNY_11
   name: Leavanny
@@ -267,7 +267,7 @@ cards:
     value: x2
   rarity: Rare
   artist: kodama
-- id: FILL_THIS-12
+- id: 440-12
   pioId: swsh8-12
   enumId: MARACTUS_12
   name: Maractus
@@ -291,7 +291,7 @@ cards:
     value: x2
   rarity: Rare
   artist: '0313'
-- id: FILL_THIS-13
+- id: 440-13
   pioId: swsh8-13
   enumId: SHELMET_13
   name: Shelmet
@@ -311,7 +311,7 @@ cards:
     value: x2
   rarity: Common
   artist: Shibuzoh.
-- id: FILL_THIS-14
+- id: 440-14
   pioId: swsh8-14
   enumId: ACCELGOR_14
   name: Accelgor
@@ -333,7 +333,7 @@ cards:
     value: x2
   rarity: Rare
   artist: nagimiso
-- id: FILL_THIS-15
+- id: 440-15
   pioId: swsh8-15
   enumId: VIRIZION_15
   name: Virizion
@@ -355,7 +355,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Kagemaru Himeno
-- id: FILL_THIS-16
+- id: 440-16
   pioId: swsh8-16
   enumId: PHANTUMP_16
   name: Phantump
@@ -378,7 +378,7 @@ cards:
     value: x2
   rarity: Common
   artist: OKACHEKE
-- id: FILL_THIS-17
+- id: 440-17
   pioId: swsh8-17
   enumId: TREVENANT_17
   name: Trevenant
@@ -401,7 +401,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Narumi Sato
-- id: FILL_THIS-18
+- id: 440-18
   pioId: swsh8-18
   enumId: GRUBBIN_18
   name: Grubbin
@@ -425,7 +425,7 @@ cards:
     value: x2
   rarity: Common
   artist: Asako Ito
-- id: FILL_THIS-19
+- id: 440-19
   pioId: swsh8-19
   enumId: DEWPIDER_19
   name: Dewpider
@@ -445,7 +445,7 @@ cards:
     value: x2
   rarity: Common
   artist: Miki Tanaka
-- id: FILL_THIS-20
+- id: 440-20
   pioId: swsh8-20
   enumId: ARAQUANID_20
   name: Araquanid
@@ -469,7 +469,7 @@ cards:
     value: x2
   rarity: Rare
   artist: KIYOTAKA OSHIYAMA
-- id: FILL_THIS-21
+- id: 440-21
   pioId: swsh8-21
   enumId: TSAREENA_V_21
   name: Tsareena V
@@ -492,7 +492,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Mochizuki
-- id: FILL_THIS-22
+- id: 440-22
   pioId: swsh8-22
   enumId: RILLABOOM_V_22
   name: Rillaboom V
@@ -517,7 +517,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-23
+- id: 440-23
   pioId: swsh8-23
   enumId: RILLABOOM_VMAX_23
   name: Rillaboom VMAX
@@ -542,7 +542,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-24
+- id: 440-24
   pioId: swsh8-24
   enumId: GOSSIFLEUR_24
   name: Gossifleur
@@ -562,7 +562,7 @@ cards:
     value: x2
   rarity: Common
   artist: Kagemaru Himeno
-- id: FILL_THIS-25
+- id: 440-25
   pioId: swsh8-25
   enumId: ELDEGOSS_25
   name: Eldegoss
@@ -583,7 +583,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Akira Komayama
-- id: FILL_THIS-26
+- id: 440-26
   pioId: swsh8-26
   enumId: APPLETUN_V_26
   name: Appletun V
@@ -608,7 +608,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: aky CG Works
-- id: FILL_THIS-27
+- id: 440-27
   pioId: swsh8-27
   enumId: ZARUDE_27
   name: Zarude
@@ -631,7 +631,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Anesaki Dynamic
-- id: FILL_THIS-28
+- id: 440-28
   pioId: swsh8-28
   enumId: VULPIX_28
   name: Vulpix
@@ -651,7 +651,7 @@ cards:
     value: x2
   rarity: Common
   artist: Sekio
-- id: FILL_THIS-29
+- id: 440-29
   pioId: swsh8-29
   enumId: VULPIX_29
   name: Vulpix
@@ -671,7 +671,7 @@ cards:
     value: x2
   rarity: Common
   artist: Megumi Mizutani
-- id: FILL_THIS-30
+- id: 440-30
   pioId: swsh8-30
   enumId: NINETALES_30
   name: Ninetales
@@ -691,7 +691,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: kirisAki
-- id: FILL_THIS-31
+- id: 440-31
   pioId: swsh8-31
   enumId: NINETALES_31
   name: Ninetales
@@ -716,7 +716,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Tika Matsuno
-- id: FILL_THIS-32
+- id: 440-32
   pioId: swsh8-32
   enumId: GROWLITHE_32
   name: Growlithe
@@ -740,7 +740,7 @@ cards:
     value: x2
   rarity: Common
   artist: Narumi Sato
-- id: FILL_THIS-33
+- id: 440-33
   pioId: swsh8-33
   enumId: ARCANINE_33
   name: Arcanine
@@ -764,7 +764,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Yuu Nishida
-- id: FILL_THIS-34
+- id: 440-34
   pioId: swsh8-34
   enumId: SLUGMA_34
   name: Slugma
@@ -787,7 +787,7 @@ cards:
     value: x2
   rarity: Common
   artist: otumami
-- id: FILL_THIS-35
+- id: 440-35
   pioId: swsh8-35
   enumId: MAGCARGO_35
   name: Magcargo
@@ -811,7 +811,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Eri Yamaki
-- id: FILL_THIS-36
+- id: 440-36
   pioId: swsh8-36
   enumId: VICTINI_36
   name: Victini
@@ -833,7 +833,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Mitsuhiro Arita
-- id: FILL_THIS-37
+- id: 440-37
   pioId: swsh8-37
   enumId: PANSEAR_37
   name: Pansear
@@ -854,7 +854,7 @@ cards:
     value: x2
   rarity: Common
   artist: Misa Tsutsui
-- id: FILL_THIS-38
+- id: 440-38
   pioId: swsh8-38
   enumId: SIMISEAR_38
   name: Simisear
@@ -879,7 +879,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Tomokazu Komiya
-- id: FILL_THIS-39
+- id: 440-39
   pioId: swsh8-39
   enumId: CHANDELURE_V_39
   name: Chandelure V
@@ -905,7 +905,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Saki Hayashiro
-- id: FILL_THIS-40
+- id: 440-40
   pioId: swsh8-40
   enumId: CHANDELURE_VMAX_40
   name: Chandelure VMAX
@@ -935,7 +935,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: AKIRA EGAWA
-- id: FILL_THIS-41
+- id: 440-41
   pioId: swsh8-41
   enumId: HEATMOR_41
   name: Heatmor
@@ -961,7 +961,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Oswaldo KATO
-- id: FILL_THIS-42
+- id: 440-42
   pioId: swsh8-42
   enumId: ORICORIO_42
   name: Oricorio
@@ -986,7 +986,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Oswaldo KATO
-- id: FILL_THIS-43
+- id: 440-43
   pioId: swsh8-43
   enumId: CINDERACE_V_43
   name: Cinderace V
@@ -1008,7 +1008,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-44
+- id: 440-44
   pioId: swsh8-44
   enumId: CINDERACE_V_44
   name: Cinderace V
@@ -1033,7 +1033,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: aky CG Works
-- id: FILL_THIS-45
+- id: 440-45
   pioId: swsh8-45
   enumId: CINDERACE_VMAX_45
   name: Cinderace VMAX
@@ -1058,7 +1058,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-46
+- id: 440-46
   pioId: swsh8-46
   enumId: SIZZLIPEDE_46
   name: Sizzlipede
@@ -1081,7 +1081,7 @@ cards:
     value: x2
   rarity: Common
   artist: miki kudo
-- id: FILL_THIS-47
+- id: 440-47
   pioId: swsh8-47
   enumId: SIZZLIPEDE_47
   name: Sizzlipede
@@ -1101,7 +1101,7 @@ cards:
     value: x2
   rarity: Common
   artist: Narumi Sato
-- id: FILL_THIS-48
+- id: 440-48
   pioId: swsh8-48
   enumId: CENTISKORCH_48
   name: Centiskorch
@@ -1126,7 +1126,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Hasuno
-- id: FILL_THIS-49
+- id: 440-49
   pioId: swsh8-49
   enumId: CENTISKORCH_49
   name: Centiskorch
@@ -1149,7 +1149,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Misa Tsutsui
-- id: FILL_THIS-50
+- id: 440-50
   pioId: swsh8-50
   enumId: SHELLDER_50
   name: Shellder
@@ -1172,7 +1172,7 @@ cards:
     value: x2
   rarity: Common
   artist: kawayoo
-- id: FILL_THIS-51
+- id: 440-51
   pioId: swsh8-51
   enumId: CLOYSTER_51
   name: Cloyster
@@ -1199,7 +1199,7 @@ cards:
     value: x2
   rarity: Rare
   artist: nagimiso
-- id: FILL_THIS-52
+- id: 440-52
   pioId: swsh8-52
   enumId: STARYU_52
   name: Staryu
@@ -1222,7 +1222,7 @@ cards:
     value: x2
   rarity: Common
   artist: tetsuya koizumi
-- id: FILL_THIS-53
+- id: 440-53
   pioId: swsh8-53
   enumId: STARMIE_53
   name: Starmie
@@ -1245,7 +1245,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Megumi Mizutani
-- id: FILL_THIS-54
+- id: 440-54
   pioId: swsh8-54
   enumId: LAPRAS_54
   name: Lapras
@@ -1269,7 +1269,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Naoki Saito
-- id: FILL_THIS-55
+- id: 440-55
   pioId: swsh8-55
   enumId: TOTODILE_55
   name: Totodile
@@ -1289,7 +1289,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mizue
-- id: FILL_THIS-56
+- id: 440-56
   pioId: swsh8-56
   enumId: CROCONAW_56
   name: Croconaw
@@ -1313,7 +1313,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Tomokazu Komiya
-- id: FILL_THIS-57
+- id: 440-57
   pioId: swsh8-57
   enumId: FERALIGATR_57
   name: Feraligatr
@@ -1340,7 +1340,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Anesaki Dynamic
-- id: FILL_THIS-58
+- id: 440-58
   pioId: swsh8-58
   enumId: MARILL_58
   name: Marill
@@ -1366,7 +1366,7 @@ cards:
     value: x2
   rarity: Common
   artist: sowsow
-- id: FILL_THIS-59
+- id: 440-59
   pioId: swsh8-59
   enumId: AZUMARILL_59
   name: Azumarill
@@ -1390,7 +1390,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Sanosuke Sakuma
-- id: FILL_THIS-60
+- id: 440-60
   pioId: swsh8-60
   enumId: QWILFISH_60
   name: Qwilfish
@@ -1412,7 +1412,7 @@ cards:
     value: x2
   rarity: Common
   artist: HYOGONOSUKE
-- id: FILL_THIS-61
+- id: 440-61
   pioId: swsh8-61
   enumId: MANTINE_61
   name: Mantine
@@ -1435,7 +1435,7 @@ cards:
     value: x2
   rarity: Common
   artist: Saya Tsuruta
-- id: FILL_THIS-62
+- id: 440-62
   pioId: swsh8-62
   enumId: MUDKIP_62
   name: Mudkip
@@ -1458,7 +1458,7 @@ cards:
     value: x2
   rarity: Common
   artist: KIYOTAKA OSHIYAMA
-- id: FILL_THIS-63
+- id: 440-63
   pioId: swsh8-63
   enumId: MARSHTOMP_63
   name: Marshtomp
@@ -1483,7 +1483,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: tetsuya koizumi
-- id: FILL_THIS-64
+- id: 440-64
   pioId: swsh8-64
   enumId: SWAMPERT_64
   name: Swampert
@@ -1510,7 +1510,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Masakazu Fukuda
-- id: FILL_THIS-65
+- id: 440-65
   pioId: swsh8-65
   enumId: CLAMPERL_65
   name: Clamperl
@@ -1530,7 +1530,7 @@ cards:
     value: x2
   rarity: Common
   artist: Anesaki Dynamic
-- id: FILL_THIS-66
+- id: 440-66
   pioId: swsh8-66
   enumId: HUNTAIL_66
   name: Huntail
@@ -1554,7 +1554,7 @@ cards:
     value: x2
   rarity: Rare
   artist: otumami
-- id: FILL_THIS-67
+- id: 440-67
   pioId: swsh8-67
   enumId: GOREBYSS_67
   name: Gorebyss
@@ -1579,7 +1579,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Misa Tsutsui
-- id: FILL_THIS-68
+- id: 440-68
   pioId: swsh8-68
   enumId: PANPOUR_68
   name: Panpour
@@ -1600,7 +1600,7 @@ cards:
     value: x2
   rarity: Common
   artist: Sekio
-- id: FILL_THIS-69
+- id: 440-69
   pioId: swsh8-69
   enumId: SIMIPOUR_69
   name: Simipour
@@ -1626,7 +1626,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Shin Nagasawa
-- id: FILL_THIS-70
+- id: 440-70
   pioId: swsh8-70
   enumId: BASCULIN_70
   name: Basculin
@@ -1647,7 +1647,7 @@ cards:
     value: x2
   rarity: Common
   artist: Souichirou Gunjima
-- id: FILL_THIS-71
+- id: 440-71
   pioId: swsh8-71
   enumId: GALARIAN_DARUMAKA_71
   name: Galarian Darumaka
@@ -1668,7 +1668,7 @@ cards:
     value: x2
   rarity: Common
   artist: Atsuko Nishida
-- id: FILL_THIS-72
+- id: 440-72
   pioId: swsh8-72
   enumId: GALARIAN_DARMANITAN_72
   name: Galarian Darmanitan
@@ -1694,7 +1694,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: SATOSHI NAKAI
-- id: FILL_THIS-73
+- id: 440-73
   pioId: swsh8-73
   enumId: GRENINJA_V_73
   name: Greninja V
@@ -1719,7 +1719,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-74
+- id: 440-74
   pioId: swsh8-74
   enumId: CLAUNCHER_74
   name: Clauncher
@@ -1742,7 +1742,7 @@ cards:
     value: x2
   rarity: Common
   artist: Pani Kobayashi
-- id: FILL_THIS-75
+- id: 440-75
   pioId: swsh8-75
   enumId: CLAWITZER_75
   name: Clawitzer
@@ -1766,7 +1766,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: tetsuya koizumi
-- id: FILL_THIS-76
+- id: 440-76
   pioId: swsh8-76
   enumId: CRABOMINABLE_V_76
   name: Crabominable V
@@ -1792,7 +1792,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: MUGENUP
-- id: FILL_THIS-77
+- id: 440-77
   pioId: swsh8-77
   enumId: PYUKUMUKU_77
   name: Pyukumuku
@@ -1817,7 +1817,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Tomokazu Komiya
-- id: FILL_THIS-78
+- id: 440-78
   pioId: swsh8-78
   enumId: INTELEON_V_78
   name: Inteleon V
@@ -1843,7 +1843,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-79
+- id: 440-79
   pioId: swsh8-79
   enumId: INTELEON_VMAX_79
   name: Inteleon VMAX
@@ -1874,7 +1874,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-80
+- id: 440-80
   pioId: swsh8-80
   enumId: CHEWTLE_80
   name: Chewtle
@@ -1894,7 +1894,7 @@ cards:
     value: x2
   rarity: Common
   artist: Saya Tsuruta
-- id: FILL_THIS-81
+- id: 440-81
   pioId: swsh8-81
   enumId: DREDNAW_81
   name: Drednaw
@@ -1915,7 +1915,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: kodama
-- id: FILL_THIS-82
+- id: 440-82
   pioId: swsh8-82
   enumId: ARROKUDA_82
   name: Arrokuda
@@ -1935,7 +1935,7 @@ cards:
     value: x2
   rarity: Common
   artist: Miki Tanaka
-- id: FILL_THIS-83
+- id: 440-83
   pioId: swsh8-83
   enumId: BARRASKEWDA_83
   name: Barraskewda
@@ -1955,7 +1955,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Hideki Ishikawa
-- id: FILL_THIS-84
+- id: 440-84
   pioId: swsh8-84
   enumId: SNOM_84
   name: Snom
@@ -1976,7 +1976,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yuka Morii
-- id: FILL_THIS-85
+- id: 440-85
   pioId: swsh8-85
   enumId: FROSMOTH_85
   name: Frosmoth
@@ -2000,7 +2000,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: chibi
-- id: FILL_THIS-86
+- id: 440-86
   pioId: swsh8-86
   enumId: PIKACHU_V_86
   name: Pikachu V
@@ -2025,7 +2025,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-87
+- id: 440-87
   pioId: swsh8-87
   enumId: VOLTORB_87
   name: Voltorb
@@ -2046,7 +2046,7 @@ cards:
     value: x2
   rarity: Common
   artist: Tomokazu Komiya
-- id: FILL_THIS-88
+- id: 440-88
   pioId: swsh8-88
   enumId: ELECTRODE_88
   name: Electrode
@@ -2071,7 +2071,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Kouki Saitou
-- id: FILL_THIS-89
+- id: 440-89
   pioId: swsh8-89
   enumId: PLUSLE_89
   name: Plusle
@@ -2092,7 +2092,7 @@ cards:
     value: x2
   rarity: Common
   artist: Megumi Higuchi
-- id: FILL_THIS-90
+- id: 440-90
   pioId: swsh8-90
   enumId: MINUN_90
   name: Minun
@@ -2115,7 +2115,7 @@ cards:
     value: x2
   rarity: Common
   artist: HYOGONOSUKE
-- id: FILL_THIS-91
+- id: 440-91
   pioId: swsh8-91
   enumId: SHINX_91
   name: Shinx
@@ -2138,7 +2138,7 @@ cards:
     value: x2
   rarity: Common
   artist: Naoyo Kimura
-- id: FILL_THIS-92
+- id: 440-92
   pioId: swsh8-92
   enumId: LUXIO_92
   name: Luxio
@@ -2159,7 +2159,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Tika Matsuno
-- id: FILL_THIS-93
+- id: 440-93
   pioId: swsh8-93
   enumId: LUXRAY_93
   name: Luxray
@@ -2178,7 +2178,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Atsushi Furusawa
-- id: FILL_THIS-94
+- id: 440-94
   pioId: swsh8-94
   enumId: ROTOM_94
   name: Rotom
@@ -2200,7 +2200,7 @@ cards:
     value: x2
   rarity: Common
   artist: Sekio
-- id: FILL_THIS-95
+- id: 440-95
   pioId: swsh8-95
   enumId: TYNAMO_95
   name: Tynamo
@@ -2223,7 +2223,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yuka Morii
-- id: FILL_THIS-96
+- id: 440-96
   pioId: swsh8-96
   enumId: EELEKTRIK_96
   name: Eelektrik
@@ -2248,7 +2248,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Shigenori Negishi
-- id: FILL_THIS-97
+- id: 440-97
   pioId: swsh8-97
   enumId: EELEKTROSS_97
   name: Eelektross
@@ -2274,7 +2274,7 @@ cards:
     value: x2
   rarity: Rare
   artist: OKACHEKE
-- id: FILL_THIS-98
+- id: 440-98
   pioId: swsh8-98
   enumId: HELIOPTILE_98
   name: Helioptile
@@ -2297,7 +2297,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mina Nakai
-- id: FILL_THIS-99
+- id: 440-99
   pioId: swsh8-99
   enumId: HELIOLISK_99
   name: Heliolisk
@@ -2322,7 +2322,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Kagemaru Himeno
-- id: FILL_THIS-100
+- id: 440-100
   pioId: swsh8-100
   enumId: CHARJABUG_100
   name: Charjabug
@@ -2346,7 +2346,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: sowsow
-- id: FILL_THIS-101
+- id: 440-101
   pioId: swsh8-101
   enumId: VIKAVOLT_101
   name: Vikavolt
@@ -2370,7 +2370,7 @@ cards:
     value: x2
   rarity: Rare
   artist: nagimiso
-- id: FILL_THIS-102
+- id: 440-102
   pioId: swsh8-102
   enumId: ZERAORA_102
   name: Zeraora
@@ -2390,7 +2390,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Teeziro
-- id: FILL_THIS-103
+- id: 440-103
   pioId: swsh8-103
   enumId: BOLTUND_V_103
   name: Boltund V
@@ -2417,7 +2417,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Shin Nagasawa
-- id: FILL_THIS-104
+- id: 440-104
   pioId: swsh8-104
   enumId: BOLTUND_VMAX_104
   name: Boltund VMAX
@@ -2446,7 +2446,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: PLANETA Tsuji
-- id: FILL_THIS-105
+- id: 440-105
   pioId: swsh8-105
   enumId: TOXEL_105
   name: Toxel
@@ -2466,7 +2466,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mina Nakai
-- id: FILL_THIS-106
+- id: 440-106
   pioId: swsh8-106
   enumId: TOXEL_106
   name: Toxel
@@ -2490,7 +2490,7 @@ cards:
     value: x2
   rarity: Common
   artist: kodama
-- id: FILL_THIS-107
+- id: 440-107
   pioId: swsh8-107
   enumId: TOXTRICITY_107
   name: Toxtricity
@@ -2512,7 +2512,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Ryuta Fuse
-- id: FILL_THIS-108
+- id: 440-108
   pioId: swsh8-108
   enumId: TOXTRICITY_108
   name: Toxtricity
@@ -2537,7 +2537,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: nagimiso
-- id: FILL_THIS-109
+- id: 440-109
   pioId: swsh8-109
   enumId: MORPEKO_109
   name: Morpeko
@@ -2557,7 +2557,7 @@ cards:
     value: x2
   rarity: Common
   artist: Sanosuke Sakuma
-- id: FILL_THIS-110
+- id: 440-110
   pioId: swsh8-110
   enumId: JIGGLYPUFF_110
   name: Jigglypuff
@@ -2582,7 +2582,7 @@ cards:
     value: x2
   rarity: Common
   artist: Saya Tsuruta
-- id: FILL_THIS-111
+- id: 440-111
   pioId: swsh8-111
   enumId: WIGGLYTUFF_111
   name: Wigglytuff
@@ -2606,7 +2606,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Asako Ito
-- id: FILL_THIS-112
+- id: 440-112
   pioId: swsh8-112
   enumId: JYNX_112
   name: Jynx
@@ -2632,7 +2632,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Shigenori Negishi
-- id: FILL_THIS-113
+- id: 440-113
   pioId: swsh8-113
   enumId: MEW_V_113
   name: Mew V
@@ -2660,7 +2660,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Mitsuhiro Arita
-- id: FILL_THIS-114
+- id: 440-114
   pioId: swsh8-114
   enumId: MEW_VMAX_114
   name: Mew VMAX
@@ -2691,7 +2691,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-115
+- id: 440-115
   pioId: swsh8-115
   enumId: SNUBBULL_115
   name: Snubbull
@@ -2714,7 +2714,7 @@ cards:
     value: x2
   rarity: Common
   artist: Kyoko Umemoto
-- id: FILL_THIS-116
+- id: 440-116
   pioId: swsh8-116
   enumId: GRANBULL_116
   name: Granbull
@@ -2740,7 +2740,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Akira Komayama
-- id: FILL_THIS-117
+- id: 440-117
   pioId: swsh8-117
   enumId: GALARIAN_CORSOLA_117
   name: Galarian Corsola
@@ -2763,7 +2763,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Kouki Saitou
-- id: FILL_THIS-118
+- id: 440-118
   pioId: swsh8-118
   enumId: GALARIAN_CURSOLA_118
   name: Galarian Cursola
@@ -2790,7 +2790,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Misa Tsutsui
-- id: FILL_THIS-119
+- id: 440-119
   pioId: swsh8-119
   enumId: MAWILE_119
   name: Mawile
@@ -2811,7 +2811,7 @@ cards:
     value: x2
   rarity: Common
   artist: Kouki Saitou
-- id: FILL_THIS-120
+- id: 440-120
   pioId: swsh8-120
   enumId: DEOXYS_120
   name: Deoxys
@@ -2835,7 +2835,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Kouki Saitou
-- id: FILL_THIS-121
+- id: 440-121
   pioId: swsh8-121
   enumId: MUNNA_121
   name: Munna
@@ -2858,7 +2858,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: miki kudo
-- id: FILL_THIS-122
+- id: 440-122
   pioId: swsh8-122
   enumId: MUSHARNA_122
   name: Musharna
@@ -2887,7 +2887,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Tika Matsuno
-- id: FILL_THIS-123
+- id: 440-123
   pioId: swsh8-123
   enumId: SIGILYPH_123
   name: Sigilyph
@@ -2915,7 +2915,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Yukiko Baba
-- id: FILL_THIS-124
+- id: 440-124
   pioId: swsh8-124
   enumId: MELOETTA_124
   name: Meloetta
@@ -2939,7 +2939,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: kirisAki
-- id: FILL_THIS-125
+- id: 440-125
   pioId: swsh8-125
   enumId: SANDYGAST_125
   name: Sandygast
@@ -2965,7 +2965,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: KIYOTAKA OSHIYAMA
-- id: FILL_THIS-126
+- id: 440-126
   pioId: swsh8-126
   enumId: PALOSSAND_126
   name: Palossand
@@ -2991,7 +2991,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Shibuzoh.
-- id: FILL_THIS-127
+- id: 440-127
   pioId: swsh8-127
   enumId: INDEEDEE_127
   name: Indeedee
@@ -3017,7 +3017,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Misa Tsutsui
-- id: FILL_THIS-128
+- id: 440-128
   pioId: swsh8-128
   enumId: DREEPY_128
   name: Dreepy
@@ -3041,7 +3041,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Teeziro
-- id: FILL_THIS-129
+- id: 440-129
   pioId: swsh8-129
   enumId: DRAKLOAK_129
   name: Drakloak
@@ -3069,7 +3069,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: HYOGONOSUKE
-- id: FILL_THIS-130
+- id: 440-130
   pioId: swsh8-130
   enumId: DRAGAPULT_130
   name: Dragapult
@@ -3095,7 +3095,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Souichirou Gunjima
-- id: FILL_THIS-131
+- id: 440-131
   pioId: swsh8-131
   enumId: SANDSHREW_131
   name: Sandshrew
@@ -3120,7 +3120,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yuka Morii
-- id: FILL_THIS-132
+- id: 440-132
   pioId: swsh8-132
   enumId: SANDSLASH_132
   name: Sandslash
@@ -3141,7 +3141,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Kyoko Umemoto
-- id: FILL_THIS-133
+- id: 440-133
   pioId: swsh8-133
   enumId: MANKEY_133
   name: Mankey
@@ -3161,7 +3161,7 @@ cards:
     value: x2
   rarity: Common
   artist: sowsow
-- id: FILL_THIS-134
+- id: 440-134
   pioId: swsh8-134
   enumId: PRIMEAPE_134
   name: Primeape
@@ -3183,7 +3183,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Yuya Oka
-- id: FILL_THIS-135
+- id: 440-135
   pioId: swsh8-135
   enumId: GEODUDE_135
   name: Geodude
@@ -3206,7 +3206,7 @@ cards:
     value: x2
   rarity: Common
   artist: OKACHEKE
-- id: FILL_THIS-136
+- id: 440-136
   pioId: swsh8-136
   enumId: GRAVELER_136
   name: Graveler
@@ -3230,7 +3230,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Masakazu Fukuda
-- id: FILL_THIS-137
+- id: 440-137
   pioId: swsh8-137
   enumId: GOLEM_137
   name: Golem
@@ -3257,7 +3257,7 @@ cards:
     value: x2
   rarity: Rare
   artist: KEIICHIRO ITO
-- id: FILL_THIS-138
+- id: 440-138
   pioId: swsh8-138
   enumId: ONIX_138
   name: Onix
@@ -3282,7 +3282,7 @@ cards:
     value: x2
   rarity: Common
   artist: KEIICHIRO ITO
-- id: FILL_THIS-139
+- id: 440-139
   pioId: swsh8-139
   enumId: STEELIX_139
   name: Steelix
@@ -3308,7 +3308,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Ryuta Fuse
-- id: FILL_THIS-140
+- id: 440-140
   pioId: swsh8-140
   enumId: GLIGAR_140
   name: Gligar
@@ -3331,7 +3331,7 @@ cards:
     value: x2
   rarity: Common
   artist: Misa Tsutsui
-- id: FILL_THIS-141
+- id: 440-141
   pioId: swsh8-141
   enumId: GLISCOR_141
   name: Gliscor
@@ -3356,7 +3356,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: SATOSHI NAKAI
-- id: FILL_THIS-142
+- id: 440-142
   pioId: swsh8-142
   enumId: MAKUHITA_142
   name: Makuhita
@@ -3379,7 +3379,7 @@ cards:
     value: x2
   rarity: Common
   artist: Oswaldo KATO
-- id: FILL_THIS-143
+- id: 440-143
   pioId: swsh8-143
   enumId: HARIYAMA_143
   name: Hariyama
@@ -3404,7 +3404,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Hitoshi Ariga
-- id: FILL_THIS-144
+- id: 440-144
   pioId: swsh8-144
   enumId: BALTOY_144
   name: Baltoy
@@ -3424,7 +3424,7 @@ cards:
     value: x2
   rarity: Common
   artist: Sumiyoshi Kizuki
-- id: FILL_THIS-145
+- id: 440-145
   pioId: swsh8-145
   enumId: CLAYDOL_145
   name: Claydol
@@ -3450,7 +3450,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Akira Komayama
-- id: FILL_THIS-146
+- id: 440-146
   pioId: swsh8-146
   enumId: LUCARIO_V_146
   name: Lucario V
@@ -3471,7 +3471,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: aky CG Works
-- id: FILL_THIS-147
+- id: 440-147
   pioId: swsh8-147
   enumId: DRILBUR_147
   name: Drilbur
@@ -3491,7 +3491,7 @@ cards:
     value: x2
   rarity: Common
   artist: tetsuya koizumi
-- id: FILL_THIS-148
+- id: 440-148
   pioId: swsh8-148
   enumId: LANDORUS_148
   name: Landorus
@@ -3516,7 +3516,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: NC Empire
-- id: FILL_THIS-149
+- id: 440-149
   pioId: swsh8-149
   enumId: PANCHAM_149
   name: Pancham
@@ -3540,7 +3540,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mina Nakai
-- id: FILL_THIS-150
+- id: 440-150
   pioId: swsh8-150
   enumId: STUFFUL_150
   name: Stufful
@@ -3563,7 +3563,7 @@ cards:
     value: x2
   rarity: Common
   artist: OKACHEKE
-- id: FILL_THIS-151
+- id: 440-151
   pioId: swsh8-151
   enumId: BEWEAR_151
   name: Bewear
@@ -3587,7 +3587,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Shigenori Negishi
-- id: FILL_THIS-152
+- id: 440-152
   pioId: swsh8-152
   enumId: CLOBBOPUS_152
   name: Clobbopus
@@ -3610,7 +3610,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mizue
-- id: FILL_THIS-153
+- id: 440-153
   pioId: swsh8-153
   enumId: GRAPPLOCT_153
   name: Grapploct
@@ -3633,7 +3633,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Souichirou Gunjima
-- id: FILL_THIS-154
+- id: 440-154
   pioId: swsh8-154
   enumId: FALINKS_154
   name: Falinks
@@ -3657,7 +3657,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Akira Komayama
-- id: FILL_THIS-155
+- id: 440-155
   pioId: swsh8-155
   enumId: FALINKS_155
   name: Falinks
@@ -3676,7 +3676,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yuu Nishida
-- id: FILL_THIS-156
+- id: 440-156
   pioId: swsh8-156
   enumId: GENGAR_V_156
   name: Gengar V
@@ -3702,7 +3702,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-157
+- id: 440-157
   pioId: swsh8-157
   enumId: GENGAR_VMAX_157
   name: Gengar VMAX
@@ -3731,7 +3731,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-158
+- id: 440-158
   pioId: swsh8-158
   enumId: TYRANITAR_V_158
   name: Tyranitar V
@@ -3755,7 +3755,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-159
+- id: 440-159
   pioId: swsh8-159
   enumId: GALARIAN_ZIGZAGOON_159
   name: Galarian Zigzagoon
@@ -3776,7 +3776,7 @@ cards:
     value: x2
   rarity: Common
   artist: Eri Yamaki
-- id: FILL_THIS-160
+- id: 440-160
   pioId: swsh8-160
   enumId: GALARIAN_LINOONE_160
   name: Galarian Linoone
@@ -3796,7 +3796,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: sowsow
-- id: FILL_THIS-161
+- id: 440-161
   pioId: swsh8-161
   enumId: GALARIAN_OBSTAGOON_161
   name: Galarian Obstagoon
@@ -3823,7 +3823,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: kodama
-- id: FILL_THIS-162
+- id: 440-162
   pioId: swsh8-162
   enumId: CARVANHA_162
   name: Carvanha
@@ -3843,7 +3843,7 @@ cards:
     value: x2
   rarity: Common
   artist: NC Empire
-- id: FILL_THIS-163
+- id: 440-163
   pioId: swsh8-163
   enumId: SHARPEDO_163
   name: Sharpedo
@@ -3863,7 +3863,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Hasuno
-- id: FILL_THIS-164
+- id: 440-164
   pioId: swsh8-164
   enumId: ABSOL_164
   name: Absol
@@ -3886,7 +3886,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Eri Yamaki
-- id: FILL_THIS-165
+- id: 440-165
   pioId: swsh8-165
   enumId: CROAGUNK_165
   name: Croagunk
@@ -3906,7 +3906,7 @@ cards:
     value: x2
   rarity: Common
   artist: Nagomi Nijo
-- id: FILL_THIS-166
+- id: 440-166
   pioId: swsh8-166
   enumId: TOXICROAK_166
   name: Toxicroak
@@ -3930,7 +3930,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Masakazu Fukuda
-- id: FILL_THIS-167
+- id: 440-167
   pioId: swsh8-167
   enumId: DARKRAI_167
   name: Darkrai
@@ -3949,7 +3949,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Megumi Mizutani
-- id: FILL_THIS-168
+- id: 440-168
   pioId: swsh8-168
   enumId: TRUBBISH_168
   name: Trubbish
@@ -3974,7 +3974,7 @@ cards:
     value: x2
   rarity: Common
   artist: Shibuzoh.
-- id: FILL_THIS-169
+- id: 440-169
   pioId: swsh8-169
   enumId: GARBODOR_169
   name: Garbodor
@@ -3998,7 +3998,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Misa Tsutsui
-- id: FILL_THIS-170
+- id: 440-170
   pioId: swsh8-170
   enumId: ZORUA_170
   name: Zorua
@@ -4021,7 +4021,7 @@ cards:
     value: x2
   rarity: Common
   artist: nagimiso
-- id: FILL_THIS-171
+- id: 440-171
   pioId: swsh8-171
   enumId: ZOROARK_171
   name: Zoroark
@@ -4045,7 +4045,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Kouki Saitou
-- id: FILL_THIS-172
+- id: 440-172
   pioId: swsh8-172
   enumId: VULLABY_172
   name: Vullaby
@@ -4072,7 +4072,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Shigenori Negishi
-- id: FILL_THIS-173
+- id: 440-173
   pioId: swsh8-173
   enumId: MANDIBUZZ_173
   name: Mandibuzz
@@ -4100,7 +4100,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Narumi Sato
-- id: FILL_THIS-174
+- id: 440-174
   pioId: swsh8-174
   enumId: PANGORO_174
   name: Pangoro
@@ -4125,7 +4125,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: HYOGONOSUKE
-- id: FILL_THIS-175
+- id: 440-175
   pioId: swsh8-175
   enumId: YVELTAL_175
   name: Yveltal
@@ -4150,7 +4150,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: kawayoo
-- id: FILL_THIS-176
+- id: 440-176
   pioId: swsh8-176
   enumId: IMPIDIMP_176
   name: Impidimp
@@ -4171,7 +4171,7 @@ cards:
     value: x2
   rarity: Common
   artist: sowsow
-- id: FILL_THIS-177
+- id: 440-177
   pioId: swsh8-177
   enumId: MORGREM_177
   name: Morgrem
@@ -4196,7 +4196,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: tetsuya koizumi
-- id: FILL_THIS-178
+- id: 440-178
   pioId: swsh8-178
   enumId: GRIMMSNARL_178
   name: Grimmsnarl
@@ -4220,7 +4220,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: kawayoo
-- id: FILL_THIS-179
+- id: 440-179
   pioId: swsh8-179
   enumId: MORPEKO_179
   name: Morpeko
@@ -4240,7 +4240,7 @@ cards:
     value: x2
   rarity: Common
   artist: Teeziro
-- id: FILL_THIS-180
+- id: 440-180
   pioId: swsh8-180
   enumId: GALARIAN_MEOWTH_180
   name: Galarian Meowth
@@ -4267,7 +4267,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: '0313'
-- id: FILL_THIS-181
+- id: 440-181
   pioId: swsh8-181
   enumId: GALARIAN_PERRSERKER_181
   name: Galarian Perrserker
@@ -4294,7 +4294,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Shigenori Negishi
-- id: FILL_THIS-182
+- id: 440-182
   pioId: swsh8-182
   enumId: SKARMORY_182
   name: Skarmory
@@ -4321,7 +4321,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Megumi Higuchi
-- id: FILL_THIS-183
+- id: 440-183
   pioId: swsh8-183
   enumId: EXCADRILL_183
   name: Excadrill
@@ -4348,7 +4348,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Lee HyunJung
-- id: FILL_THIS-184
+- id: 440-184
   pioId: swsh8-184
   enumId: DURANT_184
   name: Durant
@@ -4371,7 +4371,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Shin Nagasawa
-- id: FILL_THIS-185
+- id: 440-185
   pioId: swsh8-185
   enumId: GENESECT_V_185
   name: Genesect V
@@ -4401,7 +4401,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Tsuji
-- id: FILL_THIS-186
+- id: 440-186
   pioId: swsh8-186
   enumId: KLEFKI_186
   name: Klefki
@@ -4424,7 +4424,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: MAHOU
-- id: FILL_THIS-187
+- id: 440-187
   pioId: swsh8-187
   enumId: TOGEDEMARU_187
   name: Togedemaru
@@ -4451,7 +4451,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Oswaldo KATO
-- id: FILL_THIS-188
+- id: 440-188
   pioId: swsh8-188
   enumId: MELTAN_188
   name: Meltan
@@ -4477,7 +4477,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Teeziro
-- id: FILL_THIS-189
+- id: 440-189
   pioId: swsh8-189
   enumId: MELMETAL_189
   name: Melmetal
@@ -4506,7 +4506,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Hasuno
-- id: FILL_THIS-190
+- id: 440-190
   pioId: swsh8-190
   enumId: CORVIKNIGHT_190
   name: Corviknight
@@ -4535,7 +4535,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Ryuta Fuse
-- id: FILL_THIS-191
+- id: 440-191
   pioId: swsh8-191
   enumId: CUFANT_191
   name: Cufant
@@ -4562,7 +4562,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Oswaldo KATO
-- id: FILL_THIS-192
+- id: 440-192
   pioId: swsh8-192
   enumId: COPPERAJAH_192
   name: Copperajah
@@ -4589,7 +4589,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: KEIICHIRO ITO
-- id: FILL_THIS-193
+- id: 440-193
   pioId: swsh8-193
   enumId: LATIAS_193
   name: Latias
@@ -4612,7 +4612,7 @@ cards:
       by attacks from Pokémon VMAX.
   rarity: Rare
   artist: Yuu Nishida
-- id: FILL_THIS-194
+- id: 440-194
   pioId: swsh8-194
   enumId: LATIOS_194
   name: Latios
@@ -4634,7 +4634,7 @@ cards:
     text: Discard 2 Energy from this Pokémon.
   rarity: Rare
   artist: hatachu
-- id: FILL_THIS-195
+- id: 440-195
   pioId: swsh8-195
   enumId: GOOMY_195
   name: Goomy
@@ -4654,7 +4654,7 @@ cards:
     damage: '20'
   rarity: Common
   artist: Miki Tanaka
-- id: FILL_THIS-196
+- id: 440-196
   pioId: swsh8-196
   enumId: SLIGGOO_196
   name: Sliggoo
@@ -4676,7 +4676,7 @@ cards:
     text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
   rarity: Uncommon
   artist: Saya Tsuruta
-- id: FILL_THIS-197
+- id: 440-197
   pioId: swsh8-197
   enumId: GOODRA_197
   name: Goodra
@@ -4700,7 +4700,7 @@ cards:
     damage: '120'
   rarity: Rare
   artist: Nagomi Nijo
-- id: FILL_THIS-198
+- id: 440-198
   pioId: swsh8-198
   enumId: TURTONATOR_198
   name: Turtonator
@@ -4721,7 +4721,7 @@ cards:
     damage: '80'
   rarity: Uncommon
   artist: Ryuta Fuse
-- id: FILL_THIS-199
+- id: 440-199
   pioId: swsh8-199
   enumId: MEOWTH_199
   name: Meowth
@@ -4742,7 +4742,7 @@ cards:
     value: x2
   rarity: Common
   artist: Kouki Saitou
-- id: FILL_THIS-200
+- id: 440-200
   pioId: swsh8-200
   enumId: PERSIAN_200
   name: Persian
@@ -4766,7 +4766,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Lee HyunJung
-- id: FILL_THIS-201
+- id: 440-201
   pioId: swsh8-201
   enumId: DODRIO_V_201
   name: Dodrio V
@@ -4796,7 +4796,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-202
+- id: 440-202
   pioId: swsh8-202
   enumId: CHANSEY_202
   name: Chansey
@@ -4820,7 +4820,7 @@ cards:
     value: x2
   rarity: Common
   artist: miki kudo
-- id: FILL_THIS-203
+- id: 440-203
   pioId: swsh8-203
   enumId: BLISSEY_203
   name: Blissey
@@ -4847,7 +4847,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Mizue
-- id: FILL_THIS-204
+- id: 440-204
   pioId: swsh8-204
   enumId: KANGASKHAN_204
   name: Kangaskhan
@@ -4870,7 +4870,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Souichirou Gunjima
-- id: FILL_THIS-205
+- id: 440-205
   pioId: swsh8-205
   enumId: EEVEE_205
   name: Eevee
@@ -4891,7 +4891,7 @@ cards:
     value: x2
   rarity: Common
   artist: '0313'
-- id: FILL_THIS-206
+- id: 440-206
   pioId: swsh8-206
   enumId: SNORLAX_206
   name: Snorlax
@@ -4910,7 +4910,7 @@ cards:
     value: x2
   rarity: Common
   artist: Oswaldo KATO
-- id: FILL_THIS-207
+- id: 440-207
   pioId: swsh8-207
   enumId: DUNSPARCE_207
   name: Dunsparce
@@ -4933,7 +4933,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: ryoma uratsuka
-- id: FILL_THIS-208
+- id: 440-208
   pioId: swsh8-208
   enumId: STANTLER_208
   name: Stantler
@@ -4957,7 +4957,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Shibuzoh.
-- id: FILL_THIS-209
+- id: 440-209
   pioId: swsh8-209
   enumId: SMEARGLE_209
   name: Smeargle
@@ -4980,7 +4980,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mitsuhiro Arita
-- id: FILL_THIS-210
+- id: 440-210
   pioId: swsh8-210
   enumId: SKITTY_210
   name: Skitty
@@ -5001,7 +5001,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yukiko Baba
-- id: FILL_THIS-211
+- id: 440-211
   pioId: swsh8-211
   enumId: DELCATTY_211
   name: Delcatty
@@ -5026,7 +5026,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: kirisAki
-- id: FILL_THIS-212
+- id: 440-212
   pioId: swsh8-212
   enumId: BUNEARY_212
   name: Buneary
@@ -5047,7 +5047,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yuu Nishida
-- id: FILL_THIS-213
+- id: 440-213
   pioId: swsh8-213
   enumId: LOPUNNY_213
   name: Lopunny
@@ -5067,7 +5067,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: AKIRA EGAWA
-- id: FILL_THIS-214
+- id: 440-214
   pioId: swsh8-214
   enumId: BUNNELBY_214
   name: Bunnelby
@@ -5092,7 +5092,7 @@ cards:
     value: x2
   rarity: Common
   artist: Misa Tsutsui
-- id: FILL_THIS-215
+- id: 440-215
   pioId: swsh8-215
   enumId: DIGGERSBY_215
   name: Diggersby
@@ -5116,7 +5116,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: MAHOU
-- id: FILL_THIS-216
+- id: 440-216
   pioId: swsh8-216
   enumId: HAWLUCHA_216
   name: Hawlucha
@@ -5139,7 +5139,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Taira Akitsu
-- id: FILL_THIS-217
+- id: 440-217
   pioId: swsh8-217
   enumId: GREEDENT_V_217
   name: Greedent V
@@ -5165,7 +5165,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Yamashita
-- id: FILL_THIS-218
+- id: 440-218
   pioId: swsh8-218
   enumId: GREEDENT_VMAX_218
   name: Greedent VMAX
@@ -5194,7 +5194,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: PLANETA Mochizuki
-- id: FILL_THIS-219
+- id: 440-219
   pioId: swsh8-219
   enumId: ROOKIDEE_219
   name: Rookidee
@@ -5218,7 +5218,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: OKACHEKE
-- id: FILL_THIS-220
+- id: 440-220
   pioId: swsh8-220
   enumId: CORVISQUIRE_220
   name: Corvisquire
@@ -5243,7 +5243,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Naoyo Kimura
-- id: FILL_THIS-221
+- id: 440-221
   pioId: swsh8-221
   enumId: WOOLOO_221
   name: Wooloo
@@ -5269,7 +5269,7 @@ cards:
     value: x2
   rarity: Common
   artist: Miki Tanaka
-- id: FILL_THIS-222
+- id: 440-222
   pioId: swsh8-222
   enumId: WOOLOO_222
   name: Wooloo
@@ -5290,7 +5290,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yukiko Baba
-- id: FILL_THIS-223
+- id: 440-223
   pioId: swsh8-223
   enumId: DUBWOOL_223
   name: Dubwool
@@ -5314,7 +5314,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Shibuzoh.
-- id: FILL_THIS-224
+- id: 440-224
   pioId: swsh8-224
   enumId: ADVENTURER_S_DISCOVERY_224
   name: Adventurer's Discovery
@@ -5327,7 +5327,7 @@ cards:
     Then, shuffle your deck.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Taira Akitsu
-- id: FILL_THIS-225
+- id: 440-225
   pioId: swsh8-225
   enumId: BATTLE_VIP_PASS_225
   name: Battle VIP Pass
@@ -5342,7 +5342,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: Ryo Ueda
-- id: FILL_THIS-226
+- id: 440-226
   pioId: swsh8-226
   enumId: BUG_CATCHER_226
   name: Bug Catcher
@@ -5354,7 +5354,7 @@ cards:
   - Draw 2 cards. Flip a coin. If heads, draw 2 more cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Yuu Nishida
-- id: FILL_THIS-227
+- id: 440-227
   pioId: swsh8-227
   enumId: CHILI_CILAN_CRESS_227
   name: Chili & Cilan & Cress
@@ -5367,7 +5367,7 @@ cards:
     into your hand. Then, shuffle your deck.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Yusuke Ohmura
-- id: FILL_THIS-228
+- id: 440-228
   pioId: swsh8-228
   enumId: COOK_228
   name: Cook
@@ -5379,7 +5379,7 @@ cards:
   - Heal 70 damage from your Active Pokémon.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Sanosuke Sakuma
-- id: FILL_THIS-229
+- id: 440-229
   pioId: swsh8-229
   enumId: CRAM_O_MATIC_229
   name: Cram-o-matic
@@ -5393,7 +5393,7 @@ cards:
     shuffle your deck.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: Ryo Ueda
-- id: FILL_THIS-230
+- id: 440-230
   pioId: swsh8-230
   enumId: CROSS_SWITCHER_230
   name: Cross Switcher
@@ -5408,7 +5408,7 @@ cards:
     do, switch your Active Pokémon with 1 of your Benched Pokémon.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: inose yukie
-- id: FILL_THIS-231
+- id: 440-231
   pioId: swsh8-231
   enumId: CROSSCEIVER_231
   name: Crossceiver
@@ -5421,7 +5421,7 @@ cards:
   - Put a Pokémon or a Supporter card from your discard pile into your hand.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: Studio Bora Inc.
-- id: FILL_THIS-232
+- id: 440-232
   pioId: swsh8-232
   enumId: DANCER_232
   name: Dancer
@@ -5433,7 +5433,7 @@ cards:
   - Draw 2 cards. If you go second and it's your first turn, draw 3 more cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Sanosuke Sakuma
-- id: FILL_THIS-233
+- id: 440-233
   pioId: swsh8-233
   enumId: ELESA_S_SPARKLE_233
   name: Elesa's Sparkle
@@ -5447,7 +5447,7 @@ cards:
     shuffle your deck.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Yusuke Ohmura
-- id: FILL_THIS-234
+- id: 440-234
   pioId: swsh8-234
   enumId: FAREWELL_BELL_234
   name: Farewell Bell
@@ -5463,7 +5463,7 @@ cards:
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
     have a Pokémon Tool attached.'
   artist: AYUMI ODASHIMA
-- id: FILL_THIS-235
+- id: 440-235
   pioId: swsh8-235
   enumId: JUDGE_235
   name: Judge
@@ -5475,7 +5475,7 @@ cards:
   - Each player shuffles their hand into their deck and draws 4 cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Ryuta Fuse
-- id: FILL_THIS-236
+- id: 440-236
   pioId: swsh8-236
   enumId: POWER_TABLET_236
   name: Power Tablet
@@ -5488,7 +5488,7 @@ cards:
     opponent's Active Pokémon (before applying Weakness and Resistance).
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: Toyste Beach
-- id: FILL_THIS-237
+- id: 440-237
   pioId: swsh8-237
   enumId: QUICK_BALL_237
   name: Quick Ball
@@ -5502,7 +5502,7 @@ cards:
     your deck.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: Ryo Ueda
-- id: FILL_THIS-238
+- id: 440-238
   pioId: swsh8-238
   enumId: SCHOOLBOY_238
   name: Schoolboy
@@ -5515,7 +5515,7 @@ cards:
     2 more cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: kirisAki
-- id: FILL_THIS-239
+- id: 440-239
   pioId: swsh8-239
   enumId: SCHOOLGIRL_239
   name: Schoolgirl
@@ -5528,7 +5528,7 @@ cards:
     2 more cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: kirisAki
-- id: FILL_THIS-240
+- id: 440-240
   pioId: swsh8-240
   enumId: SHAUNA_240
   name: Shauna
@@ -5540,7 +5540,7 @@ cards:
   - Shuffle your hand into your deck. Then, draw 5 cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Yuu Nishida
-- id: FILL_THIS-241
+- id: 440-241
   pioId: swsh8-241
   enumId: SIDNEY_241
   name: Sidney
@@ -5553,7 +5553,7 @@ cards:
     Tool cards, Special Energy cards, and Stadium cards from it.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Hideki Ishikawa
-- id: FILL_THIS-242
+- id: 440-242
   pioId: swsh8-242
   enumId: SKATERS_PARK_242
   name: Skaters' Park
@@ -5565,7 +5565,7 @@ cards:
   - Whenever either player's Active Pokémon retreats, put any basic Energy that would
     be discarded into their hand instead of the discard pile.
   artist: Oswaldo KATO
-- id: FILL_THIS-243
+- id: 440-243
   pioId: swsh8-243
   enumId: SPONGY_GLOVES_243
   name: Spongy Gloves
@@ -5580,7 +5580,7 @@ cards:
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
     have a Pokémon Tool attached.'
   artist: Toyste Beach
-- id: FILL_THIS-244
+- id: 440-244
   pioId: swsh8-244
   enumId: FUSION_STRIKE_ENERGY_244
   name: Fusion Strike Energy
@@ -5595,7 +5595,7 @@ cards:
     only 1 Energy at a time. Prevent all effects of your opponent's Pokémon's Abilities
     done to the Pokémon this card is attached to.
   artist: n/a
-- id: FILL_THIS-245
+- id: 440-245
   pioId: swsh8-245
   enumId: CELEBI_V_245
   name: Celebi V
@@ -5621,7 +5621,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Teeziro
-- id: FILL_THIS-246
+- id: 440-246
   pioId: swsh8-246
   enumId: TSAREENA_V_246
   name: Tsareena V
@@ -5646,7 +5646,7 @@ cards:
   artist: PLANETA Mochizuki
   variantOf: FILL_THIS-21
   variantType: Full Art
-- id: FILL_THIS-247
+- id: 440-247
   pioId: swsh8-247
   enumId: CHANDELURE_V_247
   name: Chandelure V
@@ -5674,7 +5674,7 @@ cards:
   artist: Saki Hayashiro
   variantOf: FILL_THIS-39
   variantType: Full Art
-- id: FILL_THIS-248
+- id: 440-248
   pioId: swsh8-248
   enumId: CRABOMINABLE_V_248
   name: Crabominable V
@@ -5702,7 +5702,7 @@ cards:
   artist: MUGENUP
   variantOf: FILL_THIS-76
   variantType: Full Art
-- id: FILL_THIS-249
+- id: 440-249
   pioId: swsh8-249
   enumId: BOLTUND_V_249
   name: Boltund V
@@ -5731,7 +5731,7 @@ cards:
   artist: Eske Yoshinob
   variantOf: FILL_THIS-103
   variantType: Full Art
-- id: FILL_THIS-250
+- id: 440-250
   pioId: swsh8-250
   enumId: MEW_V_250
   name: Mew V
@@ -5761,7 +5761,7 @@ cards:
   artist: aky CG Works
   variantOf: FILL_THIS-113
   variantType: Full Art
-- id: FILL_THIS-251
+- id: 440-251
   pioId: swsh8-251
   enumId: MEW_V_251
   name: Mew V
@@ -5791,7 +5791,7 @@ cards:
   artist: Naoki Saito
   variantOf: FILL_THIS-113
   variantType: Full Art
-- id: FILL_THIS-252
+- id: 440-252
   pioId: swsh8-252
   enumId: SANDACONDA_V_252
   name: Sandaconda V
@@ -5817,7 +5817,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Narumi Sato
-- id: FILL_THIS-253
+- id: 440-253
   pioId: swsh8-253
   enumId: HOOPA_V_253
   name: Hoopa V
@@ -5843,7 +5843,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: takuyoa
-- id: FILL_THIS-254
+- id: 440-254
   pioId: swsh8-254
   enumId: GENESECT_V_254
   name: Genesect V
@@ -5875,7 +5875,7 @@ cards:
   artist: PLANETA Tsuji
   variantOf: FILL_THIS-185
   variantType: Full Art
-- id: FILL_THIS-255
+- id: 440-255
   pioId: swsh8-255
   enumId: GENESECT_V_255
   name: Genesect V
@@ -5907,7 +5907,7 @@ cards:
   artist: Akira Komayama
   variantOf: FILL_THIS-185
   variantType: Full Art
-- id: FILL_THIS-256
+- id: 440-256
   pioId: swsh8-256
   enumId: GREEDENT_V_256
   name: Greedent V
@@ -5935,7 +5935,7 @@ cards:
   artist: PLANETA Mochizuki
   variantOf: FILL_THIS-217
   variantType: Full Art
-- id: FILL_THIS-257
+- id: 440-257
   pioId: swsh8-257
   enumId: GREEDENT_V_257
   name: Greedent V
@@ -5963,7 +5963,7 @@ cards:
   artist: Saya Tsuruta
   variantOf: FILL_THIS-217
   variantType: Full Art
-- id: FILL_THIS-258
+- id: 440-258
   pioId: swsh8-258
   enumId: CHILI_CILAN_CRESS_258
   name: Chili & Cilan & Cress
@@ -5978,7 +5978,7 @@ cards:
   artist: Sanosuke Sakuma
   variantOf: FILL_THIS-227
   variantType: Full Art
-- id: FILL_THIS-259
+- id: 440-259
   pioId: swsh8-259
   enumId: DANCER_259
   name: Dancer
@@ -5992,7 +5992,7 @@ cards:
   artist: Yuu Nishida
   variantOf: FILL_THIS-232
   variantType: Full Art
-- id: FILL_THIS-260
+- id: 440-260
   pioId: swsh8-260
   enumId: ELESA_S_SPARKLE_260
   name: Elesa's Sparkle
@@ -6008,7 +6008,7 @@ cards:
   artist: Ryuta Fuse
   variantOf: FILL_THIS-233
   variantType: Full Art
-- id: FILL_THIS-261
+- id: 440-261
   pioId: swsh8-261
   enumId: SCHOOLBOY_261
   name: Schoolboy
@@ -6023,7 +6023,7 @@ cards:
   artist: Hideki Ishikawa
   variantOf: FILL_THIS-238
   variantType: Full Art
-- id: FILL_THIS-262
+- id: 440-262
   pioId: swsh8-262
   enumId: SCHOOLGIRL_262
   name: Schoolgirl
@@ -6038,7 +6038,7 @@ cards:
   artist: Hideki Ishikawa
   variantOf: FILL_THIS-239
   variantType: Full Art
-- id: FILL_THIS-263
+- id: 440-263
   pioId: swsh8-263
   enumId: SHAUNA_263
   name: Shauna
@@ -6052,7 +6052,7 @@ cards:
   artist: Yuu Nishida
   variantOf: FILL_THIS-240
   variantType: Full Art
-- id: FILL_THIS-264
+- id: 440-264
   pioId: swsh8-264
   enumId: SIDNEY_264
   name: Sidney
@@ -6067,7 +6067,7 @@ cards:
   artist: Hideki Ishikawa
   variantOf: FILL_THIS-241
   variantType: Full Art
-- id: FILL_THIS-265
+- id: 440-265
   pioId: swsh8-265
   enumId: CHANDELURE_VMAX_265
   name: Chandelure VMAX
@@ -6099,7 +6099,7 @@ cards:
   artist: AKIRA EGAWA
   variantOf: FILL_THIS-40
   variantType: Full Art
-- id: FILL_THIS-266
+- id: 440-266
   pioId: swsh8-266
   enumId: INTELEON_VMAX_266
   name: Inteleon VMAX
@@ -6132,7 +6132,7 @@ cards:
   artist: Kazuma Koda
   variantOf: FILL_THIS-79
   variantType: Full Art
-- id: FILL_THIS-267
+- id: 440-267
   pioId: swsh8-267
   enumId: BOLTUND_VMAX_267
   name: Boltund VMAX
@@ -6163,7 +6163,7 @@ cards:
   artist: PLANETA Tsuji
   variantOf: FILL_THIS-104
   variantType: Full Art
-- id: FILL_THIS-268
+- id: 440-268
   pioId: swsh8-268
   enumId: MEW_VMAX_268
   name: Mew VMAX
@@ -6196,7 +6196,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-114
   variantType: Full Art
-- id: FILL_THIS-269
+- id: 440-269
   pioId: swsh8-269
   enumId: MEW_VMAX_269
   name: Mew VMAX
@@ -6229,7 +6229,7 @@ cards:
   artist: AKIRA EGAWA
   variantOf: FILL_THIS-114
   variantType: Full Art
-- id: FILL_THIS-270
+- id: 440-270
   pioId: swsh8-270
   enumId: ESPEON_VMAX_270
   name: Espeon VMAX
@@ -6263,7 +6263,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: Kouki Saitou
-- id: FILL_THIS-271
+- id: 440-271
   pioId: swsh8-271
   enumId: GENGAR_VMAX_271
   name: Gengar VMAX
@@ -6294,7 +6294,7 @@ cards:
   artist: sowsow
   variantOf: FILL_THIS-157
   variantType: Full Art
-- id: FILL_THIS-272
+- id: 440-272
   pioId: swsh8-272
   enumId: GREEDENT_VMAX_272
   name: Greedent VMAX
@@ -6325,7 +6325,7 @@ cards:
   artist: PLANETA Mochizuki
   variantOf: FILL_THIS-218
   variantType: Full Art
-- id: FILL_THIS-273
+- id: 440-273
   pioId: swsh8-273
   enumId: CHILI_CILAN_CRESS_273
   name: Chili & Cilan & Cress
@@ -6340,7 +6340,7 @@ cards:
   artist: Sanosuke Sakuma
   variantOf: FILL_THIS-227
   variantType: Full Art
-- id: FILL_THIS-274
+- id: 440-274
   pioId: swsh8-274
   enumId: DANCER_274
   name: Dancer
@@ -6354,7 +6354,7 @@ cards:
   artist: Yuu Nishida
   variantOf: FILL_THIS-232
   variantType: Full Art
-- id: FILL_THIS-275
+- id: 440-275
   pioId: swsh8-275
   enumId: ELESA_S_SPARKLE_275
   name: Elesa's Sparkle
@@ -6370,7 +6370,7 @@ cards:
   artist: Ryuta Fuse
   variantOf: FILL_THIS-233
   variantType: Full Art
-- id: FILL_THIS-276
+- id: 440-276
   pioId: swsh8-276
   enumId: SCHOOLBOY_276
   name: Schoolboy
@@ -6385,7 +6385,7 @@ cards:
   artist: Hideki Ishikawa
   variantOf: FILL_THIS-238
   variantType: Full Art
-- id: FILL_THIS-277
+- id: 440-277
   pioId: swsh8-277
   enumId: SCHOOLGIRL_277
   name: Schoolgirl
@@ -6400,7 +6400,7 @@ cards:
   artist: Hideki Ishikawa
   variantOf: FILL_THIS-239
   variantType: Full Art
-- id: FILL_THIS-278
+- id: 440-278
   pioId: swsh8-278
   enumId: SHAUNA_278
   name: Shauna
@@ -6414,7 +6414,7 @@ cards:
   artist: Yuu Nishida
   variantOf: FILL_THIS-240
   variantType: Full Art
-- id: FILL_THIS-279
+- id: 440-279
   pioId: swsh8-279
   enumId: SIDNEY_279
   name: Sidney
@@ -6429,7 +6429,7 @@ cards:
   artist: Hideki Ishikawa
   variantOf: FILL_THIS-241
   variantType: Full Art
-- id: FILL_THIS-280
+- id: 440-280
   pioId: swsh8-280
   enumId: FLAAFFY_280
   name: Flaaffy
@@ -6455,7 +6455,7 @@ cards:
     value: x2
   rarity: Secret
   artist: Studio Bora Inc.
-- id: FILL_THIS-281
+- id: 440-281
   pioId: swsh8-281
   enumId: POWER_TABLET_281
   name: Power Tablet
@@ -6470,7 +6470,7 @@ cards:
   artist: Toyste Beach
   variantOf: FILL_THIS-236
   variantType: Secret Art
-- id: FILL_THIS-282
+- id: 440-282
   pioId: swsh8-282
   enumId: TRAINING_COURT_282
   name: Training Court
@@ -6482,7 +6482,7 @@ cards:
   - Once during each player's turn, that player may put a basic Energy card from their
     discard pile into their hand.
   artist: 5ban Graphics
-- id: FILL_THIS-283
+- id: 440-283
   pioId: swsh8-283
   enumId: GRASS_ENERGY_283
   name: Grass Energy
@@ -6492,7 +6492,7 @@ cards:
   rarity: Secret
   energy: [[G]]
   artist: n/a
-- id: FILL_THIS-284
+- id: 440-284
   pioId: swsh8-284
   enumId: FIRE_ENERGY_284
   name: Fire Energy

--- a/data/src/main/resources/cards/440-fusion_strike.yaml
+++ b/data/src/main/resources/cards/440-fusion_strike.yaml
@@ -299,7 +299,7 @@ cards:
   number: '13'
   types: [G]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [BASIC, FUSION_STRIKE]
   evolvesTo: [Accelgor]
   hp: 70
   retreatCost: 3
@@ -319,7 +319,7 @@ cards:
   number: '14'
   types: [G]
   superType: POKEMON
-  subTypes: [STAGE1, EVOLUTION]
+  subTypes: [STAGE1, EVOLUTION, FUSION_STRIKE]
   evolvesFrom: Shelmet
   hp: 90
   retreatCost: 1
@@ -969,7 +969,7 @@ cards:
   number: '42'
   types: [R]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [BASIC, FUSION_STRIKE]
   hp: 90
   retreatCost: 1
   abilities:
@@ -1518,7 +1518,7 @@ cards:
   number: '65'
   types: [W]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [BASIC, FUSION_STRIKE]
   evolvesTo: [Huntail, Gorebyss]
   hp: 60
   retreatCost: 2
@@ -1562,7 +1562,7 @@ cards:
   number: '67'
   types: [W]
   superType: POKEMON
-  subTypes: [STAGE1, EVOLUTION]
+  subTypes: [STAGE1, EVOLUTION, FUSION_STRIKE]
   evolvesFrom: Clamperl
   hp: 110
   retreatCost: 1
@@ -2474,7 +2474,7 @@ cards:
   number: '106'
   types: [L]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [BASIC, FUSION_STRIKE]
   evolvesTo: [Toxtricity]
   hp: 60
   retreatCost: 1
@@ -2520,7 +2520,7 @@ cards:
   number: '108'
   types: [L]
   superType: POKEMON
-  subTypes: [STAGE1, EVOLUTION]
+  subTypes: [STAGE1, EVOLUTION, FUSION_STRIKE]
   evolvesFrom: Toxel
   hp: 120
   retreatCost: 2
@@ -2640,7 +2640,7 @@ cards:
   number: '113'
   types: [P]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_V]
+  subTypes: [BASIC, POKEMON_V, FUSION_STRIKE]
   hp: 180
   moves:
   - cost: [P]
@@ -2668,7 +2668,7 @@ cards:
   number: '114'
   types: [P]
   superType: POKEMON
-  subTypes: [EVOLUTION, VMAX]
+  subTypes: [EVOLUTION, VMAX, FUSION_STRIKE]
   evolvesFrom: Mew V
   hp: 310
   moves:
@@ -2819,7 +2819,7 @@ cards:
   number: '120'
   types: [P]
   superType: POKEMON
-  subTypes: [BASIC, RAPID_STRIKE, SINGLE_STRIKE]
+  subTypes: [BASIC, RAPID_STRIKE, SINGLE_STRIKE, FUSION_STRIKE]
   hp: 120
   retreatCost: 1
   moves:
@@ -2923,7 +2923,7 @@ cards:
   number: '124'
   types: [P]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [BASIC, FUSION_STRIKE]
   hp: 90
   retreatCost: 1
   moves:
@@ -3025,7 +3025,7 @@ cards:
   number: '128'
   types: [P]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [BASIC, FUSION_STRIKE]
   evolvesTo: [Drakloak]
   hp: 60
   retreatCost: 1
@@ -3049,7 +3049,7 @@ cards:
   number: '129'
   types: [P]
   superType: POKEMON
-  subTypes: [STAGE1, EVOLUTION]
+  subTypes: [STAGE1, EVOLUTION, FUSION_STRIKE]
   evolvesFrom: Dreepy
   evolvesTo: [Dragapult]
   hp: 90
@@ -3077,7 +3077,7 @@ cards:
   number: '130'
   types: [P]
   superType: POKEMON
-  subTypes: [STAGE2, EVOLUTION]
+  subTypes: [STAGE2, EVOLUTION, FUSION_STRIKE]
   evolvesFrom: Drakloak
   hp: 150
   moves:
@@ -4379,7 +4379,7 @@ cards:
   number: '185'
   types: [M]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_V]
+  subTypes: [BASIC, POKEMON_V, FUSION_STRIKE]
   hp: 190
   retreatCost: 2
   abilities:
@@ -4597,7 +4597,7 @@ cards:
   number: '193'
   types: [N]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [BASIC, FUSION_STRIKE]
   hp: 120
   retreatCost: 1
   abilities:
@@ -4620,7 +4620,7 @@ cards:
   number: '194'
   types: [N]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [BASIC, FUSION_STRIKE]
   hp: 130
   retreatCost: 2
   abilities:
@@ -4965,7 +4965,7 @@ cards:
   number: '209'
   types: [C]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [BASIC, FUSION_STRIKE]
   hp: 70
   retreatCost: 1
   moves:
@@ -5361,7 +5361,7 @@ cards:
   name: Chili & Cilan & Cress
   number: '227'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, FUSION_STRIKE]
   rarity: Uncommon
   text:
   - Search your deck for up to 3 Fusion Strike Pokémon, reveal them, and put them
@@ -5400,7 +5400,7 @@ cards:
   name: Cross Switcher
   number: '230'
   superType: TRAINER
-  subTypes: [ITEM]
+  subTypes: [ITEM, FUSION_STRIKE]
   rarity: Uncommon
   text:
   - You must play 2 Cross Switcher cards at once. (This effect works one time for
@@ -5415,7 +5415,7 @@ cards:
   name: Crossceiver
   number: '231'
   superType: TRAINER
-  subTypes: [ITEM]
+  subTypes: [ITEM, FUSION_STRIKE]
   rarity: Uncommon
   text:
   - You must play 2 Crossceiver cards at once. (This effect works one time for 2 cards.)
@@ -5440,7 +5440,7 @@ cards:
   name: Elesa's Sparkle
   number: '233'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, FUSION_STRIKE]
   rarity: Uncommon
   text:
   - Choose up to 2 of your Fusion Strike Pokémon. For each of those Pokémon, search
@@ -5482,7 +5482,7 @@ cards:
   name: Power Tablet
   number: '236'
   superType: TRAINER
-  subTypes: [ITEM]
+  subTypes: [ITEM, FUSION_STRIKE]
   rarity: Uncommon
   text:
   - During this turn, your Fusion Strike Pokémon's attacks do 30 more damage to your
@@ -5587,7 +5587,7 @@ cards:
   name: Fusion Strike Energy
   number: '244'
   superType: ENERGY
-  subTypes: [SPECIAL_ENERGY]
+  subTypes: [SPECIAL_ENERGY, FUSION_STRIKE]
   rarity: Uncommon
   text:
   - This card can only be attached to a Fusion Strike Pokémon. If this card is attached
@@ -5739,7 +5739,7 @@ cards:
   number: '250'
   types: [P]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_V]
+  subTypes: [BASIC, POKEMON_V, FUSION_STRIKE]
   hp: 180
   moves:
   - cost: [P]
@@ -5769,7 +5769,7 @@ cards:
   number: '251'
   types: [P]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_V]
+  subTypes: [BASIC, POKEMON_V, FUSION_STRIKE]
   hp: 180
   moves:
   - cost: [P]
@@ -5825,7 +5825,7 @@ cards:
   number: '253'
   types: [D]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_V]
+  subTypes: [BASIC, POKEMON_V, FUSION_STRIKE]
   hp: 220
   retreatCost: 2
   abilities:
@@ -5851,7 +5851,7 @@ cards:
   number: '254'
   types: [M]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_V]
+  subTypes: [BASIC, POKEMON_V, FUSION_STRIKE]
   hp: 190
   retreatCost: 2
   abilities:
@@ -5883,7 +5883,7 @@ cards:
   number: '255'
   types: [M]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_V]
+  subTypes: [BASIC, POKEMON_V, FUSION_STRIKE]
   hp: 190
   retreatCost: 2
   abilities:
@@ -5970,7 +5970,7 @@ cards:
   name: Chili & Cilan & Cress
   number: '258'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, FUSION_STRIKE]
   rarity: Ultra Rare
   text:
   - Search your deck for up to 3 Fusion Strike Pokémon, reveal them, and put them
@@ -5999,7 +5999,7 @@ cards:
   name: Elesa's Sparkle
   number: '260'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, FUSION_STRIKE]
   rarity: Ultra Rare
   text:
   - Choose up to 2 of your Fusion Strike Pokémon. For each of those Pokémon, search
@@ -6171,7 +6171,7 @@ cards:
   number: '268'
   types: [P]
   superType: POKEMON
-  subTypes: [EVOLUTION, VMAX]
+  subTypes: [EVOLUTION, VMAX, FUSION_STRIKE]
   evolvesFrom: Mew V
   hp: 310
   moves:
@@ -6204,7 +6204,7 @@ cards:
   number: '269'
   types: [P]
   superType: POKEMON
-  subTypes: [EVOLUTION, VMAX]
+  subTypes: [EVOLUTION, VMAX, FUSION_STRIKE]
   evolvesFrom: Mew V
   hp: 310
   moves:
@@ -6332,7 +6332,7 @@ cards:
   name: Chili & Cilan & Cress
   number: '273'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, FUSION_STRIKE]
   rarity: Ultra Rare
   text:
   - Search your deck for up to 3 Fusion Strike Pokémon, reveal them, and put them
@@ -6361,7 +6361,7 @@ cards:
   name: Elesa's Sparkle
   number: '275'
   superType: TRAINER
-  subTypes: [SUPPORTER]
+  subTypes: [SUPPORTER, FUSION_STRIKE]
   rarity: Ultra Rare
   text:
   - Choose up to 2 of your Fusion Strike Pokémon. For each of those Pokémon, search
@@ -6462,7 +6462,7 @@ cards:
   name: Power Tablet
   number: '281'
   superType: TRAINER
-  subTypes: [ITEM]
+  subTypes: [ITEM, FUSION_STRIKE]
   rarity: Secret
   text:
   - During this turn, your Fusion Strike Pokémon's attacks do 30 more damage to your

--- a/data/src/main/resources/cards/440-fusion_strike.yaml
+++ b/data/src/main/resources/cards/440-fusion_strike.yaml
@@ -1,6 +1,6 @@
 id: '440'
 name: swsh8
-enumId: FUSION_STRIKE
+enumId: Fusion Strike
 abbr: FST
 pioId: swsh8
 cards:

--- a/data/src/main/resources/cards/440-fusion_strike.yaml
+++ b/data/src/main/resources/cards/440-fusion_strike.yaml
@@ -1,0 +1,6504 @@
+id: FILL_THIS
+name: swsh8
+enumId: FILL_THIS
+abbr: FILL_THIS
+pioId: swsh8
+cards:
+- id: FILL_THIS-1
+  pioId: swsh8-1
+  enumId: CATERPIE_1
+  name: Caterpie
+  number: '1'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Metapod]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Flock
+    text: Search your deck for a Caterpie and put it onto your Bench. Then, shuffle
+      your deck.
+  - cost: [G]
+    name: Bug Bite
+    damage: '10'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Mitsuhiro Arita
+- id: FILL_THIS-2
+  pioId: swsh8-2
+  enumId: METAPOD_2
+  name: Metapod
+  number: '2'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Caterpie
+  evolvesTo: [Butterfree]
+  hp: 80
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Exoskeleton
+    text: This Pokémon takes 20 less damage from attacks (after applying Weakness
+      and Resistance).
+  moves:
+  - cost: [G]
+    name: Ram
+    damage: '10'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Saya Tsuruta
+- id: FILL_THIS-3
+  pioId: swsh8-3
+  enumId: BUTTERFREE_3
+  name: Butterfree
+  number: '3'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Metapod
+  hp: 120
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Tricolored Scales
+    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
+      your turn, you may make your opponent's Active Pokémon Burned, Confused, and
+      Poisoned.
+  moves:
+  - cost: [G, C]
+    name: Gust
+    damage: '90'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  artist: ryoma uratsuka
+- id: FILL_THIS-4
+  pioId: swsh8-4
+  enumId: SHROOMISH_4
+  name: Shroomish
+  number: '4'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Breloom]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Tackle
+    damage: '10'
+  - cost: [G, C]
+    name: Seed Bomb
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Naoyo Kimura
+- id: FILL_THIS-5
+  pioId: swsh8-5
+  enumId: BRELOOM_5
+  name: Breloom
+  number: '5'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Shroomish
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [G]
+    name: Headbutt
+    damage: '30'
+  - cost: [G, G, C]
+    name: Impact Blow
+    damage: '150'
+    text: During your next turn, this Pokémon can't use Impact Blow.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Yukiko Baba
+- id: FILL_THIS-6
+  pioId: swsh8-6
+  enumId: BRELOOM_V_6
+  name: Breloom V
+  number: '6'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, SINGLE_STRIKE]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [G, C]
+    name: Counter
+    damage: 20+
+    text: If this Pokémon was damaged by an attack during your opponent's last turn,
+      this attack does that much more damage.
+  - cost: [G, G, C]
+    name: Mach Cross
+    damage: '140'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: FILL_THIS-7
+  pioId: swsh8-7
+  enumId: PANSAGE_7
+  name: Pansage
+  number: '7'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Simisage]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Scratch
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Nagomi Nijo
+- id: FILL_THIS-8
+  pioId: swsh8-8
+  enumId: SIMISAGE_8
+  name: Simisage
+  number: '8'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Pansage
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Return
+    damage: '30'
+    text: You may draw cards until you have 6 cards in your hand.
+  - cost: [G, C]
+    name: Whip Smash
+    damage: '70'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Akira Komayama
+- id: FILL_THIS-9
+  pioId: swsh8-9
+  enumId: SEWADDLE_9
+  name: Sewaddle
+  number: '9'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Swadloon]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Grass Munch
+    damage: '10'
+    text: Discard a [G] Energy from your opponent's Active Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Akira Komayama
+- id: FILL_THIS-10
+  pioId: swsh8-10
+  enumId: SWADLOON_10
+  name: Swadloon
+  number: '10'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Sewaddle
+  evolvesTo: [Leavanny]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [G]
+    name: Trip Over
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 20 more damage.
+  - cost: [G, C, C]
+    name: Seed Bomb
+    damage: '60'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: '0313'
+- id: FILL_THIS-11
+  pioId: swsh8-11
+  enumId: LEAVANNY_11
+  name: Leavanny
+  number: '11'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Swadloon
+  hp: 130
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Healing Circle
+    text: Heal all damage from each of your Benched Pokémon. If you healed any damage
+      in this way, shuffle this Pokémon and all attached cards into your deck.
+  - cost: [G, C, C]
+    name: Razor Leaf
+    damage: '120'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare
+  artist: kodama
+- id: FILL_THIS-12
+  pioId: swsh8-12
+  enumId: MARACTUS_12
+  name: Maractus
+  number: '12'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [G]
+    name: Peck
+    damage: '20'
+  - cost: [G, C]
+    name: Ditch and Shake
+    damage: 50x
+    text: Discard any number of Pokémon Tool cards from your hand. This attack does
+      50 damage for each card you discarded in this way.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare
+  artist: '0313'
+- id: FILL_THIS-13
+  pioId: swsh8-13
+  enumId: SHELMET_13
+  name: Shelmet
+  number: '13'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Accelgor]
+  hp: 70
+  retreatCost: 3
+  moves:
+  - cost: [G]
+    name: Spit Beam
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Shibuzoh.
+- id: FILL_THIS-14
+  pioId: swsh8-14
+  enumId: ACCELGOR_14
+  name: Accelgor
+  number: '14'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Shelmet
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [G, C, C]
+    name: Ninja Tornado
+    damage: '120'
+    text: If this Pokémon moved from your Bench to the Active Spot this turn, this
+      attack can be used for Grass.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare
+  artist: nagimiso
+- id: FILL_THIS-15
+  pioId: swsh8-15
+  enumId: VIRIZION_15
+  name: Virizion
+  number: '15'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Bail Out
+    text: Put up to 2 Pokémon from your discard pile into your hand.
+  - cost: [G, C, C]
+    name: Solar Beam
+    damage: '90'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare
+  artist: Kagemaru Himeno
+- id: FILL_THIS-16
+  pioId: swsh8-16
+  enumId: PHANTUMP_16
+  name: Phantump
+  number: '16'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Trevenant]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Tackle
+    damage: '10'
+  - cost: [G, C]
+    name: Seed Bomb
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: OKACHEKE
+- id: FILL_THIS-17
+  pioId: swsh8-17
+  enumId: TREVENANT_17
+  name: Trevenant
+  number: '17'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Phantump
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [G, C]
+    name: Gentle Slap
+    damage: '40'
+  - cost: [G, C, C]
+    name: Wood Hammer
+    damage: '90'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Narumi Sato
+- id: FILL_THIS-18
+  pioId: swsh8-18
+  enumId: GRUBBIN_18
+  name: Grubbin
+  number: '18'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Charjabug]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Energize
+    text: Attach a [L] Energy card from your discard pile to this Pokémon.
+  - cost: [C, C, C]
+    name: Surprise Attack
+    damage: '50'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Asako Ito
+- id: FILL_THIS-19
+  pioId: swsh8-19
+  enumId: DEWPIDER_19
+  name: Dewpider
+  number: '19'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Araquanid]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Bug Bite
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Miki Tanaka
+- id: FILL_THIS-20
+  pioId: swsh8-20
+  enumId: ARAQUANID_20
+  name: Araquanid
+  number: '20'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Dewpider
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [G]
+    name: Bug Bite
+    damage: '30'
+  - cost: [G, C, C]
+    name: Bubble Launch
+    damage: '110'
+    text: Move an Energy from this Pokémon to 1 of your Benched Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare
+  artist: KIYOTAKA OSHIYAMA
+- id: FILL_THIS-21
+  pioId: swsh8-21
+  enumId: TSAREENA_V_21
+  name: Tsareena V
+  number: '21'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 2
+  moves:
+  - cost: [G, C]
+    name: Queen's Orders
+    damage: 20+
+    text: You may discard any number of your Benched Pokémon. This attack does 40
+      more damage for each Benched Pokémon you discarded in this way.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: FILL_THIS-22
+  pioId: swsh8-22
+  enumId: RILLABOOM_V_22
+  name: Rillaboom V
+  number: '22'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, RAPID_STRIKE]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [G, C, C]
+    name: Drain Punch
+    damage: '60'
+    text: Heal 30 damage from this Pokémon.
+  - cost: [G, C, C, C]
+    name: Drum Rush
+    damage: '160'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-23
+  pioId: swsh8-23
+  enumId: RILLABOOM_VMAX_23
+  name: Rillaboom VMAX
+  number: '23'
+  types: [G]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX, RAPID_STRIKE]
+  evolvesFrom: Rillaboom V
+  hp: 330
+  retreatCost: 3
+  moves:
+  - cost: [G, C, C, C]
+    name: G-Max Drum Solo
+    damage: '180'
+    text: This attack also does 40 damage to 2 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-24
+  pioId: swsh8-24
+  enumId: GOSSIFLEUR_24
+  name: Gossifleur
+  number: '24'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Eldegoss]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Leafage
+    damage: '10'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Kagemaru Himeno
+- id: FILL_THIS-25
+  pioId: swsh8-25
+  enumId: ELDEGOSS_25
+  name: Eldegoss
+  number: '25'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Gossifleur
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Sunny Wind
+    damage: '50'
+    text: Heal 20 damage from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Akira Komayama
+- id: FILL_THIS-26
+  pioId: swsh8-26
+  enumId: APPLETUN_V_26
+  name: Appletun V
+  number: '26'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 3
+  moves:
+  - cost: [G]
+    name: Headbutt
+    damage: '30'
+  - cost: [G, G, C]
+    name: Sweet Impact
+    damage: '100'
+    text: Heal 30 damage from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+- id: FILL_THIS-27
+  pioId: swsh8-27
+  enumId: ZARUDE_27
+  name: Zarude
+  number: '27'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Scratch
+    damage: '20'
+  - cost: [G, C]
+    name: Wild Whip
+    damage: 40+
+    text: Flip a coin. If heads, this attack does 30 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Anesaki Dynamic
+- id: FILL_THIS-28
+  pioId: swsh8-28
+  enumId: VULPIX_28
+  name: Vulpix
+  number: '28'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Ninetales]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [R, C]
+    name: Live Coal
+    damage: '30'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: Sekio
+- id: FILL_THIS-29
+  pioId: swsh8-29
+  enumId: VULPIX_29
+  name: Vulpix
+  number: '29'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Ninetales]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Smash Kick
+    damage: '10'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: Megumi Mizutani
+- id: FILL_THIS-30
+  pioId: swsh8-30
+  enumId: NINETALES_30
+  name: Ninetales
+  number: '30'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Vulpix
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [R, C]
+    name: Supernatural Flames
+    damage: '70'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Uncommon
+  artist: kirisAki
+- id: FILL_THIS-31
+  pioId: swsh8-31
+  enumId: NINETALES_31
+  name: Ninetales
+  number: '31'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Vulpix
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Byway of the Nine-Tailed Fox
+    text: The Retreat Cost of each of your Pokémon that has any [R] Energy attached
+      is [C][C] less.
+  moves:
+  - cost: [R, C]
+    name: Flame Tail
+    damage: '60'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Uncommon
+  artist: Tika Matsuno
+- id: FILL_THIS-32
+  pioId: swsh8-32
+  enumId: GROWLITHE_32
+  name: Growlithe
+  number: '32'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Arcanine]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Warm Up
+    text: Search your deck for a [R] Energy card and attach it to 1 of your Pokémon.
+      Then, shuffle your deck.
+  - cost: [R, C, C]
+    name: Combustion
+    damage: '30'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: Narumi Sato
+- id: FILL_THIS-33
+  pioId: swsh8-33
+  enumId: ARCANINE_33
+  name: Arcanine
+  number: '33'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Growlithe
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [R]
+    name: Fire Claws
+    damage: '40'
+  - cost: [R, R, C]
+    name: Heat Tackle
+    damage: '160'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare
+  artist: Yuu Nishida
+- id: FILL_THIS-34
+  pioId: swsh8-34
+  enumId: SLUGMA_34
+  name: Slugma
+  number: '34'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Magcargo]
+  hp: 80
+  retreatCost: 3
+  moves:
+  - cost: [R]
+    name: Live Coal
+    damage: '10'
+  - cost: [C, C]
+    name: Flare
+    damage: '20'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: otumami
+- id: FILL_THIS-35
+  pioId: swsh8-35
+  enumId: MAGCARGO_35
+  name: Magcargo
+  number: '35'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Slugma
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [C, C]
+    name: Rock Throw
+    damage: '40'
+  - cost: [R, R, C]
+    name: Body Splash
+    damage: '150'
+    text: Flip 3 coins. For each tails, discard an Energy from this Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Uncommon
+  artist: Eri Yamaki
+- id: FILL_THIS-36
+  pioId: swsh8-36
+  enumId: VICTINI_36
+  name: Victini
+  number: '36'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Fiery Cheering
+    text: Attach a basic Energy card from your discard pile to 1 of your Benched Pokémon.
+  - cost: [R]
+    name: Flare
+    damage: '20'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Uncommon
+  artist: Mitsuhiro Arita
+- id: FILL_THIS-37
+  pioId: swsh8-37
+  enumId: PANSEAR_37
+  name: Pansear
+  number: '37'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Simisear]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Surprise Attack
+    damage: '30'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: Misa Tsutsui
+- id: FILL_THIS-38
+  pioId: swsh8-38
+  enumId: SIMISEAR_38
+  name: Simisear
+  number: '38'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Pansear
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Light Punch
+    damage: '20'
+  - cost: [R]
+    name: Fling Fire
+    damage: 60x
+    text: Discard up to 2 basic Energy cards from your hand. This attack does 60 damage
+      for each card you discarded in this way.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Uncommon
+  artist: Tomokazu Komiya
+- id: FILL_THIS-39
+  pioId: swsh8-39
+  enumId: CHANDELURE_V_39
+  name: Chandelure V
+  number: '39'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 2
+  moves:
+  - cost: [R]
+    name: Confuse Ray
+    text: Your opponent's Active Pokémon is now Confused.
+  - cost: [R, C]
+    name: Poltergeist
+    damage: 40x
+    text: Your opponent reveals their hand. This attack does 40 damage for each Trainer
+      card you find there.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Saki Hayashiro
+- id: FILL_THIS-40
+  pioId: swsh8-40
+  enumId: CHANDELURE_VMAX_40
+  name: Chandelure VMAX
+  number: '40'
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Chandelure V
+  hp: 320
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Cursed Shimmer
+    text: As long as this Pokémon is in the Active Spot, your opponent can't play
+      any Pokémon Tool cards from their hand.
+  moves:
+  - cost: [R, C]
+    name: Max Poltergeist
+    damage: 70x
+    text: Your opponent reveals their hand. This attack does 70 damage for each Trainer
+      card you find there.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: AKIRA EGAWA
+- id: FILL_THIS-41
+  pioId: swsh8-41
+  enumId: HEATMOR_41
+  name: Heatmor
+  number: '41'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [R]
+    name: Flame Cloak
+    damage: '20'
+    text: Attach a [R] Energy card from your discard pile to this Pokémon.
+  - cost: [R, R, C]
+    name: Exciting Flame
+    damage: '90'
+    text: If this Pokémon has at least 3 extra Energy attached (in addition to this
+      attack's cost), this attack also does 180 damage to 1 of your opponent's Benched
+      Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Uncommon
+  artist: Oswaldo KATO
+- id: FILL_THIS-42
+  pioId: swsh8-42
+  enumId: ORICORIO_42
+  name: Oricorio
+  number: '42'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Lesson in Zeal
+    text: All of your Fusion Strike Pokémon take 20 less damage from attacks from
+      your opponent's Pokémon (after applying Weakness and Resistance). You can't
+      apply more than 1 Lesson in Zeal Ability at a time.
+  moves:
+  - cost: [R, C]
+    name: Glistening Droplets
+    text: Put 5 damage counters on your opponent's Pokémon in any way you like.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare
+  artist: Oswaldo KATO
+- id: FILL_THIS-43
+  pioId: swsh8-43
+  enumId: CINDERACE_V_43
+  name: Cinderace V
+  number: '43'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [R, R, C]
+    name: Blaze Kick
+    damage: '210'
+    text: Discard 2 [R] Energy from this Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-44
+  pioId: swsh8-44
+  enumId: CINDERACE_V_44
+  name: Cinderace V
+  number: '44'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, SINGLE_STRIKE]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Flare
+    damage: '50'
+  - cost: [R, C, C, C]
+    name: All-Out Shot
+    damage: '210'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+- id: FILL_THIS-45
+  pioId: swsh8-45
+  enumId: CINDERACE_VMAX_45
+  name: Cinderace VMAX
+  number: '45'
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX, SINGLE_STRIKE]
+  evolvesFrom: Cinderace V
+  hp: 320
+  retreatCost: 2
+  moves:
+  - cost: [R, C, C, C]
+    name: G-Max Fireball
+    damage: '230'
+    text: Your opponent's Active Pokémon is now Burned. During your next turn, this
+      Pokémon can't attack.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-46
+  pioId: swsh8-46
+  enumId: SIZZLIPEDE_46
+  name: Sizzlipede
+  number: '46'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Centiskorch]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [R]
+    name: Gnaw
+    damage: '10'
+  - cost: [R, C]
+    name: Ember
+    damage: '20'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: miki kudo
+- id: FILL_THIS-47
+  pioId: swsh8-47
+  enumId: SIZZLIPEDE_47
+  name: Sizzlipede
+  number: '47'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE]
+  evolvesTo: [Centiskorch]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [R]
+    name: Singe
+    text: Your opponent's Active Pokémon is now Burned.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: Narumi Sato
+- id: FILL_THIS-48
+  pioId: swsh8-48
+  enumId: CENTISKORCH_48
+  name: Centiskorch
+  number: '48'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION, RAPID_STRIKE]
+  evolvesFrom: Sizzlipede
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [R, C]
+    name: Coil
+    damage: '30'
+    text: During your next turn, this Pokémon's attacks do 90 more damage to your
+      opponent's Active Pokémon (before applying Weakness and Resistance).
+  - cost: [R, R, C]
+    name: Burning Train
+    damage: '120'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare
+  artist: Hasuno
+- id: FILL_THIS-49
+  pioId: swsh8-49
+  enumId: CENTISKORCH_49
+  name: Centiskorch
+  number: '49'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Sizzlipede
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [R]
+    name: Steady Firebreathing
+    damage: '30'
+  - cost: [R, R, C]
+    name: Heat Blast
+    damage: '100'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Uncommon
+  artist: Misa Tsutsui
+- id: FILL_THIS-50
+  pioId: swsh8-50
+  enumId: SHELLDER_50
+  name: Shellder
+  number: '50'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE]
+  evolvesTo: [Cloyster]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Tongue Slap
+    damage: '10'
+  - cost: [W, C]
+    name: Wave Splash
+    damage: '20'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: kawayoo
+- id: FILL_THIS-51
+  pioId: swsh8-51
+  enumId: CLOYSTER_51
+  name: Cloyster
+  number: '51'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION, RAPID_STRIKE]
+  evolvesFrom: Shellder
+  hp: 130
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Shell Armor
+    text: This Pokémon takes 30 less damage from attacks (after applying Weakness
+      and Resistance).
+  moves:
+  - cost: [W, C]
+    name: Aqua Split
+    damage: '60'
+    text: This attack also does 30 damage to 2 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare
+  artist: nagimiso
+- id: FILL_THIS-52
+  pioId: swsh8-52
+  enumId: STARYU_52
+  name: Staryu
+  number: '52'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE]
+  evolvesTo: [Starmie]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Soak in Water
+    text: Attach a [W] Energy card from your hand to this Pokémon.
+  - cost: [W]
+    name: Spinning Attack
+    damage: '10'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: tetsuya koizumi
+- id: FILL_THIS-53
+  pioId: swsh8-53
+  enumId: STARMIE_53
+  name: Starmie
+  number: '53'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION, RAPID_STRIKE]
+  evolvesFrom: Staryu
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Multishot Star
+    text: Discard any amount of [W] Energy from this Pokémon. Then, for each Energy
+      card you discarded in this way, choose 1 of your opponent's Pokémon and do 30
+      damage to it. (You can choose the same Pokémon more than once.) This damage
+      isn't affected by Weakness or Resistance.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  artist: Megumi Mizutani
+- id: FILL_THIS-54
+  pioId: swsh8-54
+  enumId: LAPRAS_54
+  name: Lapras
+  number: '54'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE]
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Icy Wind
+    text: Your opponent's Active Pokémon is now Asleep.
+  - cost: [W, W, C]
+    name: Splash Arch
+    text: Put all Energy attached to this Pokémon into your hand. This attack does
+      100 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and
+      Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: Naoki Saito
+- id: FILL_THIS-55
+  pioId: swsh8-55
+  enumId: TOTODILE_55
+  name: Totodile
+  number: '55'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Croconaw]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Rain Splash
+    damage: '20'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Mizue
+- id: FILL_THIS-56
+  pioId: swsh8-56
+  enumId: CROCONAW_56
+  name: Croconaw
+  number: '56'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Totodile
+  evolvesTo: [Feraligatr]
+  hp: 100
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Wave Splash
+    damage: '30'
+  - cost: [W, C, C]
+    name: Surf
+    damage: '60'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: Tomokazu Komiya
+- id: FILL_THIS-57
+  pioId: swsh8-57
+  enumId: FERALIGATR_57
+  name: Feraligatr
+  number: '57'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Croconaw
+  hp: 170
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Rowdy
+    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
+      your turn, you must flip a coin. If heads, discard the top 5 cards of your opponent's
+      deck. If tails, discard the top 5 cards of your deck.
+  moves:
+  - cost: [W, W, C]
+    name: Crunch
+    damage: '140'
+    text: Discard an Energy from your opponent's Active Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  artist: Anesaki Dynamic
+- id: FILL_THIS-58
+  pioId: swsh8-58
+  enumId: MARILL_58
+  name: Marill
+  number: '58'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Azumarill]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Aqua Liner
+    text: This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't
+      apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [C, C]
+    name: Let's All Rollout
+    damage: 20x
+    text: This attack does 20 damage for each of your Benched Pokémon that has the
+      Let's All Rollout attack.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: sowsow
+- id: FILL_THIS-59
+  pioId: swsh8-59
+  enumId: AZUMARILL_59
+  name: Azumarill
+  number: '59'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Marill
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Dive and Rescue
+    text: Put up to 3 in any combination of Pokémon and Supporter cards from your
+      discard pile into your hand.
+  - cost: [C, C, C]
+    name: Surf
+    damage: '90'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare
+  artist: Sanosuke Sakuma
+- id: FILL_THIS-60
+  pioId: swsh8-60
+  enumId: QWILFISH_60
+  name: Qwilfish
+  number: '60'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Collect
+    text: Draw a card.
+  - cost: [W, C]
+    name: Spike Sting
+    damage: '30'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: HYOGONOSUKE
+- id: FILL_THIS-61
+  pioId: swsh8-61
+  enumId: MANTINE_61
+  name: Mantine
+  number: '61'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Bounce
+    damage: '20'
+    text: You may switch this Pokémon with 1 of your Benched Pokémon.
+  - cost: [C, C, C]
+    name: Wave Splash
+    damage: '80'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Saya Tsuruta
+- id: FILL_THIS-62
+  pioId: swsh8-62
+  enumId: MUDKIP_62
+  name: Mudkip
+  number: '62'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Marshtomp]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Mud-Slap
+    damage: '20'
+  - cost: [W, C, C]
+    name: Playful Kick
+    damage: '30'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: KIYOTAKA OSHIYAMA
+- id: FILL_THIS-63
+  pioId: swsh8-63
+  enumId: MARSHTOMP_63
+  name: Marshtomp
+  number: '63'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Mudkip
+  evolvesTo: [Swampert]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Mud-Slap
+    damage: '30'
+  - cost: [W, C, C]
+    name: Energy Loop
+    damage: '80'
+    text: Put an Energy attached to this Pokémon into your hand.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: tetsuya koizumi
+- id: FILL_THIS-64
+  pioId: swsh8-64
+  enumId: SWAMPERT_64
+  name: Swampert
+  number: '64'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Marshtomp
+  hp: 170
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Muddy Maker
+    text: Once during your turn, you may attach a [W] Energy card or a [F] Energy
+      card from your hand to 1 of your Pokémon.
+  moves:
+  - cost: [W, C, C]
+    name: Earthquake
+    damage: '180'
+    text: This attack also does 20 damage to each of your Benched Pokémon. (Don't
+      apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  artist: Masakazu Fukuda
+- id: FILL_THIS-65
+  pioId: swsh8-65
+  enumId: CLAMPERL_65
+  name: Clamperl
+  number: '65'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Huntail, Gorebyss]
+  hp: 60
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Bursting Bubble
+    damage: '10'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Anesaki Dynamic
+- id: FILL_THIS-66
+  pioId: swsh8-66
+  enumId: HUNTAIL_66
+  name: Huntail
+  number: '66'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Clamperl
+  hp: 110
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Single Strike Jammer
+    text: Your opponent's Single Strike Pokémon's attacks cost [C] more.
+  moves:
+  - cost: [W, C, C]
+    name: Cavernous Chomp
+    damage: '80'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare
+  artist: otumami
+- id: FILL_THIS-67
+  pioId: swsh8-67
+  enumId: GOREBYSS_67
+  name: Gorebyss
+  number: '67'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Clamperl
+  hp: 110
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Rapid Strike Canceler
+    text: Your opponent's Rapid Strike Pokémon in play have no Abilities.
+  moves:
+  - cost: [W, C]
+    name: Draining Kiss
+    damage: '50'
+    text: Heal 30 damage from this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare
+  artist: Misa Tsutsui
+- id: FILL_THIS-68
+  pioId: swsh8-68
+  enumId: PANPOUR_68
+  name: Panpour
+  number: '68'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Simipour]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Pry
+    damage: '10'
+    text: Your opponent reveals their hand.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Sekio
+- id: FILL_THIS-69
+  pioId: swsh8-69
+  enumId: SIMIPOUR_69
+  name: Simipour
+  number: '69'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Panpour
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Water Pulse
+    damage: '20'
+    text: Your opponent's Active Pokémon is now Asleep.
+  - cost: [C, C]
+    name: Circus Soaking
+    damage: 60x
+    text: Your opponent reveals their hand. This attack does 60 damage for each Supporter
+      card you find there.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: Shin Nagasawa
+- id: FILL_THIS-70
+  pioId: swsh8-70
+  enumId: BASCULIN_70
+  name: Basculin
+  number: '70'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [W, C]
+    name: Swarm the Wound
+    damage: 30+
+    text: This attack does 10 more damage for each damage counter on your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Souichirou Gunjima
+- id: FILL_THIS-71
+  pioId: swsh8-71
+  enumId: GALARIAN_DARUMAKA_71
+  name: Galarian Darumaka
+  number: '71'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Darmanitan]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Reckless Charge
+    damage: '20'
+    text: Flip a coin. If tails, this Pokémon also does 10 damage to itself.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: Atsuko Nishida
+- id: FILL_THIS-72
+  pioId: swsh8-72
+  enumId: GALARIAN_DARMANITAN_72
+  name: Galarian Darmanitan
+  number: '72'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Galarian Darumaka
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [W, C]
+    name: Powder Snow
+    damage: '30'
+    text: Your opponent's Active Pokémon is now Asleep.
+  - cost: [W, W, C]
+    name: Daruma Headbutt
+    damage: '130'
+    text: If this Pokémon has any damage counters on it, this attack can be used for
+      Water.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Uncommon
+  artist: SATOSHI NAKAI
+- id: FILL_THIS-73
+  pioId: swsh8-73
+  enumId: GRENINJA_V_73
+  name: Greninja V
+  number: '73'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [W, C]
+    name: Water Drip
+    damage: '40'
+  - cost: [W, W, C]
+    name: Dancing Shuriken
+    damage: 80x
+    text: Flip 3 coins. This attack does 80 damage for each heads.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-74
+  pioId: swsh8-74
+  enumId: CLAUNCHER_74
+  name: Clauncher
+  number: '74'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Clawitzer]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Water Gun
+    damage: '10'
+  - cost: [W, C]
+    name: Vise Grip
+    damage: '20'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Pani Kobayashi
+- id: FILL_THIS-75
+  pioId: swsh8-75
+  enumId: CLAWITZER_75
+  name: Clawitzer
+  number: '75'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Clauncher
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Snipe Shot
+    text: This attack does 50 damage to 1 of your opponent's Benched Pokémon. (Don't
+      apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [W, W, C]
+    name: Crabhammer
+    damage: '110'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: tetsuya koizumi
+- id: FILL_THIS-76
+  pioId: swsh8-76
+  enumId: CRABOMINABLE_V_76
+  name: Crabominable V
+  number: '76'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 4
+  moves:
+  - cost: [W]
+    name: Trigger Avalanche
+    text: Discard the top 2 cards of your opponent's deck.
+  - cost: [W, W, C]
+    name: Destroyer Punch
+    damage: 90+
+    text: This attack does 60 more damage for each damage counter on your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: MUGENUP
+- id: FILL_THIS-77
+  pioId: swsh8-77
+  enumId: PYUKUMUKU_77
+  name: Pyukumuku
+  number: '77'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 80
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Pitch a Pyukumuku
+    text: Once during your turn, if this Pokémon is in your hand, you may reveal it
+      and put it on the bottom of your deck. If you do, draw a card. You can't use
+      more than 1 Pitch a Pyukumuku Ability each turn.
+  moves:
+  - cost: [W, C, C]
+    name: Knuckle Punch
+    damage: '50'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: Tomokazu Komiya
+- id: FILL_THIS-78
+  pioId: swsh8-78
+  enumId: INTELEON_V_78
+  name: Inteleon V
+  number: '78'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, RAPID_STRIKE]
+  hp: 200
+  retreatCost: 2
+  moves:
+  - cost: [W, C]
+    name: Surf
+    damage: '40'
+  - cost: [W, W, C]
+    name: Aqua Bullet
+    damage: '120'
+    text: This attack also does 20 damage to 1 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-79
+  pioId: swsh8-79
+  enumId: INTELEON_VMAX_79
+  name: Inteleon VMAX
+  number: '79'
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX, RAPID_STRIKE]
+  evolvesFrom: Inteleon V
+  hp: 320
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Double Gunner
+    text: You must discard a [W] Energy card from your hand in order to use this Ability.
+      Once during your turn, you may choose 2 of your opponent's Benched Pokémon and
+      put 2 damage counters on each of them.
+  moves:
+  - cost: [W, C]
+    name: G-Max Spiral
+    damage: 70+
+    text: You may put an Energy attached to this Pokémon into your hand. If you do,
+      this attack does 70 more damage.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-80
+  pioId: swsh8-80
+  enumId: CHEWTLE_80
+  name: Chewtle
+  number: '80'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Drednaw]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [W, C]
+    name: Bite
+    damage: '30'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Saya Tsuruta
+- id: FILL_THIS-81
+  pioId: swsh8-81
+  enumId: DREDNAW_81
+  name: Drednaw
+  number: '81'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Chewtle
+  hp: 140
+  retreatCost: 4
+  moves:
+  - cost: [W, C, C]
+    name: Hard Bite
+    damage: 80+
+    text: Flip a coin. If heads, this attack does 50 more damage.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: kodama
+- id: FILL_THIS-82
+  pioId: swsh8-82
+  enumId: ARROKUDA_82
+  name: Arrokuda
+  number: '82'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Barraskewda]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Peck
+    damage: '10'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Miki Tanaka
+- id: FILL_THIS-83
+  pioId: swsh8-83
+  enumId: BARRASKEWDA_83
+  name: Barraskewda
+  number: '83'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Arrokuda
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Pierce
+    damage: '50'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: Hideki Ishikawa
+- id: FILL_THIS-84
+  pioId: swsh8-84
+  enumId: SNOM_84
+  name: Snom
+  number: '84'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Frosmoth]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Find Ice
+    text: Search your deck for up to 2 [W] Energy cards, reveal them, and put them
+      into your hand. Then, shuffle your deck.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: Yuka Morii
+- id: FILL_THIS-85
+  pioId: swsh8-85
+  enumId: FROSMOTH_85
+  name: Frosmoth
+  number: '85'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Snom
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Icy Wind
+    text: Your opponent's Active Pokémon is now Asleep.
+  - cost: [W, W, C]
+    name: Blizzard Loop
+    damage: '160'
+    text: Put all Energy attached to this Pokémon into your hand.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Uncommon
+  artist: chibi
+- id: FILL_THIS-86
+  pioId: swsh8-86
+  enumId: PIKACHU_V_86
+  name: Pikachu V
+  number: '86'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  evolvesTo: [Raichu]
+  hp: 200
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Tail Whap
+    damage: '20'
+  - cost: [L, C, C]
+    name: Thunderbolt
+    damage: '100'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-87
+  pioId: swsh8-87
+  enumId: VOLTORB_87
+  name: Voltorb
+  number: '87'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, SINGLE_STRIKE]
+  evolvesTo: [Electrode]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Single Shot Blast
+    damage: '30'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Tomokazu Komiya
+- id: FILL_THIS-88
+  pioId: swsh8-88
+  enumId: ELECTRODE_88
+  name: Electrode
+  number: '88'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION, SINGLE_STRIKE]
+  evolvesFrom: Voltorb
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Sonic Boom
+    damage: '40'
+    text: This attack's damage isn't affected by Weakness or Resistance.
+  - cost: [C]
+    name: Explosion
+    damage: '120'
+    text: This Pokémon also does 90 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Kouki Saitou
+- id: FILL_THIS-89
+  pioId: swsh8-89
+  enumId: PLUSLE_89
+  name: Plusle
+  number: '89'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Spark Duo
+    damage: 20+
+    text: If 1 of your Minun used an attack during your last turn, this attack does
+      100 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Megumi Higuchi
+- id: FILL_THIS-90
+  pioId: swsh8-90
+  enumId: MINUN_90
+  name: Minun
+  number: '90'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Call for Family
+    text: Search your deck for up to 2 Basic Pokémon and put them onto your Bench.
+      Then, shuffle your deck.
+  - cost: [L]
+    name: Static Shock
+    damage: '20'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: HYOGONOSUKE
+- id: FILL_THIS-91
+  pioId: swsh8-91
+  enumId: SHINX_91
+  name: Shinx
+  number: '91'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Luxio]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Gnaw
+    damage: '10'
+  - cost: [L, C]
+    name: Electric Claws
+    damage: '20'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Naoyo Kimura
+- id: FILL_THIS-92
+  pioId: swsh8-92
+  enumId: LUXIO_92
+  name: Luxio
+  number: '92'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Shinx
+  evolvesTo: [Luxray]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [L, C]
+    name: Electric Claws
+    damage: '50'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: Tika Matsuno
+- id: FILL_THIS-93
+  pioId: swsh8-93
+  enumId: LUXRAY_93
+  name: Luxray
+  number: '93'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Luxio
+  hp: 160
+  moves:
+  - cost: [L, C]
+    name: Thunder Claws
+    damage: '90'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Atsushi Furusawa
+- id: FILL_THIS-94
+  pioId: swsh8-94
+  enumId: ROTOM_94
+  name: Rotom
+  number: '94'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Surprise Short
+    text: Discard all Pokémon Tools from all of your opponent's Pokémon.
+  - cost: [L]
+    name: Static Shock
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Sekio
+- id: FILL_THIS-95
+  pioId: swsh8-95
+  enumId: TYNAMO_95
+  name: Tynamo
+  number: '95'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Eelektrik]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Thunder Wave
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [C, C]
+    name: Tackle
+    damage: '20'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Yuka Morii
+- id: FILL_THIS-96
+  pioId: swsh8-96
+  enumId: EELEKTRIK_96
+  name: Eelektrik
+  number: '96'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Tynamo
+  evolvesTo: [Eelektross]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [L]
+    name: Lightning Ball
+    damage: '20'
+  - cost: [L, C, C]
+    name: Thunder
+    damage: '80'
+    text: This Pokémon also does 20 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: Shigenori Negishi
+- id: FILL_THIS-97
+  pioId: swsh8-97
+  enumId: EELEKTROSS_97
+  name: Eelektross
+  number: '97'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Eelektrik
+  hp: 160
+  retreatCost: 3
+  moves:
+  - cost: [L]
+    name: Upper Shock
+    damage: '40'
+    text: If this Pokémon evolved from Eelektrik during this turn, your opponent's
+      Active Pokémon is now Paralyzed.
+  - cost: [L, C, C]
+    name: Wild Charge
+    damage: '160'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: OKACHEKE
+- id: FILL_THIS-98
+  pioId: swsh8-98
+  enumId: HELIOPTILE_98
+  name: Helioptile
+  number: '98'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Heliolisk]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Gnaw
+    damage: '10'
+  - cost: [L, C]
+    name: Electro Ball
+    damage: '20'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Mina Nakai
+- id: FILL_THIS-99
+  pioId: swsh8-99
+  enumId: HELIOLISK_99
+  name: Heliolisk
+  number: '99'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Helioptile
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Gnaw
+    damage: '20'
+  - cost: [L, C]
+    name: Electrobullet
+    damage: '60'
+    text: This attack also does 20 damage to 1 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: Kagemaru Himeno
+- id: FILL_THIS-100
+  pioId: swsh8-100
+  enumId: CHARJABUG_100
+  name: Charjabug
+  number: '100'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Grubbin
+  evolvesTo: [Vikavolt]
+  hp: 100
+  retreatCost: 3
+  moves:
+  - cost: [C, C]
+    name: Vise Grip
+    damage: '30'
+  - cost: [L, C, C]
+    name: Head Bolt
+    damage: '60'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: sowsow
+- id: FILL_THIS-101
+  pioId: swsh8-101
+  enumId: VIKAVOLT_101
+  name: Vikavolt
+  number: '101'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Charjabug
+  hp: 150
+  moves:
+  - cost: [C, C, C]
+    name: Bite
+    damage: '70'
+  - cost: [L, L, C, C]
+    name: Electro Blaster
+    text: Discard 2 [L] Energy from this Pokémon. This attack does 200 damage to 1
+      of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched
+      Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: nagimiso
+- id: FILL_THIS-102
+  pioId: swsh8-102
+  enumId: ZERAORA_102
+  name: Zeraora
+  number: '102'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [L, C]
+    name: Wild Charge
+    damage: '70'
+    text: This Pokémon also does 20 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Teeziro
+- id: FILL_THIS-103
+  pioId: swsh8-103
+  enumId: BOLTUND_V_103
+  name: Boltund V
+  number: '103'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Smash Turn
+    damage: '30'
+    text: You may switch this Pokémon with 1 of your Benched Pokémon.
+  - cost: [L, L, C]
+    name: Electrobullet
+    damage: '120'
+    text: This attack also does 30 damage to 1 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Shin Nagasawa
+- id: FILL_THIS-104
+  pioId: swsh8-104
+  enumId: BOLTUND_VMAX_104
+  name: Boltund VMAX
+  number: '104'
+  types: [L]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Boltund V
+  hp: 320
+  retreatCost: 2
+  moves:
+  - cost: [L, C]
+    name: Bolt Storm
+    damage: 30+
+    text: This attack does 30 more damage for each [L] Energy attached to all of your
+      Pokémon.
+  - cost: [L, L, C]
+    name: Max Bolt
+    damage: '230'
+    text: During your next turn, this Pokémon can't use Max Bolt.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: PLANETA Tsuji
+- id: FILL_THIS-105
+  pioId: swsh8-105
+  enumId: TOXEL_105
+  name: Toxel
+  number: '105'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Toxtricity]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [L]
+    name: Ram
+    damage: '20'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Mina Nakai
+- id: FILL_THIS-106
+  pioId: swsh8-106
+  enumId: TOXEL_106
+  name: Toxel
+  number: '106'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Toxtricity]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Growl
+    text: During your opponent's next turn, the Defending Pokémon's attacks do 30
+      less damage (before applying Weakness and Resistance).
+  - cost: [L]
+    name: Tiny Bolt
+    damage: '10'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: kodama
+- id: FILL_THIS-107
+  pioId: swsh8-107
+  enumId: TOXTRICITY_107
+  name: Toxtricity
+  number: '107'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Toxel
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [L, C]
+    name: Punk Shock
+    damage: '70'
+    text: You may choose to make your opponent's Active Pokémon Paralyzed. If you
+      do, this Pokémon also does 70 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: Ryuta Fuse
+- id: FILL_THIS-108
+  pioId: swsh8-108
+  enumId: TOXTRICITY_108
+  name: Toxtricity
+  number: '108'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Toxel
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Maximum Downer
+    text: If all your Pokémon in play are Fusion Strike Pokémon, your opponent's Pokémon
+      VMAX in play get -30 HP.
+  moves:
+  - cost: [L, L, C]
+    name: Head Bolt
+    damage: '90'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: nagimiso
+- id: FILL_THIS-109
+  pioId: swsh8-109
+  enumId: MORPEKO_109
+  name: Morpeko
+  number: '109'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [L, C]
+    name: Targeted Spark
+    text: This attack does 30 damage to 1 of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Sanosuke Sakuma
+- id: FILL_THIS-110
+  pioId: swsh8-110
+  enumId: JIGGLYPUFF_110
+  name: Jigglypuff
+  number: '110'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Wigglytuff]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Pound
+    damage: '20'
+  - cost: [C, C]
+    name: Let's All Rollout
+    damage: 20x
+    text: This attack does 20 damage for each of your Benched Pokémon that has the
+      Let's All Rollout attack.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: Saya Tsuruta
+- id: FILL_THIS-111
+  pioId: swsh8-111
+  enumId: WIGGLYTUFF_111
+  name: Wigglytuff
+  number: '111'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Jigglypuff
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [P]
+    name: Find Treasure
+    text: Search your deck for up to 2 cards and put them into your hand. Then, shuffle
+      your deck.
+  - cost: [P, C, C]
+    name: Hyper Voice
+    damage: '90'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Uncommon
+  artist: Asako Ito
+- id: FILL_THIS-112
+  pioId: swsh8-112
+  enumId: JYNX_112
+  name: Jynx
+  number: '112'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Double Draw
+    text: Draw 2 cards.
+  - cost: [P, C]
+    name: Dazzle Dance
+    damage: '30'
+    text: Your opponent's Active Pokémon is now Confused.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Shigenori Negishi
+- id: FILL_THIS-113
+  pioId: swsh8-113
+  enumId: MEW_V_113
+  name: Mew V
+  number: '113'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 180
+  moves:
+  - cost: [P]
+    name: Energy Mix
+    text: Search your deck for an Energy card and attach it to 1 of your Fusion Strike
+      Pokémon. Then, shuffle your deck.
+  - cost: [P, C]
+    name: Psychic Leap
+    damage: '70'
+    text: You may shuffle this Pokémon and all attached cards into your deck.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Mitsuhiro Arita
+- id: FILL_THIS-114
+  pioId: swsh8-114
+  enumId: MEW_VMAX_114
+  name: Mew VMAX
+  number: '114'
+  types: [P]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Mew V
+  hp: 310
+  moves:
+  - cost: [C, C]
+    name: Cross Fusion Strike
+    text: Choose 1 of your Benched Fusion Strike Pokémon's attacks and use it as this
+      attack.
+  - cost: [P, P]
+    name: Max Miracle
+    damage: '130'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-115
+  pioId: swsh8-115
+  enumId: SNUBBULL_115
+  name: Snubbull
+  number: '115'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Granbull]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Headbutt
+    damage: '10'
+  - cost: [C, C, C]
+    name: Bite
+    damage: '30'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: Kyoko Umemoto
+- id: FILL_THIS-116
+  pioId: swsh8-116
+  enumId: GRANBULL_116
+  name: Granbull
+  number: '116'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Snubbull
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Dig Up
+    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
+      your turn, you may put up to 2 Pokémon Tool cards from your discard pile into
+      your hand.
+  moves:
+  - cost: [C, C, C]
+    name: Bite
+    damage: '90'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare
+  artist: Akira Komayama
+- id: FILL_THIS-117
+  pioId: swsh8-117
+  enumId: GALARIAN_CORSOLA_117
+  name: Galarian Corsola
+  number: '117'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Cursola]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Tackle
+    damage: '30'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Kouki Saitou
+- id: FILL_THIS-118
+  pioId: swsh8-118
+  enumId: GALARIAN_CURSOLA_118
+  name: Galarian Cursola
+  number: '118'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Galarian Corsola
+  hp: 100
+  retreatCost: 2
+  moves:
+  - cost: [P]
+    name: Force Regeneration
+    text: Put a Basic Pokémon V from your opponent's discard pile onto their Bench.
+      If you do, put damage counters on that Pokémon until its remaining HP is 30.
+  - cost: [P, C, C]
+    name: Spooky Shot
+    damage: '80'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Misa Tsutsui
+- id: FILL_THIS-119
+  pioId: swsh8-119
+  enumId: MAWILE_119
+  name: Mawile
+  number: '119'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Chomp Chomp Hold
+    damage: '30'
+    text: During your opponent's next turn, the Defending Pokémon's attacks cost [C]
+      more, and its Retreat Cost is [C] more.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: Kouki Saitou
+- id: FILL_THIS-120
+  pioId: swsh8-120
+  enumId: DEOXYS_120
+  name: Deoxys
+  number: '120'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE, SINGLE_STRIKE]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [C, C, C]
+    name: Photon Boost
+    damage: 80+
+    text: If this Pokémon has any Fusion Strike Energy attached, this attack does
+      80 more damage.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: Kouki Saitou
+- id: FILL_THIS-121
+  pioId: swsh8-121
+  enumId: MUNNA_121
+  name: Munna
+  number: '121'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Musharna]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Ram
+    damage: '10'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: miki kudo
+- id: FILL_THIS-122
+  pioId: swsh8-122
+  enumId: MUSHARNA_122
+  name: Musharna
+  number: '122'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Munna
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Sleep Inducer
+    text: Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The
+      new Active Pokémon is now Asleep.
+  - cost: [P, C]
+    name: Psychic
+    damage: 30+
+    text: This attack does 30 more damage for each Energy attached to your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Tika Matsuno
+- id: FILL_THIS-123
+  pioId: swsh8-123
+  enumId: SIGILYPH_123
+  name: Sigilyph
+  number: '123'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Joust
+    damage: '20'
+    text: Before doing damage, discard all Pokémon Tools from your opponent's Active
+      Pokémon.
+  - cost: [P, C]
+    name: Reflect Energy
+    damage: '60'
+    text: Move an Energy from this Pokémon to 1 of your Benched Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Yukiko Baba
+- id: FILL_THIS-124
+  pioId: swsh8-124
+  enumId: MELOETTA_124
+  name: Meloetta
+  number: '124'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [P, C]
+    name: Melodious Echo
+    damage: 70x
+    text: This attack does 70 damage for each Fusion Strike Energy attached to all
+      of your Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: kirisAki
+- id: FILL_THIS-125
+  pioId: swsh8-125
+  enumId: SANDYGAST_125
+  name: Sandygast
+  number: '125'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Palossand]
+  hp: 80
+  retreatCost: 3
+  moves:
+  - cost: [P]
+    name: Vibration
+    damage: '10'
+  - cost: [P, P]
+    name: Spooky Shot
+    damage: '30'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: KIYOTAKA OSHIYAMA
+- id: FILL_THIS-126
+  pioId: swsh8-126
+  enumId: PALOSSAND_126
+  name: Palossand
+  number: '126'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Sandygast
+  hp: 140
+  retreatCost: 4
+  moves:
+  - cost: [P, P, C]
+    name: Spooky Sand
+    damage: '120'
+  - cost: [P, P, P, C]
+    name: Oppressing Sandstorm
+    text: If your opponent's Active Pokémon is a Basic Pokémon, it is Knocked Out.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Shibuzoh.
+- id: FILL_THIS-127
+  pioId: swsh8-127
+  enumId: INDEEDEE_127
+  name: Indeedee
+  number: '127'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Call for Family
+    text: Search your deck for up to 2 Basic Pokémon and put them onto your Bench.
+      Then, shuffle your deck.
+  - cost: [P, C, C]
+    name: Heart Sign
+    damage: '80'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Misa Tsutsui
+- id: FILL_THIS-128
+  pioId: swsh8-128
+  enumId: DREEPY_128
+  name: Dreepy
+  number: '128'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Drakloak]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Infestation
+    damage: '10'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Teeziro
+- id: FILL_THIS-129
+  pioId: swsh8-129
+  enumId: DRAKLOAK_129
+  name: Drakloak
+  number: '129'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Dreepy
+  evolvesTo: [Dragapult]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Spooky Shot
+    damage: '20'
+  - cost: [P, C]
+    name: U-turn
+    damage: '30'
+    text: Switch this Pokémon with 1 of your Benched Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: HYOGONOSUKE
+- id: FILL_THIS-130
+  pioId: swsh8-130
+  enumId: DRAGAPULT_130
+  name: Dragapult
+  number: '130'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Drakloak
+  hp: 150
+  moves:
+  - cost: [P]
+    name: Fusion Strike Assault
+    damage: 30x
+    text: This attack does 30 damage for each of your Fusion Strike Pokémon in play.
+  - cost: [P, C]
+    name: Speed Attack
+    damage: '120'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: Souichirou Gunjima
+- id: FILL_THIS-131
+  pioId: swsh8-131
+  enumId: SANDSHREW_131
+  name: Sandshrew
+  number: '131'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Sandslash]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Dig It Up
+    text: Look at the top card of your deck. You may discard that card.
+  - cost: [C, C]
+    name: Let's All Rollout
+    damage: 20x
+    text: This attack does 20 damage for each of your Benched Pokémon that has the
+      Let's All Rollout attack.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Yuka Morii
+- id: FILL_THIS-132
+  pioId: swsh8-132
+  enumId: SANDSLASH_132
+  name: Sandslash
+  number: '132'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Sandshrew
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [F, C]
+    name: Dig Uppercut
+    damage: '60'
+    text: Put a card from your discard pile into your hand.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: Kyoko Umemoto
+- id: FILL_THIS-133
+  pioId: swsh8-133
+  enumId: MANKEY_133
+  name: Mankey
+  number: '133'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Primeape]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Scratch
+    damage: '10'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Common
+  artist: sowsow
+- id: FILL_THIS-134
+  pioId: swsh8-134
+  enumId: PRIMEAPE_134
+  name: Primeape
+  number: '134'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Mankey
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Gut Punch
+    damage: 30+
+    text: If your opponent's Active Pokémon is a Pokémon V, this attack does 60 more
+      damage.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Uncommon
+  artist: Yuya Oka
+- id: FILL_THIS-135
+  pioId: swsh8-135
+  enumId: GEODUDE_135
+  name: Geodude
+  number: '135'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Graveler]
+  hp: 80
+  retreatCost: 3
+  moves:
+  - cost: [F]
+    name: Rollout
+    damage: '10'
+  - cost: [C, C]
+    name: Light Punch
+    damage: '20'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: OKACHEKE
+- id: FILL_THIS-136
+  pioId: swsh8-136
+  enumId: GRAVELER_136
+  name: Graveler
+  number: '136'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Geodude
+  evolvesTo: [Golem]
+  hp: 110
+  retreatCost: 4
+  moves:
+  - cost: [F]
+    name: Tackle
+    damage: '30'
+  - cost: [F, C, C]
+    name: Boulder Crush
+    damage: '70'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: Masakazu Fukuda
+- id: FILL_THIS-137
+  pioId: swsh8-137
+  enumId: GOLEM_137
+  name: Golem
+  number: '137'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Graveler
+  hp: 180
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Desperate Blast
+    text: If this Pokémon is in the Active Spot and is Knocked Out by damage from
+      an attack from your opponent's Pokémon, put 10 damage counters on the Attacking
+      Pokémon.
+  moves:
+  - cost: [F, C, C]
+    name: Double-Edge
+    damage: '160'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: KEIICHIRO ITO
+- id: FILL_THIS-138
+  pioId: swsh8-138
+  enumId: ONIX_138
+  name: Onix
+  number: '138'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Steelix]
+  hp: 110
+  retreatCost: 4
+  moves:
+  - cost: [C, C]
+    name: Guard Press
+    damage: '30'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  - cost: [F, F, C]
+    name: Rock Throw
+    damage: '90'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: KEIICHIRO ITO
+- id: FILL_THIS-139
+  pioId: swsh8-139
+  enumId: STEELIX_139
+  name: Steelix
+  number: '139'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Onix
+  hp: 190
+  retreatCost: 4
+  moves:
+  - cost: [C, C]
+    name: Powerful Rage
+    damage: 20x
+    text: This attack does 20 damage for each damage counter on this Pokémon.
+  - cost: [F, F, C]
+    name: Earthquake
+    damage: '180'
+    text: This attack also does 30 damage to each of your Benched Pokémon. (Don't
+      apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: Ryuta Fuse
+- id: FILL_THIS-140
+  pioId: swsh8-140
+  enumId: GLIGAR_140
+  name: Gligar
+  number: '140'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Gliscor]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Poison Sting
+    text: Your opponent's Active Pokémon is now Poisoned.
+  - cost: [F, C]
+    name: Pierce
+    damage: '30'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Misa Tsutsui
+- id: FILL_THIS-141
+  pioId: swsh8-141
+  enumId: GLISCOR_141
+  name: Gliscor
+  number: '141'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Gligar
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [F, C]
+    name: Cut Down
+    damage: '30'
+    text: Discard an Energy from your opponent's Active Pokémon.
+  - cost: [F, F, C]
+    name: Venomous Hit
+    damage: '100'
+    text: Your opponent's Active Pokémon is now Poisoned.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: SATOSHI NAKAI
+- id: FILL_THIS-142
+  pioId: swsh8-142
+  enumId: MAKUHITA_142
+  name: Makuhita
+  number: '142'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, SINGLE_STRIKE]
+  evolvesTo: [Hariyama]
+  hp: 90
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Lunge Out
+    damage: '10'
+  - cost: [F, C, C]
+    name: Hammer In
+    damage: '60'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Common
+  artist: Oswaldo KATO
+- id: FILL_THIS-143
+  pioId: swsh8-143
+  enumId: HARIYAMA_143
+  name: Hariyama
+  number: '143'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION, SINGLE_STRIKE]
+  evolvesFrom: Makuhita
+  hp: 140
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Guts
+    text: If this Pokémon would be Knocked Out by damage from an attack, flip a coin.
+      If heads, this Pokémon is not Knocked Out, and its remaining HP becomes 10.
+  moves:
+  - cost: [F, C, C]
+    name: Hammer In
+    damage: '100'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Uncommon
+  artist: Hitoshi Ariga
+- id: FILL_THIS-144
+  pioId: swsh8-144
+  enumId: BALTOY_144
+  name: Baltoy
+  number: '144'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Claydol]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Smack
+    damage: '20'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Sumiyoshi Kizuki
+- id: FILL_THIS-145
+  pioId: swsh8-145
+  enumId: CLAYDOL_145
+  name: Claydol
+  number: '145'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Baltoy
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Rapid Spin
+    damage: '30'
+    text: Switch this Pokémon with 1 of your Benched Pokémon. If you do, your opponent
+      switches their Active Pokémon with 1 of their Benched Pokémon.
+  - cost: [F, F]
+    name: Ancient Imprint
+    text: Put damage counters on your opponent's Active Pokémon until its remaining
+      HP is 60.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: Akira Komayama
+- id: FILL_THIS-146
+  pioId: swsh8-146
+  enumId: LUCARIO_V_146
+  name: Lucario V
+  number: '146'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [F, F, C]
+    name: Aura Sphere
+    damage: '120'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+- id: FILL_THIS-147
+  pioId: swsh8-147
+  enumId: DRILBUR_147
+  name: Drilbur
+  number: '147'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Excadrill]
+  hp: 60
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Scratch
+    damage: '20'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: tetsuya koizumi
+- id: FILL_THIS-148
+  pioId: swsh8-148
+  enumId: LANDORUS_148
+  name: Landorus
+  number: '148'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Strafe
+    damage: '20'
+    text: You may switch this Pokémon with 1 of your Benched Pokémon.
+  - cost: [F, F, C]
+    name: Earthen Boom
+    damage: '120'
+    text: Move all Energy from this Pokémon to your Benched Pokémon in any way you
+      like.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: NC Empire
+- id: FILL_THIS-149
+  pioId: swsh8-149
+  enumId: PANCHAM_149
+  name: Pancham
+  number: '149'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Pangoro]
+  hp: 60
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Raised Bad
+    text: Search your deck for up to 2 [D] Energy cards and attach them to this Pokémon.
+      Then, shuffle your deck.
+  - cost: [C, C, C]
+    name: Smash Kick
+    damage: '30'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Common
+  artist: Mina Nakai
+- id: FILL_THIS-150
+  pioId: swsh8-150
+  enumId: STUFFUL_150
+  name: Stufful
+  number: '150'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Bewear]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Beat
+    damage: '10'
+  - cost: [F, C]
+    name: Rollout
+    damage: '30'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Common
+  artist: OKACHEKE
+- id: FILL_THIS-151
+  pioId: swsh8-151
+  enumId: BEWEAR_151
+  name: Bewear
+  number: '151'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Stufful
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [F, C]
+    name: Split Spiral Punch
+    damage: '40'
+    text: Your opponent's Active Pokémon is now Confused.
+  - cost: [F, F, C]
+    name: Strength
+    damage: '130'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Uncommon
+  artist: Shigenori Negishi
+- id: FILL_THIS-152
+  pioId: swsh8-152
+  enumId: CLOBBOPUS_152
+  name: Clobbopus
+  number: '152'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Grapploct]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Beat
+    damage: '10'
+  - cost: [F, C]
+    name: Knuckle Punch
+    damage: '20'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Common
+  artist: Mizue
+- id: FILL_THIS-153
+  pioId: swsh8-153
+  enumId: GRAPPLOCT_153
+  name: Grapploct
+  number: '153'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Clobbopus
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [F, C]
+    name: Lunge Out
+    damage: '40'
+  - cost: [F, C, C]
+    name: Magnum Punch
+    damage: '90'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Uncommon
+  artist: Souichirou Gunjima
+- id: FILL_THIS-154
+  pioId: swsh8-154
+  enumId: FALINKS_154
+  name: Falinks
+  number: '154'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Headbutt
+    damage: '30'
+  - cost: [F, C, C]
+    name: Cliff Edge Formation
+    damage: 60+
+    text: If your opponent has exactly 1 Prize card remaining, this attack does 160
+      more damage.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Uncommon
+  artist: Akira Komayama
+- id: FILL_THIS-155
+  pioId: swsh8-155
+  enumId: FALINKS_155
+  name: Falinks
+  number: '155'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Invade
+    damage: '30'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Common
+  artist: Yuu Nishida
+- id: FILL_THIS-156
+  pioId: swsh8-156
+  enumId: GENGAR_V_156
+  name: Gengar V
+  number: '156'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, SINGLE_STRIKE]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [D, D]
+    name: Dark Slumber
+    damage: '40'
+    text: Your opponent's Active Pokémon is now Asleep.
+  - cost: [D, D, D]
+    name: Pain Explosion
+    damage: '190'
+    text: Put 3 damage counters on this Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-157
+  pioId: swsh8-157
+  enumId: GENGAR_VMAX_157
+  name: Gengar VMAX
+  number: '157'
+  types: [D]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX, SINGLE_STRIKE]
+  evolvesFrom: Gengar V
+  hp: 320
+  retreatCost: 3
+  moves:
+  - cost: [D, D]
+    name: Fear and Panic
+    damage: 60x
+    text: This attack does 60 damage for each of your opponent's Pokémon V and Pokémon-GX
+      in play.
+  - cost: [D, D, D]
+    name: G-Max Swallow Up
+    damage: '250'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-158
+  pioId: swsh8-158
+  enumId: TYRANITAR_V_158
+  name: Tyranitar V
+  number: '158'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 230
+  retreatCost: 4
+  moves:
+  - cost: [D, C, C]
+    name: Hammer In
+    damage: '80'
+  - cost: [D, D, D, C]
+    name: Land Crush
+    damage: '150'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-159
+  pioId: swsh8-159
+  enumId: GALARIAN_ZIGZAGOON_159
+  name: Galarian Zigzagoon
+  number: '159'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Linoone]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Lick
+    damage: '10'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Eri Yamaki
+- id: FILL_THIS-160
+  pioId: swsh8-160
+  enumId: GALARIAN_LINOONE_160
+  name: Galarian Linoone
+  number: '160'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Galarian Zigzagoon
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Rear Kick
+    damage: '30'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: sowsow
+- id: FILL_THIS-161
+  pioId: swsh8-161
+  enumId: GALARIAN_OBSTAGOON_161
+  name: Galarian Obstagoon
+  number: '161'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Galarian Linoone
+  hp: 170
+  retreatCost: 2
+  moves:
+  - cost: [D]
+    name: Silence
+    damage: '30'
+    text: Choose 1 of your opponent's Active Pokémon's attacks. During your opponent's
+      next turn, that Pokémon can't use that attack.
+  - cost: [D]
+    name: Merciless Strike
+    damage: 60+
+    text: If your opponent's Active Pokémon already has any damage counters on it,
+      this attack does 90 more damage.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: kodama
+- id: FILL_THIS-162
+  pioId: swsh8-162
+  enumId: CARVANHA_162
+  name: Carvanha
+  number: '162'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Sharpedo]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Bite
+    damage: '10'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: NC Empire
+- id: FILL_THIS-163
+  pioId: swsh8-163
+  enumId: SHARPEDO_163
+  name: Sharpedo
+  number: '163'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Carvanha
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [D, C]
+    name: Sharp Fang
+    damage: '70'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: Hasuno
+- id: FILL_THIS-164
+  pioId: swsh8-164
+  enumId: ABSOL_164
+  name: Absol
+  number: '164'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Drag Off
+    text: Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. This
+      attack does 30 damage to the new Active Pokémon.
+  - cost: [D, C, C]
+    name: Slash
+    damage: '80'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: Eri Yamaki
+- id: FILL_THIS-165
+  pioId: swsh8-165
+  enumId: CROAGUNK_165
+  name: Croagunk
+  number: '165'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Toxicroak]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Corkscrew Punch
+    damage: '20'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Nagomi Nijo
+- id: FILL_THIS-166
+  pioId: swsh8-166
+  enumId: TOXICROAK_166
+  name: Toxicroak
+  number: '166'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Croagunk
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Severe Poison
+    text: Your opponent's Active Pokémon is now Poisoned. During Pokémon Checkup,
+      put 4 damage counters on that Pokémon instead of 1.
+  - cost: [D, C, C]
+    name: Magnum Punch
+    damage: '90'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Masakazu Fukuda
+- id: FILL_THIS-167
+  pioId: swsh8-167
+  enumId: DARKRAI_167
+  name: Darkrai
+  number: '167'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [D, C, C]
+    name: Dark Cutter
+    damage: '90'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: Megumi Mizutani
+- id: FILL_THIS-168
+  pioId: swsh8-168
+  enumId: TRUBBISH_168
+  name: Trubbish
+  number: '168'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Garbodor]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [D]
+    name: Call for Family
+    text: Search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle
+      your deck.
+  - cost: [D, C]
+    name: Super Poison Breath
+    damage: '20'
+    text: Your opponent's Active Pokémon is now Poisoned.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Shibuzoh.
+- id: FILL_THIS-169
+  pioId: swsh8-169
+  enumId: GARBODOR_169
+  name: Garbodor
+  number: '169'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Trubbish
+  hp: 120
+  retreatCost: 3
+  moves:
+  - cost: [D]
+    name: Poison Gas
+    damage: '30'
+    text: Your opponent's Active Pokémon is now Poisoned.
+  - cost: [D, D, C]
+    name: Sludge Whirlpool
+    damage: '130'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: Misa Tsutsui
+- id: FILL_THIS-170
+  pioId: swsh8-170
+  enumId: ZORUA_170
+  name: Zorua
+  number: '170'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Zoroark]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Ram
+    damage: '10'
+  - cost: [D, C]
+    name: Rear Kick
+    damage: '20'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: nagimiso
+- id: FILL_THIS-171
+  pioId: swsh8-171
+  enumId: ZOROARK_171
+  name: Zoroark
+  number: '171'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Zorua
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Double Claw
+    damage: 40x
+    text: Flip 2 coins. This attack does 40 damage for each heads.
+  - cost: [D, D, C]
+    name: Night Daze
+    damage: '100'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: Kouki Saitou
+- id: FILL_THIS-172
+  pioId: swsh8-172
+  enumId: VULLABY_172
+  name: Vullaby
+  number: '172'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Mandibuzz]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Razor Wing
+    damage: '10'
+  - cost: [D, C]
+    name: Air Slash
+    damage: '30'
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Shigenori Negishi
+- id: FILL_THIS-173
+  pioId: swsh8-173
+  enumId: MANDIBUZZ_173
+  name: Mandibuzz
+  number: '173'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Vullaby
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [D]
+    name: Bone Block
+    damage: '20'
+    text: During your opponent's next turn, Pokémon can't be played from your opponent's
+      hand to evolve the Defending Pokémon.\n 
+  - cost: [D, C]
+    name: Dark Cutter
+    damage: '70'
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Narumi Sato
+- id: FILL_THIS-174
+  pioId: swsh8-174
+  enumId: PANGORO_174
+  name: Pangoro
+  number: '174'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Pancham
+  hp: 140
+  retreatCost: 4
+  moves:
+  - cost: [D, D, C]
+    name: Knocking Hammer
+    damage: '90'
+    text: Discard the top card of your opponent's deck.
+  - cost: [D, D, D, C]
+    name: Shakedown
+    damage: '150'
+    text: Discard a random card from your opponent's hand.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: HYOGONOSUKE
+- id: FILL_THIS-175
+  pioId: swsh8-175
+  enumId: YVELTAL_175
+  name: Yveltal
+  number: '175'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, SINGLE_STRIKE]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [D, D]
+    name: Dark Cutter
+    damage: '50'
+  - cost: [D, D, D]
+    name: Single Strike Wings
+    damage: '110'
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: kawayoo
+- id: FILL_THIS-176
+  pioId: swsh8-176
+  enumId: IMPIDIMP_176
+  name: Impidimp
+  number: '176'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, SINGLE_STRIKE]
+  evolvesTo: [Morgrem]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Play Rough
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 30 more damage.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: sowsow
+- id: FILL_THIS-177
+  pioId: swsh8-177
+  enumId: MORGREM_177
+  name: Morgrem
+  number: '177'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION, SINGLE_STRIKE]
+  evolvesFrom: Impidimp
+  evolvesTo: [Grimmsnarl]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [D]
+    name: Bite
+    damage: '20'
+  - cost: [D, D]
+    name: Crushing Blow
+    damage: '40'
+    text: Flip a coin. If heads, discard an Energy from your opponent's Active Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: tetsuya koizumi
+- id: FILL_THIS-178
+  pioId: swsh8-178
+  enumId: GRIMMSNARL_178
+  name: Grimmsnarl
+  number: '178'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION, SINGLE_STRIKE]
+  evolvesFrom: Morgrem
+  hp: 170
+  retreatCost: 3
+  moves:
+  - cost: [D]
+    name: Bite
+    damage: '60'
+  - cost: [D, D]
+    name: Rear Attack
+    damage: 100+
+    text: If you have 2 or fewer Benched Pokémon, this attack does 140 more damage.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: kawayoo
+- id: FILL_THIS-179
+  pioId: swsh8-179
+  enumId: MORPEKO_179
+  name: Morpeko
+  number: '179'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, SINGLE_STRIKE]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Explosive Discontent
+    damage: 30x
+    text: This attack does 30 damage for each damage counter on this Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Teeziro
+- id: FILL_THIS-180
+  pioId: swsh8-180
+  enumId: GALARIAN_MEOWTH_180
+  name: Galarian Meowth
+  number: '180'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Persian]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [M]
+    name: Growl
+    text: During your opponent's next turn, the Defending Pokémon's attacks do 20
+      less damage (before applying Weakness and Resistance).
+  - cost: [C, C]
+    name: Slash
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Common
+  artist: '0313'
+- id: FILL_THIS-181
+  pioId: swsh8-181
+  enumId: GALARIAN_PERRSERKER_181
+  name: Galarian Perrserker
+  number: '181'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Galarian Meowth
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [M]
+    name: Call to Muster
+    text: Search your deck for up to 2 basic Energy cards and attach them to your
+      Pokémon in any way you like. Then, shuffle your deck.
+  - cost: [C, C, C]
+    name: Headbang
+    damage: '80'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Uncommon
+  artist: Shigenori Negishi
+- id: FILL_THIS-182
+  pioId: swsh8-182
+  enumId: SKARMORY_182
+  name: Skarmory
+  number: '182'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, SINGLE_STRIKE]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Steel Wing
+    damage: '30'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  - cost: [M, M, C]
+    name: Slicing Blade
+    damage: '110'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Common
+  artist: Megumi Higuchi
+- id: FILL_THIS-183
+  pioId: swsh8-183
+  enumId: EXCADRILL_183
+  name: Excadrill
+  number: '183'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Drilbur
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [M, C]
+    name: Metal Claw
+    damage: '50'
+  - cost: [M, M, C]
+    name: Rock Tomb
+    damage: '120'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Uncommon
+  artist: Lee HyunJung
+- id: FILL_THIS-184
+  pioId: swsh8-184
+  enumId: DURANT_184
+  name: Durant
+  number: '184'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C, C, C]
+    name: Adversity Jaws
+    damage: '70'
+    text: If your opponent's Active Pokémon is a [R] Pokémon, it is now Paralyzed.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Common
+  artist: Shin Nagasawa
+- id: FILL_THIS-185
+  pioId: swsh8-185
+  enumId: GENESECT_V_185
+  name: Genesect V
+  number: '185'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Fusion Strike System
+    text: Once during your turn, you may draw cards until you have as many cards in
+      your hand as you have Fusion Strike Pokémon in play.
+  moves:
+  - cost: [M, M, C]
+    name: Techno Blast
+    damage: '210'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Tsuji
+- id: FILL_THIS-186
+  pioId: swsh8-186
+  enumId: KLEFKI_186
+  name: Klefki
+  number: '186'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Unlock
+    damage: '10'
+    text: Draw 2 cards.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Common
+  artist: MAHOU
+- id: FILL_THIS-187
+  pioId: swsh8-187
+  enumId: TOGEDEMARU_187
+  name: Togedemaru
+  number: '187'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Let's All Rollout
+    damage: 20x
+    text: This attack does 20 damage for each of your Benched Pokémon that has the
+      Let's All Rollout attack.
+  - cost: [M, C, C]
+    name: Rolling Attack
+    damage: '50'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Uncommon
+  artist: Oswaldo KATO
+- id: FILL_THIS-188
+  pioId: swsh8-188
+  enumId: MELTAN_188
+  name: Meltan
+  number: '188'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, SINGLE_STRIKE]
+  evolvesTo: [Melmetal]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [M]
+    name: Iron Intake
+    text: Heal 30 damage from this Pokémon.
+  - cost: [C, C]
+    name: Headbutt
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Common
+  artist: Teeziro
+- id: FILL_THIS-189
+  pioId: swsh8-189
+  enumId: MELMETAL_189
+  name: Melmetal
+  number: '189'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION, SINGLE_STRIKE]
+  evolvesFrom: Meltan
+  hp: 150
+  retreatCost: 4
+  moves:
+  - cost: [M, C, C]
+    name: Ingot Swing
+    damage: '80'
+    text: During your opponent's next turn, prevent all damage done to this Pokémon
+      by attacks from Pokémon that have an Ability.
+  - cost: [M, M, C, C]
+    name: Blasting Hammer
+    damage: '150'
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  artist: Hasuno
+- id: FILL_THIS-190
+  pioId: swsh8-190
+  enumId: CORVIKNIGHT_190
+  name: Corviknight
+  number: '190'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Corvisquire
+  hp: 170
+  retreatCost: 2
+  moves:
+  - cost: [M]
+    name: Steel Wing
+    damage: '50'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  - cost: [M, C, C]
+    name: Power Cyclone
+    damage: '160'
+    text: Move an Energy from this Pokémon to 1 of your Benched Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Ryuta Fuse
+- id: FILL_THIS-191
+  pioId: swsh8-191
+  enumId: CUFANT_191
+  name: Cufant
+  number: '191'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, SINGLE_STRIKE]
+  evolvesTo: [Copperajah]
+  hp: 100
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Rollout
+    damage: '10'
+  - cost: [M, C, C]
+    name: High Horsepower
+    damage: '80'
+    text: This Pokémon also does 20 damage to itself.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Common
+  artist: Oswaldo KATO
+- id: FILL_THIS-192
+  pioId: swsh8-192
+  enumId: COPPERAJAH_192
+  name: Copperajah
+  number: '192'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION, SINGLE_STRIKE]
+  evolvesFrom: Cufant
+  hp: 190
+  retreatCost: 4
+  moves:
+  - cost: [M, C, C]
+    name: Strength
+    damage: '90'
+  - cost: [M, C, C, C]
+    name: High Horsepower
+    damage: '160'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Uncommon
+  artist: KEIICHIRO ITO
+- id: FILL_THIS-193
+  pioId: swsh8-193
+  enumId: LATIAS_193
+  name: Latias
+  number: '193'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Red Assist
+    text: Once during your turn, you may attach a [P] Energy card from your hand to
+      1 of your Latios.
+  moves:
+  - cost: [R, P, C]
+    name: Dyna Barrier
+    damage: '70'
+    text: During your opponent's next turn, prevent all damage done to this Pokémon
+      by attacks from Pokémon VMAX.
+  rarity: Rare
+  artist: Yuu Nishida
+- id: FILL_THIS-194
+  pioId: swsh8-194
+  enumId: LATIOS_194
+  name: Latios
+  number: '194'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Blue Assist
+    text: Once during your turn, you may attach a [P] Energy card from your hand to
+      1 of your Latias.
+  moves:
+  - cost: [W, W, P, C]
+    name: Luster Purge
+    damage: '210'
+    text: Discard 2 Energy from this Pokémon.
+  rarity: Rare
+  artist: hatachu
+- id: FILL_THIS-195
+  pioId: swsh8-195
+  enumId: GOOMY_195
+  name: Goomy
+  number: '195'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Sliggoo]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Tackle
+    damage: '10'
+  - cost: [W, P]
+    name: Melt
+    damage: '20'
+  rarity: Common
+  artist: Miki Tanaka
+- id: FILL_THIS-196
+  pioId: swsh8-196
+  enumId: SLIGGOO_196
+  name: Sliggoo
+  number: '196'
+  types: [N]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Goomy
+  evolvesTo: [Goodra]
+  hp: 80
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Melt
+    damage: '20'
+  - cost: [W, P]
+    name: Body Slam
+    damage: '50'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  rarity: Uncommon
+  artist: Saya Tsuruta
+- id: FILL_THIS-197
+  pioId: swsh8-197
+  enumId: GOODRA_197
+  name: Goodra
+  number: '197'
+  types: [N]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Sliggoo
+  hp: 160
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Slimy Room
+    text: As long as this Pokémon is in the Active Spot, whenever your opponent tries
+      to attach an Energy card from their hand to a Pokémon, they must flip a coin.
+      If tails, your opponent discards that Energy card instead of attaching it, and
+      this doesn't use up their Energy attachment for the turn.
+  moves:
+  - cost: [W, P]
+    name: Buster Tail
+    damage: '120'
+  rarity: Rare
+  artist: Nagomi Nijo
+- id: FILL_THIS-198
+  pioId: swsh8-198
+  enumId: TURTONATOR_198
+  name: Turtonator
+  number: '198'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [R, F]
+    name: Shell Trap
+    damage: '30'
+    text: During your opponent's next turn, if this Pokémon is damaged by an attack
+      (even if it is Knocked Out), put 8 damage counters on the Attacking Pokémon.
+  - cost: [C, C, C]
+    name: Heat Crash
+    damage: '80'
+  rarity: Uncommon
+  artist: Ryuta Fuse
+- id: FILL_THIS-199
+  pioId: swsh8-199
+  enumId: MEOWTH_199
+  name: Meowth
+  number: '199'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Persian]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Pay Day
+    damage: '10'
+    text: Draw a card.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Kouki Saitou
+- id: FILL_THIS-200
+  pioId: swsh8-200
+  enumId: PERSIAN_200
+  name: Persian
+  number: '200'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Meowth
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Pay Day
+    damage: '30'
+    text: Draw a card.
+  - cost: [C, C]
+    name: Bite
+    damage: '70'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: Lee HyunJung
+- id: FILL_THIS-201
+  pioId: swsh8-201
+  enumId: DODRIO_V_201
+  name: Dodrio V
+  number: '201'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V, RAPID_STRIKE]
+  hp: 200
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: No Reprieve
+    damage: '20'
+    text: During your next turn, this Pokémon's attacks do 80 more damage to your
+      opponent's Active Pokémon (before applying Weakness and Resistance).
+  - cost: [C, C, C]
+    name: Rampage Drill
+    damage: '160'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-202
+  pioId: swsh8-202
+  enumId: CHANSEY_202
+  name: Chansey
+  number: '202'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Blissey]
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Drain Slap
+    damage: '30'
+    text: Heal 30 damage from this Pokémon.
+  - cost: [C, C, C]
+    name: Gentle Slap
+    damage: '70'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: miki kudo
+- id: FILL_THIS-203
+  pioId: swsh8-203
+  enumId: BLISSEY_203
+  name: Blissey
+  number: '203'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Chansey
+  hp: 130
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Expert in Roundness
+    text: Prevent all damage done to each of your Pokémon that has the Let's All Rollout
+      attack by attacks from your opponent's Pokémon VMAX.
+  moves:
+  - cost: [C, C, C]
+    name: Let's All Rollout
+    damage: 20x
+    text: This attack does 20 damage for each of your Benched Pokémon that has the
+      Let's All Rollout attack.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Mizue
+- id: FILL_THIS-204
+  pioId: swsh8-204
+  enumId: KANGASKHAN_204
+  name: Kangaskhan
+  number: '204'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE]
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Pound
+    damage: '30'
+  - cost: [C, C, C]
+    name: Coordinated One-Two Punch
+    damage: 60+
+    text: Flip a coin. If heads, this attack does 100 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Souichirou Gunjima
+- id: FILL_THIS-205
+  pioId: swsh8-205
+  enumId: EEVEE_205
+  name: Eevee
+  number: '205'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Vaporeon, Jolteon, Flareon, Sylveon, Espeon, Umbreon, Leafeon, Glaceon]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Continuous Steps
+    damage: 30x
+    text: Flip a coin until you get tails. This attack does 30 damage for each heads.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: '0313'
+- id: FILL_THIS-206
+  pioId: swsh8-206
+  enumId: SNORLAX_206
+  name: Snorlax
+  number: '206'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 160
+  retreatCost: 3
+  moves:
+  - cost: [C, C, C]
+    name: Heavy Impact
+    damage: '80'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Oswaldo KATO
+- id: FILL_THIS-207
+  pioId: swsh8-207
+  enumId: DUNSPARCE_207
+  name: Dunsparce
+  number: '207'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Mysterious Nest
+    text: '[C] Pokémon in play (both yours and your opponent''s) have no Weakness.'
+  moves:
+  - cost: [C, C]
+    name: Rollout
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: ryoma uratsuka
+- id: FILL_THIS-208
+  pioId: swsh8-208
+  enumId: STANTLER_208
+  name: Stantler
+  number: '208'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Rear Kick
+    damage: '20'
+  - cost: [C, C]
+    name: Wild Dive
+    damage: 30x
+    text: This attack does 30 damage for each Energy attached to your opponent's Active
+      Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: Shibuzoh.
+- id: FILL_THIS-209
+  pioId: swsh8-209
+  enumId: SMEARGLE_209
+  name: Smeargle
+  number: '209'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Sketching Trash
+    text: Put up to 2 Fusion Strike Trainer cards from your discard pile into your
+      hand.
+  - cost: [C, C, C]
+    name: Tail Whap
+    damage: '80'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Mitsuhiro Arita
+- id: FILL_THIS-210
+  pioId: swsh8-210
+  enumId: SKITTY_210
+  name: Skitty
+  number: '210'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Delcatty]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Whimsy Tackle
+    damage: '30'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Yukiko Baba
+- id: FILL_THIS-211
+  pioId: swsh8-211
+  enumId: DELCATTY_211
+  name: Delcatty
+  number: '211'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Skitty
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Willful Busybody
+    text: Your opponent reveals their hand. Choose a card you find there and put it
+      on the bottom of their deck.
+  - cost: [C, C]
+    name: Double Slap
+    damage: 50x
+    text: Flip 2 coins. This attack does 50 damage for each heads.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: kirisAki
+- id: FILL_THIS-212
+  pioId: swsh8-212
+  enumId: BUNEARY_212
+  name: Buneary
+  number: '212'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE]
+  evolvesTo: [Lopunny]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Double Kick
+    damage: 20x
+    text: Flip 2 coins. This attack does 20 damage for each heads.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Yuu Nishida
+- id: FILL_THIS-213
+  pioId: swsh8-213
+  enumId: LOPUNNY_213
+  name: Lopunny
+  number: '213'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION, RAPID_STRIKE]
+  evolvesFrom: Buneary
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Hopping Shot
+    damage: '70'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: AKIRA EGAWA
+- id: FILL_THIS-214
+  pioId: swsh8-214
+  enumId: BUNNELBY_214
+  name: Bunnelby
+  number: '214'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Diggersby]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Find a Friend
+    text: Search your deck for a Pokémon, reveal it, and put it into your hand. Then,
+      shuffle your deck.
+  - cost: [C, C]
+    name: Take Down
+    damage: '30'
+    text: This Pokémon also does 10 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Misa Tsutsui
+- id: FILL_THIS-215
+  pioId: swsh8-215
+  enumId: DIGGERSBY_215
+  name: Diggersby
+  number: '215'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Bunnelby
+  hp: 140
+  retreatCost: 4
+  moves:
+  - cost: [C, C, C]
+    name: Hammer In
+    damage: '80'
+  - cost: [C, C, C, C]
+    name: Take Down
+    damage: '150'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: MAHOU
+- id: FILL_THIS-216
+  pioId: swsh8-216
+  enumId: HAWLUCHA_216
+  name: Hawlucha
+  number: '216'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Flying Stomp
+    damage: '20'
+    text: Discard a Special Energy from your opponent's Active Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Taira Akitsu
+- id: FILL_THIS-217
+  pioId: swsh8-217
+  enumId: GREEDENT_V_217
+  name: Greedent V
+  number: '217'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Body Slam
+    damage: '40'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [C, C, C]
+    name: Nom-Nom-Nom Incisors
+    damage: '120'
+    text: Draw 3 cards.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Yamashita
+- id: FILL_THIS-218
+  pioId: swsh8-218
+  enumId: GREEDENT_VMAX_218
+  name: Greedent VMAX
+  number: '218'
+  types: [C]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Greedent V
+  hp: 320
+  retreatCost: 3
+  moves:
+  - cost: [C, C]
+    name: Turn a Profit
+    damage: '30'
+    text: If your opponent's Basic Pokémon is Knocked Out by damage from this attack,
+      take 2 more Prize cards.
+  - cost: [C, C, C]
+    name: Max Gimme Gimme
+    damage: '160'
+    text: Draw 3 cards.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: PLANETA Mochizuki
+- id: FILL_THIS-219
+  pioId: swsh8-219
+  enumId: ROOKIDEE_219
+  name: Rookidee
+  number: '219'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Corvisquire]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Fury Attack
+    damage: 10x
+    text: Flip 3 coins. This attack does 10 damage for each heads.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: OKACHEKE
+- id: FILL_THIS-220
+  pioId: swsh8-220
+  enumId: CORVISQUIRE_220
+  name: Corvisquire
+  number: '220'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Rookidee
+  evolvesTo: [Corviknight]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Fury Attack
+    damage: 30x
+    text: Flip 3 coins. This attack does 30 damage for each heads.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Naoyo Kimura
+- id: FILL_THIS-221
+  pioId: swsh8-221
+  enumId: WOOLOO_221
+  name: Wooloo
+  number: '221'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Dubwool]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Derail
+    damage: '10'
+    text: Discard a Special Energy from your opponent's Active Pokémon.
+  - cost: [C, C]
+    name: Let's All Rollout
+    damage: 20x
+    text: This attack does 20 damage for each of your Benched Pokémon that has the
+      Let's All Rollout attack.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Miki Tanaka
+- id: FILL_THIS-222
+  pioId: swsh8-222
+  enumId: WOOLOO_222
+  name: Wooloo
+  number: '222'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Dubwool]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Knock Away
+    damage: 20+
+    text: Flip a coin. If heads, this attack does 40 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Yukiko Baba
+- id: FILL_THIS-223
+  pioId: swsh8-223
+  enumId: DUBWOOL_223
+  name: Dubwool
+  number: '223'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Wooloo
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Bounce
+    damage: '30'
+    text: You may switch this Pokémon with 1 of your Benched Pokémon.
+  - cost: [C, C]
+    name: Rolling Tackle
+    damage: '70'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: Shibuzoh.
+- id: FILL_THIS-224
+  pioId: swsh8-224
+  enumId: ADVENTURER_S_DISCOVERY_224
+  name: Adventurer's Discovery
+  number: '224'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Search your deck for up to 3 Pokémon V, reveal them, and put them into your hand.
+    Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Taira Akitsu
+- id: FILL_THIS-225
+  pioId: swsh8-225
+  enumId: BATTLE_VIP_PASS_225
+  name: Battle VIP Pass
+  number: '225'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - You can use this card only during your first turn.
+  - Search your deck for up to 2 Basic Pokémon and put them onto your Bench. Then,
+    shuffle your deck.
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Ryo Ueda
+- id: FILL_THIS-226
+  pioId: swsh8-226
+  enumId: BUG_CATCHER_226
+  name: Bug Catcher
+  number: '226'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Draw 2 cards. Flip a coin. If heads, draw 2 more cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yuu Nishida
+- id: FILL_THIS-227
+  pioId: swsh8-227
+  enumId: CHILI_CILAN_CRESS_227
+  name: Chili & Cilan & Cress
+  number: '227'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Search your deck for up to 3 Fusion Strike Pokémon, reveal them, and put them
+    into your hand. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yusuke Ohmura
+- id: FILL_THIS-228
+  pioId: swsh8-228
+  enumId: COOK_228
+  name: Cook
+  number: '228'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Heal 70 damage from your Active Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Sanosuke Sakuma
+- id: FILL_THIS-229
+  pioId: swsh8-229
+  enumId: CRAM_O_MATIC_229
+  name: Cram-o-matic
+  number: '229'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - You can use this card only if you discard another Item card from your hand. Flip
+    a coin. If heads, search your deck for a card and put it into your hand. Then,
+    shuffle your deck.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Ryo Ueda
+- id: FILL_THIS-230
+  pioId: swsh8-230
+  enumId: CROSS_SWITCHER_230
+  name: Cross Switcher
+  number: '230'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - You must play 2 Cross Switcher cards at once. (This effect works one time for
+    2 cards.)
+  - Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. If you
+    do, switch your Active Pokémon with 1 of your Benched Pokémon.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: inose yukie
+- id: FILL_THIS-231
+  pioId: swsh8-231
+  enumId: CROSSCEIVER_231
+  name: Crossceiver
+  number: '231'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - You must play 2 Crossceiver cards at once. (This effect works one time for 2 cards.)
+  - Put a Pokémon or a Supporter card from your discard pile into your hand.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Studio Bora Inc.
+- id: FILL_THIS-232
+  pioId: swsh8-232
+  enumId: DANCER_232
+  name: Dancer
+  number: '232'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Draw 2 cards. If you go second and it's your first turn, draw 3 more cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Sanosuke Sakuma
+- id: FILL_THIS-233
+  pioId: swsh8-233
+  enumId: ELESA_S_SPARKLE_233
+  name: Elesa's Sparkle
+  number: '233'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Choose up to 2 of your Fusion Strike Pokémon. For each of those Pokémon, search
+    your deck for a Fusion Strike Energy card and attach it to that Pokémon. Then,
+    shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yusuke Ohmura
+- id: FILL_THIS-234
+  pioId: swsh8-234
+  enumId: FAREWELL_BELL_234
+  name: Farewell Bell
+  number: '234'
+  superType: TRAINER
+  subTypes: [ITEM, ITEM, POKEMON_TOOL]
+  rarity: Uncommon
+  text:
+  - If the Pokémon VMAX this card is attached to is Knocked Out by damage from an
+    attack from your opponent's Pokémon, search your deck for a card and put it into
+    your hand. Then, shuffle your deck.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
+    have a Pokémon Tool attached.'
+  artist: AYUMI ODASHIMA
+- id: FILL_THIS-235
+  pioId: swsh8-235
+  enumId: JUDGE_235
+  name: Judge
+  number: '235'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Each player shuffles their hand into their deck and draws 4 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Ryuta Fuse
+- id: FILL_THIS-236
+  pioId: swsh8-236
+  enumId: POWER_TABLET_236
+  name: Power Tablet
+  number: '236'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - During this turn, your Fusion Strike Pokémon's attacks do 30 more damage to your
+    opponent's Active Pokémon (before applying Weakness and Resistance).
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Toyste Beach
+- id: FILL_THIS-237
+  pioId: swsh8-237
+  enumId: QUICK_BALL_237
+  name: Quick Ball
+  number: '237'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - You can play this card only if you discard another card from your hand. Search
+    your deck for a Basic Pokémon, reveal it, and put it into your hand. Then, shuffle
+    your deck.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Ryo Ueda
+- id: FILL_THIS-238
+  pioId: swsh8-238
+  enumId: SCHOOLBOY_238
+  name: Schoolboy
+  number: '238'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Draw 2 cards. If your opponent has exactly 1, 3, or 5 Prize cards remaining, draw
+    2 more cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: kirisAki
+- id: FILL_THIS-239
+  pioId: swsh8-239
+  enumId: SCHOOLGIRL_239
+  name: Schoolgirl
+  number: '239'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Draw 2 cards. If your opponent has exactly 2, 4, or 6 Prize cards remaining, draw
+    2 more cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: kirisAki
+- id: FILL_THIS-240
+  pioId: swsh8-240
+  enumId: SHAUNA_240
+  name: Shauna
+  number: '240'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Shuffle your hand into your deck. Then, draw 5 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yuu Nishida
+- id: FILL_THIS-241
+  pioId: swsh8-241
+  enumId: SIDNEY_241
+  name: Sidney
+  number: '241'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Your opponent reveals their hand. Discard up to 2 in any combination of Pokémon
+    Tool cards, Special Energy cards, and Stadium cards from it.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hideki Ishikawa
+- id: FILL_THIS-242
+  pioId: swsh8-242
+  enumId: SKATERS_PARK_242
+  name: Skaters' Park
+  number: '242'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Uncommon
+  text:
+  - Whenever either player's Active Pokémon retreats, put any basic Energy that would
+    be discarded into their hand instead of the discard pile.
+  artist: Oswaldo KATO
+- id: FILL_THIS-243
+  pioId: swsh8-243
+  enumId: SPONGY_GLOVES_243
+  name: Spongy Gloves
+  number: '243'
+  superType: TRAINER
+  subTypes: [ITEM, ITEM, POKEMON_TOOL]
+  rarity: Uncommon
+  text:
+  - The attacks of the Pokémon this card is attached to do 30 more damage to your
+    opponent's Active [W] Pokémon (before applying Weakness and Resistance).
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
+    have a Pokémon Tool attached.'
+  artist: Toyste Beach
+- id: FILL_THIS-244
+  pioId: swsh8-244
+  enumId: FUSION_STRIKE_ENERGY_244
+  name: Fusion Strike Energy
+  number: '244'
+  superType: ENERGY
+  subTypes: [SPECIAL_ENERGY]
+  rarity: Uncommon
+  text:
+  - This card can only be attached to a Fusion Strike Pokémon. If this card is attached
+    to anything other than a Fusion Strike Pokémon, discard this card. As long as
+    this card is attached to a Pokémon, it provides every type of Energy but provides
+    only 1 Energy at a time. Prevent all effects of your opponent's Pokémon's Abilities
+    done to the Pokémon this card is attached to.
+  artist: n/a
+- id: FILL_THIS-245
+  pioId: swsh8-245
+  enumId: CELEBI_V_245
+  name: Celebi V
+  number: '245'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Leaflet Dance
+    text: Attach any number of [G] Energy cards from your hand to your Pokémon in
+      any way you like.
+  - cost: [G, C]
+    name: Slash Back
+    damage: '60'
+    text: Switch this Pokémon with 1 of your Benched Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Teeziro
+- id: FILL_THIS-246
+  pioId: swsh8-246
+  enumId: TSAREENA_V_246
+  name: Tsareena V
+  number: '246'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 2
+  moves:
+  - cost: [G, C]
+    name: Queen's Orders
+    damage: 20+
+    text: You may discard any number of your Benched Pokémon. This attack does 40
+      more damage for each Benched Pokémon you discarded in this way.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+  variantOf: FILL_THIS-21
+  variantType: Full Art
+- id: FILL_THIS-247
+  pioId: swsh8-247
+  enumId: CHANDELURE_V_247
+  name: Chandelure V
+  number: '247'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 2
+  moves:
+  - cost: [R]
+    name: Confuse Ray
+    text: Your opponent's Active Pokémon is now Confused.
+  - cost: [R, C]
+    name: Poltergeist
+    damage: 40x
+    text: Your opponent reveals their hand. This attack does 40 damage for each Trainer
+      card you find there.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Saki Hayashiro
+  variantOf: FILL_THIS-39
+  variantType: Full Art
+- id: FILL_THIS-248
+  pioId: swsh8-248
+  enumId: CRABOMINABLE_V_248
+  name: Crabominable V
+  number: '248'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 4
+  moves:
+  - cost: [W]
+    name: Trigger Avalanche
+    text: Discard the top 2 cards of your opponent's deck.
+  - cost: [W, W, C]
+    name: Destroyer Punch
+    damage: 90+
+    text: This attack does 60 more damage for each damage counter on your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: MUGENUP
+  variantOf: FILL_THIS-76
+  variantType: Full Art
+- id: FILL_THIS-249
+  pioId: swsh8-249
+  enumId: BOLTUND_V_249
+  name: Boltund V
+  number: '249'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Smash Turn
+    damage: '30'
+    text: You may switch this Pokémon with 1 of your Benched Pokémon.
+  - cost: [L, L, C]
+    name: Electrobullet
+    damage: '120'
+    text: This attack also does 30 damage to 1 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Eske Yoshinob
+  variantOf: FILL_THIS-103
+  variantType: Full Art
+- id: FILL_THIS-250
+  pioId: swsh8-250
+  enumId: MEW_V_250
+  name: Mew V
+  number: '250'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 180
+  moves:
+  - cost: [P]
+    name: Energy Mix
+    text: Search your deck for an Energy card and attach it to 1 of your Fusion Strike
+      Pokémon. Then, shuffle your deck.
+  - cost: [P, C]
+    name: Psychic Leap
+    damage: '70'
+    text: You may shuffle this Pokémon and all attached cards into your deck.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+  variantOf: FILL_THIS-113
+  variantType: Full Art
+- id: FILL_THIS-251
+  pioId: swsh8-251
+  enumId: MEW_V_251
+  name: Mew V
+  number: '251'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 180
+  moves:
+  - cost: [P]
+    name: Energy Mix
+    text: Search your deck for an Energy card and attach it to 1 of your Fusion Strike
+      Pokémon. Then, shuffle your deck.
+  - cost: [P, C]
+    name: Psychic Leap
+    damage: '70'
+    text: You may shuffle this Pokémon and all attached cards into your deck.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Naoki Saito
+  variantOf: FILL_THIS-113
+  variantType: Full Art
+- id: FILL_THIS-252
+  pioId: swsh8-252
+  enumId: SANDACONDA_V_252
+  name: Sandaconda V
+  number: '252'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Wall of Sand
+    text: This Pokémon takes 30 less damage from attacks (after applying Weakness
+      and Resistance).
+  moves:
+  - cost: [F, F, C]
+    name: Land Crush
+    damage: '140'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Narumi Sato
+- id: FILL_THIS-253
+  pioId: swsh8-253
+  enumId: HOOPA_V_253
+  name: Hoopa V
+  number: '253'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Two-Faced
+    text: As long as this Pokémon is in play, it is Psychic and Darkness type.
+  moves:
+  - cost: [D, D, C]
+    name: Shadow Impact
+    damage: '170'
+    text: Put 3 damage counters on 1 of your Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: takuyoa
+- id: FILL_THIS-254
+  pioId: swsh8-254
+  enumId: GENESECT_V_254
+  name: Genesect V
+  number: '254'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Fusion Strike System
+    text: Once during your turn, you may draw cards until you have as many cards in
+      your hand as you have Fusion Strike Pokémon in play.
+  moves:
+  - cost: [M, M, C]
+    name: Techno Blast
+    damage: '210'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Tsuji
+  variantOf: FILL_THIS-185
+  variantType: Full Art
+- id: FILL_THIS-255
+  pioId: swsh8-255
+  enumId: GENESECT_V_255
+  name: Genesect V
+  number: '255'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Fusion Strike System
+    text: Once during your turn, you may draw cards until you have as many cards in
+      your hand as you have Fusion Strike Pokémon in play.
+  moves:
+  - cost: [M, M, C]
+    name: Techno Blast
+    damage: '210'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Akira Komayama
+  variantOf: FILL_THIS-185
+  variantType: Full Art
+- id: FILL_THIS-256
+  pioId: swsh8-256
+  enumId: GREEDENT_V_256
+  name: Greedent V
+  number: '256'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Body Slam
+    damage: '40'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [C, C, C]
+    name: Nom-Nom-Nom Incisors
+    damage: '120'
+    text: Draw 3 cards.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+  variantOf: FILL_THIS-217
+  variantType: Full Art
+- id: FILL_THIS-257
+  pioId: swsh8-257
+  enumId: GREEDENT_V_257
+  name: Greedent V
+  number: '257'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Body Slam
+    damage: '40'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [C, C, C]
+    name: Nom-Nom-Nom Incisors
+    damage: '120'
+    text: Draw 3 cards.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Saya Tsuruta
+  variantOf: FILL_THIS-217
+  variantType: Full Art
+- id: FILL_THIS-258
+  pioId: swsh8-258
+  enumId: CHILI_CILAN_CRESS_258
+  name: Chili & Cilan & Cress
+  number: '258'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Search your deck for up to 3 Fusion Strike Pokémon, reveal them, and put them
+    into your hand. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Sanosuke Sakuma
+  variantOf: FILL_THIS-227
+  variantType: Full Art
+- id: FILL_THIS-259
+  pioId: swsh8-259
+  enumId: DANCER_259
+  name: Dancer
+  number: '259'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 2 cards. If you go second and it's your first turn, draw 3 more cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yuu Nishida
+  variantOf: FILL_THIS-232
+  variantType: Full Art
+- id: FILL_THIS-260
+  pioId: swsh8-260
+  enumId: ELESA_S_SPARKLE_260
+  name: Elesa's Sparkle
+  number: '260'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Choose up to 2 of your Fusion Strike Pokémon. For each of those Pokémon, search
+    your deck for a Fusion Strike Energy card and attach it to that Pokémon. Then,
+    shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Ryuta Fuse
+  variantOf: FILL_THIS-233
+  variantType: Full Art
+- id: FILL_THIS-261
+  pioId: swsh8-261
+  enumId: SCHOOLBOY_261
+  name: Schoolboy
+  number: '261'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 2 cards. If your opponent has exactly 1, 3, or 5 Prize cards remaining, draw
+    2 more cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hideki Ishikawa
+  variantOf: FILL_THIS-238
+  variantType: Full Art
+- id: FILL_THIS-262
+  pioId: swsh8-262
+  enumId: SCHOOLGIRL_262
+  name: Schoolgirl
+  number: '262'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 2 cards. If your opponent has exactly 2, 4, or 6 Prize cards remaining, draw
+    2 more cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hideki Ishikawa
+  variantOf: FILL_THIS-239
+  variantType: Full Art
+- id: FILL_THIS-263
+  pioId: swsh8-263
+  enumId: SHAUNA_263
+  name: Shauna
+  number: '263'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Shuffle your hand into your deck. Then, draw 5 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yuu Nishida
+  variantOf: FILL_THIS-240
+  variantType: Full Art
+- id: FILL_THIS-264
+  pioId: swsh8-264
+  enumId: SIDNEY_264
+  name: Sidney
+  number: '264'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Your opponent reveals their hand. Discard up to 2 in any combination of Pokémon
+    Tool cards, Special Energy cards, and Stadium cards from it.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hideki Ishikawa
+  variantOf: FILL_THIS-241
+  variantType: Full Art
+- id: FILL_THIS-265
+  pioId: swsh8-265
+  enumId: CHANDELURE_VMAX_265
+  name: Chandelure VMAX
+  number: '265'
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Chandelure V
+  hp: 320
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Cursed Shimmer
+    text: As long as this Pokémon is in the Active Spot, your opponent can't play
+      any Pokémon Tool cards from their hand.
+  moves:
+  - cost: [R, C]
+    name: Max Poltergeist
+    damage: 70x
+    text: Your opponent reveals their hand. This attack does 70 damage for each Trainer
+      card you find there.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: AKIRA EGAWA
+  variantOf: FILL_THIS-40
+  variantType: Full Art
+- id: FILL_THIS-266
+  pioId: swsh8-266
+  enumId: INTELEON_VMAX_266
+  name: Inteleon VMAX
+  number: '266'
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX, RAPID_STRIKE]
+  evolvesFrom: Inteleon V
+  hp: 320
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Double Gunner
+    text: You must discard a [W] Energy card from your hand in order to use this Ability.
+      Once during your turn, you may choose 2 of your opponent's Benched Pokémon and
+      put 2 damage counters on each of them.
+  moves:
+  - cost: [W, C]
+    name: G-Max Spiral
+    damage: 70+
+    text: You may put an Energy attached to this Pokémon into your hand. If you do,
+      this attack does 70 more damage.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: Kazuma Koda
+  variantOf: FILL_THIS-79
+  variantType: Full Art
+- id: FILL_THIS-267
+  pioId: swsh8-267
+  enumId: BOLTUND_VMAX_267
+  name: Boltund VMAX
+  number: '267'
+  types: [L]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Boltund V
+  hp: 320
+  retreatCost: 2
+  moves:
+  - cost: [L, C]
+    name: Bolt Storm
+    damage: 30+
+    text: This attack does 30 more damage for each [L] Energy attached to all of your
+      Pokémon.
+  - cost: [L, L, C]
+    name: Max Bolt
+    damage: '230'
+    text: During your next turn, this Pokémon can't use Max Bolt.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: PLANETA Tsuji
+  variantOf: FILL_THIS-104
+  variantType: Full Art
+- id: FILL_THIS-268
+  pioId: swsh8-268
+  enumId: MEW_VMAX_268
+  name: Mew VMAX
+  number: '268'
+  types: [P]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Mew V
+  hp: 310
+  moves:
+  - cost: [C, C]
+    name: Cross Fusion Strike
+    text: Choose 1 of your Benched Fusion Strike Pokémon's attacks and use it as this
+      attack.
+  - cost: [P, P]
+    name: Max Miracle
+    damage: '130'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-114
+  variantType: Full Art
+- id: FILL_THIS-269
+  pioId: swsh8-269
+  enumId: MEW_VMAX_269
+  name: Mew VMAX
+  number: '269'
+  types: [P]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Mew V
+  hp: 310
+  moves:
+  - cost: [C, C]
+    name: Cross Fusion Strike
+    text: Choose 1 of your Benched Fusion Strike Pokémon's attacks and use it as this
+      attack.
+  - cost: [P, P]
+    name: Max Miracle
+    damage: '130'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: AKIRA EGAWA
+  variantOf: FILL_THIS-114
+  variantType: Full Art
+- id: FILL_THIS-270
+  pioId: swsh8-270
+  enumId: ESPEON_VMAX_270
+  name: Espeon VMAX
+  number: '270'
+  types: [P]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Espeon V
+  hp: 310
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Solar Revelation
+    text: Prevent all effects of attacks from your opponent's Pokémon done to all
+      of your Pokémon that have Energy attached.(Existing effects are not removed.
+      Damage is not an effect.)
+  moves:
+  - cost: [P, C, C]
+    name: Max Mindstorm
+    damage: 60x
+    text: This attack does 60 damage for each Energy attached to all of your opponent's
+      Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: Kouki Saitou
+- id: FILL_THIS-271
+  pioId: swsh8-271
+  enumId: GENGAR_VMAX_271
+  name: Gengar VMAX
+  number: '271'
+  types: [D]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX, SINGLE_STRIKE]
+  evolvesFrom: Gengar V
+  hp: 320
+  retreatCost: 3
+  moves:
+  - cost: [D, D]
+    name: Fear and Panic
+    damage: 60x
+    text: This attack does 60 damage for each of your opponent's Pokémon V and Pokémon-GX
+      in play.
+  - cost: [D, D, D]
+    name: G-Max Swallow Up
+    damage: '250'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: sowsow
+  variantOf: FILL_THIS-157
+  variantType: Full Art
+- id: FILL_THIS-272
+  pioId: swsh8-272
+  enumId: GREEDENT_VMAX_272
+  name: Greedent VMAX
+  number: '272'
+  types: [C]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Greedent V
+  hp: 320
+  retreatCost: 3
+  moves:
+  - cost: [C, C]
+    name: Turn a Profit
+    damage: '30'
+    text: If your opponent's Basic Pokémon is Knocked Out by damage from this attack,
+      take 2 more Prize cards.
+  - cost: [C, C, C]
+    name: Max Gimme Gimme
+    damage: '160'
+    text: Draw 3 cards.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: PLANETA Mochizuki
+  variantOf: FILL_THIS-218
+  variantType: Full Art
+- id: FILL_THIS-273
+  pioId: swsh8-273
+  enumId: CHILI_CILAN_CRESS_273
+  name: Chili & Cilan & Cress
+  number: '273'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Search your deck for up to 3 Fusion Strike Pokémon, reveal them, and put them
+    into your hand. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Sanosuke Sakuma
+  variantOf: FILL_THIS-227
+  variantType: Full Art
+- id: FILL_THIS-274
+  pioId: swsh8-274
+  enumId: DANCER_274
+  name: Dancer
+  number: '274'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 2 cards. If you go second and it's your first turn, draw 3 more cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yuu Nishida
+  variantOf: FILL_THIS-232
+  variantType: Full Art
+- id: FILL_THIS-275
+  pioId: swsh8-275
+  enumId: ELESA_S_SPARKLE_275
+  name: Elesa's Sparkle
+  number: '275'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Choose up to 2 of your Fusion Strike Pokémon. For each of those Pokémon, search
+    your deck for a Fusion Strike Energy card and attach it to that Pokémon. Then,
+    shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Ryuta Fuse
+  variantOf: FILL_THIS-233
+  variantType: Full Art
+- id: FILL_THIS-276
+  pioId: swsh8-276
+  enumId: SCHOOLBOY_276
+  name: Schoolboy
+  number: '276'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 2 cards. If your opponent has exactly 1, 3, or 5 Prize cards remaining, draw
+    2 more cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hideki Ishikawa
+  variantOf: FILL_THIS-238
+  variantType: Full Art
+- id: FILL_THIS-277
+  pioId: swsh8-277
+  enumId: SCHOOLGIRL_277
+  name: Schoolgirl
+  number: '277'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 2 cards. If your opponent has exactly 2, 4, or 6 Prize cards remaining, draw
+    2 more cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hideki Ishikawa
+  variantOf: FILL_THIS-239
+  variantType: Full Art
+- id: FILL_THIS-278
+  pioId: swsh8-278
+  enumId: SHAUNA_278
+  name: Shauna
+  number: '278'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Shuffle your hand into your deck. Then, draw 5 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yuu Nishida
+  variantOf: FILL_THIS-240
+  variantType: Full Art
+- id: FILL_THIS-279
+  pioId: swsh8-279
+  enumId: SIDNEY_279
+  name: Sidney
+  number: '279'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Your opponent reveals their hand. Discard up to 2 in any combination of Pokémon
+    Tool cards, Special Energy cards, and Stadium cards from it.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hideki Ishikawa
+  variantOf: FILL_THIS-241
+  variantType: Full Art
+- id: FILL_THIS-280
+  pioId: swsh8-280
+  enumId: FLAAFFY_280
+  name: Flaaffy
+  number: '280'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Mareep
+  evolvesTo: [Ampharos]
+  hp: 90
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Dynamotor
+    text: Once during your turn (before your attack), you may attach a [L] Energy
+      card from your discard pile to 1 of your Benched Pokémon.
+  moves:
+  - cost: [L, L, C]
+    name: Electro Ball
+    damage: '50'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Secret
+  artist: Studio Bora Inc.
+- id: FILL_THIS-281
+  pioId: swsh8-281
+  enumId: POWER_TABLET_281
+  name: Power Tablet
+  number: '281'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Secret
+  text:
+  - During this turn, your Fusion Strike Pokémon's attacks do 30 more damage to your
+    opponent's Active Pokémon (before applying Weakness and Resistance).
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Toyste Beach
+  variantOf: FILL_THIS-236
+  variantType: Secret Art
+- id: FILL_THIS-282
+  pioId: swsh8-282
+  enumId: TRAINING_COURT_282
+  name: Training Court
+  number: '282'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Secret
+  text:
+  - Once during each player's turn, that player may put a basic Energy card from their
+    discard pile into their hand.
+  artist: 5ban Graphics
+- id: FILL_THIS-283
+  pioId: swsh8-283
+  enumId: GRASS_ENERGY_283
+  name: Grass Energy
+  number: '283'
+  superType: ENERGY
+  subTypes: [BASIC_ENERGY]
+  rarity: Secret
+  energy: [[G]]
+  artist: n/a
+- id: FILL_THIS-284
+  pioId: swsh8-284
+  enumId: FIRE_ENERGY_284
+  name: Fire Energy
+  number: '284'
+  superType: ENERGY
+  subTypes: [BASIC_ENERGY]
+  rarity: Secret
+  energy: [[R]]
+  artist: n/a

--- a/data/src/main/resources/cards/440-fusion_strike.yaml
+++ b/data/src/main/resources/cards/440-fusion_strike.yaml
@@ -1,3 +1,4 @@
+schema: E2
 id: '440'
 name: swsh8
 enumId: Fusion Strike

--- a/data/src/main/resources/cards/440-fusion_strike.yaml
+++ b/data/src/main/resources/cards/440-fusion_strike.yaml
@@ -5645,7 +5645,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Mochizuki
-  variantOf: FILL_THIS-21
+  variantOf: 440-21
   variantType: Full Art
 - id: 440-247
   pioId: swsh8-247
@@ -5673,7 +5673,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Saki Hayashiro
-  variantOf: FILL_THIS-39
+  variantOf: 440-39
   variantType: Full Art
 - id: 440-248
   pioId: swsh8-248
@@ -5701,7 +5701,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: MUGENUP
-  variantOf: FILL_THIS-76
+  variantOf: 440-76
   variantType: Full Art
 - id: 440-249
   pioId: swsh8-249
@@ -5730,7 +5730,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Eske Yoshinob
-  variantOf: FILL_THIS-103
+  variantOf: 440-103
   variantType: Full Art
 - id: 440-250
   pioId: swsh8-250
@@ -5760,7 +5760,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: aky CG Works
-  variantOf: FILL_THIS-113
+  variantOf: 440-113
   variantType: Full Art
 - id: 440-251
   pioId: swsh8-251
@@ -5790,7 +5790,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Naoki Saito
-  variantOf: FILL_THIS-113
+  variantOf: 440-113
   variantType: Full Art
 - id: 440-252
   pioId: swsh8-252
@@ -5874,7 +5874,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Tsuji
-  variantOf: FILL_THIS-185
+  variantOf: 440-185
   variantType: Full Art
 - id: 440-255
   pioId: swsh8-255
@@ -5906,7 +5906,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Akira Komayama
-  variantOf: FILL_THIS-185
+  variantOf: 440-185
   variantType: Full Art
 - id: 440-256
   pioId: swsh8-256
@@ -5934,7 +5934,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Mochizuki
-  variantOf: FILL_THIS-217
+  variantOf: 440-217
   variantType: Full Art
 - id: 440-257
   pioId: swsh8-257
@@ -5962,7 +5962,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Saya Tsuruta
-  variantOf: FILL_THIS-217
+  variantOf: 440-217
   variantType: Full Art
 - id: 440-258
   pioId: swsh8-258

--- a/data/src/main/resources/cards/441-brilliant_stars.yaml
+++ b/data/src/main/resources/cards/441-brilliant_stars.yaml
@@ -4344,3 +4344,762 @@ cards:
   artist: sadaji
   variantOf: FILL_THIS-150
   variantType: Secret Art
+- id: 441-TG01
+  pioId: swsh10tg-TG01
+  enumId: ABOMASNOW_TG01
+  name: Abomasnow
+  number: TG01
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION, SINGLE_STRIKE]
+  evolvesFrom: Snover
+  hp: 140
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Toughness Boost
+    text: Your Single Strike Pokémon in play, except any Abomasnow, get +50 HP. You
+      can't apply more than 1 Toughness Boost Ability at a time.
+  moves:
+  - cost: [G, C, C]
+    name: Mega Punch
+    damage: '90'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  artist: Mitsuhiro Arita
+- id: 441-TG02
+  pioId: swsh10tg-TG02
+  enumId: FLAPPLE_TG02
+  name: Flapple
+  number: TG02
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Applin
+  hp: 80
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Apple Drop
+    text: Once during your turn, you may put 2 damage counters on 1 of your opponent's
+      Pokémon. If you placed any damage counters in this way, shuffle this Pokémon
+      and all attached cards into your deck.
+  moves:
+  - cost: [C, C]
+    name: Acid Spray
+    damage: '60'
+    text: Flip a coin. If heads, discard an Energy from your opponent's Active Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  artist: Misaki Hashimoto
+- id: 441-TG03
+  pioId: swsh10tg-TG03
+  enumId: KINGDRA_TG03
+  name: Kingdra
+  number: TG03
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Seadra
+  hp: 150
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Deep Sea King
+    text: When your Active Pokémon is Knocked Out by damage from an attack from your
+      opponent's Pokémon, you may move any amount of [W] Energy from that Pokémon
+      to this Pokémon.
+  moves:
+  - cost: [W]
+    name: Aqua Burst
+    damage: 40x
+    text: This attack does 40 damage for each [W] Energy attached to this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  artist: Taira Akitsu
+- id: 441-TG04
+  pioId: swsh10tg-TG04
+  enumId: FROSMOTH_TG04
+  name: Frosmoth
+  number: TG04
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Snom
+  hp: 90
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Ice Dance
+    text: As often as you like during your turn, you may attach a [W] Energy card
+      from your hand to 1 of your Benched [W] Pokémon.
+  moves:
+  - cost: [W, C]
+    name: Aurora Beam
+    damage: '30'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  artist: aoki
+- id: 441-TG05
+  pioId: swsh10tg-TG05
+  enumId: GARDEVOIR_TG05
+  name: Gardevoir
+  number: TG05
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Kirlia
+  hp: 140
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Shining Arcana
+    text: Once during your turn, you may look at the top 2 cards of your deck and
+      attach any number of basic Energy cards you find there to your Pokémon in any
+      way you like. Put the other cards into your hand.
+  moves:
+  - cost: [C, C, C]
+    name: Brainwave
+    damage: 60+
+    text: This attack does 30 more damage for each [P] Energy attached to this Pokémon.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  artist: Sanosuke Sakuma
+- id: 441-TG06
+  pioId: swsh10tg-TG06
+  enumId: WYRDEER_TG06
+  name: Wyrdeer
+  number: TG06
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Stantler
+  hp: 140
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Hurried Gait
+    text: Once during your turn, you may draw a card.
+  moves:
+  - cost: [C, C]
+    name: Extrasensory
+    damage: 40+
+    text: If you have the same number of cards in your hand as your opponent, this
+      attack does 80 more damage.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: kirisAki
+- id: 441-TG07
+  pioId: swsh10tg-TG07
+  enumId: FALINKS_TG07
+  name: Falinks
+  number: TG07
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, RAPID_STRIKE]
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [F, C]
+    name: Rapid Strike Squad
+    damage: 20x
+    text: This attack does 20 damage for each of your Rapid Strike Pokémon in play.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare Holo
+  artist: Kinu Nishimura
+- id: 441-TG08
+  pioId: swsh10tg-TG08
+  enumId: KLEAVOR_TG08
+  name: Kleavor
+  number: TG08
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Scyther
+  hp: 140
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Timber Cleave
+    text: Flip 2 coins. If both of them are heads, your opponent's Active Pokémon
+      is Knocked Out.
+  - cost: [F, F]
+    name: Berserker Tackle
+    damage: '120'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: Souichirou Gunjima
+- id: 441-TG09
+  pioId: swsh10tg-TG09
+  enumId: MIGHTYENA_TG09
+  name: Mightyena
+  number: TG09
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Poochyena
+  hp: 110
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Hustle Bark
+    text: If your opponent has any Pokémon VMAX in play, this Pokémon's attacks cost
+      [C][C][C] less.
+  moves:
+  - cost: [C, C, C]
+    name: Wild Tackle
+    damage: '160'
+    text: This Pokémon also does 50 damage to itself.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: GOSSAN
+- id: 441-TG10
+  pioId: swsh10tg-TG10
+  enumId: GALARIAN_OBSTAGOON_TG10
+  name: Galarian Obstagoon
+  number: TG10
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Galarian Linoone
+  hp: 160
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Untamed Shout
+    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
+      your turn, you may put 3 damage counters on 1 of your opponent's Pokémon.
+  moves:
+  - cost: [D, C]
+    name: Obstruct
+    damage: '90'
+    text: During your opponent's next turn, prevent all damage done to this Pokémon
+      by attacks from Basic Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: GOSSAN
+- id: 441-TG11
+  pioId: swsh10tg-TG11
+  enumId: BRONZONG_TG11
+  name: Bronzong
+  number: TG11
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Bronzor
+  hp: 110
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Metal Transfer
+    text: As often as you like during your turn, you may move a [M] Energy from 1
+      of your Pokémon to another of your Pokémon.
+  moves:
+  - cost: [M, C, C]
+    name: Zen Headbutt
+    damage: '70'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  artist: Hataya
+- id: 441-TG12
+  pioId: swsh10tg-TG12
+  enumId: HOOTHOOT_TG12
+  name: Hoothoot
+  number: TG12
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Noctowl]
+  hp: 50
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Stand Sentry
+    text: Basic Energy attached to your Benched Pokémon can't be discarded by an effect
+      of your opponent's Item or Supporter cards.
+  moves:
+  - cost: [C, C]
+    name: Flap
+    damage: '20'
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: HYOGONOSUKE
+- id: 441-TG13
+  pioId: swsh10tg-TG13
+  enumId: STARMIE_V_TG13
+  name: Starmie V
+  number: TG13
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  moves:
+  - cost: [C, C]
+    name: Swift
+    damage: '50'
+    text: This attack's damage isn't affected by Weakness or Resistance, or by any
+      effects on your opponent's Active Pokémon.
+  - cost: [W, W]
+    name: Energy Spiral
+    damage: 50x
+    text: This attack does 50 damage for each Energy attached to all of your opponent's
+      Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Akira Komayama
+- id: 441-TG14
+  pioId: swsh10tg-TG14
+  enumId: ICE_RIDER_CALYREX_V_TG14
+  name: Ice Rider Calyrex V
+  number: TG14
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Pierce
+    damage: '40'
+  - cost: [W, W, C]
+    name: Glacial Lance
+    damage: '200'
+    text: Discard 2 Energy from this Pokémon.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Mitsuhiro Arita
+- id: 441-TG15
+  pioId: swsh10tg-TG15
+  enumId: ICE_RIDER_CALYREX_VMAX_TG15
+  name: Ice Rider Calyrex VMAX
+  number: TG15
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Ice Rider Calyrex V
+  hp: 320
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Ride of the High King
+    damage: 10+
+    text: This attack does 30 more damage for each of your opponent's Benched Pokémon.
+  - cost: [W, W]
+    name: Max Lance
+    damage: 10+
+    text: You may discard up to 2 Energy from this Pokémon. If you do, this attack
+      does 120 more damage for each card you discarded in this way.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: Hitoshi Ariga
+- id: 441-TG16
+  pioId: swsh10tg-TG16
+  enumId: GALARIAN_ARTICUNO_V_TG16
+  name: Galarian Articuno V
+  number: TG16
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Reconstitute
+    text: You must discard 2 cards from your hand in order to use this Ability. Once
+      during your turn, you may draw a card.
+  moves:
+  - cost: [P, C, C]
+    name: Psyray
+    damage: '110'
+    text: Your opponent's Active Pokémon is now Confused.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Kouki Saitou
+- id: 441-TG17
+  pioId: swsh10tg-TG17
+  enumId: SHADOW_RIDER_CALYREX_V_TG17
+  name: Shadow Rider Calyrex V
+  number: TG17
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [P]
+    name: Shadow Mist
+    damage: '10'
+    text: During your opponent's next turn, they can't play any Special Energy or
+      Stadium cards from their hand.
+  - cost: [C, C, C]
+    name: Astral Barrage
+    text: Choose 2 of your opponent's Pokémon and put 5 damage counters on each of
+      them.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Oswaldo KATO
+- id: 441-TG18
+  pioId: swsh10tg-TG18
+  enumId: SHADOW_RIDER_CALYREX_VMAX_TG18
+  name: Shadow Rider Calyrex VMAX
+  number: TG18
+  types: [P]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Shadow Rider Calyrex V
+  hp: 320
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Underworld Door
+    text: Once during your turn, you may attach a [P] Energy card from your hand to
+      1 of your Benched [P] Pokémon. If you attached Energy to a Pokémon in this way,
+      draw 2 cards.
+  moves:
+  - cost: [C, C, C]
+    name: Max Geist
+    damage: 10+
+    text: This attack does 30 more damage for each [P] Energy attached to all of your
+      Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: chibi
+- id: 441-TG19
+  pioId: swsh10tg-TG19
+  enumId: GALARIAN_ZAPDOS_V_TG19
+  name: Galarian Zapdos V
+  number: TG19
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Fighting Instinct
+    text: This Pokémon's attacks cost [C] less for each of your opponent's Pokémon
+      V in play.
+  moves:
+  - cost: [F, C, C, C]
+    name: Thunderous Kick
+    damage: '170'
+    text: Before doing damage, discard a Special Energy from your opponent's Active
+      Pokémon.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: kirisAki
+- id: 441-TG20
+  pioId: swsh10tg-TG20
+  enumId: GALARIAN_MOLTRES_V_TG20
+  name: Galarian Moltres V
+  number: TG20
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Direflame Wings
+    text: Once during your turn, you may attach a [D] Energy card from your discard
+      pile to this Pokémon. You can't use more than 1 Direflame Wings Ability each
+      turn.
+  moves:
+  - cost: [D, D, C]
+    name: Aura Burn
+    damage: '190'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Jiro Sasumo
+- id: 441-TG21
+  pioId: swsh10tg-TG21
+  enumId: ZACIAN_V_TG21
+  name: Zacian V
+  number: TG21
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Intrepid Sword
+    text: Once during your turn, you may look at the top 3 cards of your deck and
+      attach any number of [M] Energy cards you find there to this Pokémon. Put the
+      other cards into your hand. If you use this Ability, your turn ends.
+  moves:
+  - cost: [M, M, M]
+    name: Brave Blade
+    damage: '230'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aoki
+- id: 441-TG22
+  pioId: swsh10tg-TG22
+  enumId: ZAMAZENTA_V_TG22
+  name: Zamazenta V
+  number: TG22
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 230
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Dauntless Shield
+    text: Prevent all damage done to this Pokémon by attacks from your opponent's
+      Pokémon VMAX.
+  moves:
+  - cost: [M, M, C]
+    name: Assault Tackle
+    damage: '130'
+    text: Discard a Special Energy from your opponent's Active Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Ryuta Fuse
+- id: 441-TG23
+  pioId: swsh10tg-TG23
+  enumId: GARCHOMP_V_TG23
+  name: Garchomp V
+  number: TG23
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  moves:
+  - cost: [W, F, C]
+    name: Dragon Claw
+    damage: '120'
+  - cost: [W, F, F, C]
+    name: Sonic Strike
+    text: Discard 3 Energy from this Pokémon. This attack does 220 damage to 1 of
+      your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Taira Akitsu
+- id: 441-TG24
+  pioId: swsh10tg-TG24
+  enumId: ALLISTER_TG24
+  name: Allister
+  number: TG24
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 3 cards. If you drew any cards in this way, discard up to 3 cards from your
+    hand. (You must discard at least 1 card.)
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Jiro Sasumo
+- id: 441-TG25
+  pioId: swsh10tg-TG25
+  enumId: BEA_TG25
+  name: Bea
+  number: TG25
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Discard the top 5 cards of your deck, and attach any Energy cards you discarded
+    in this way to your Benched [F] Pokémon in any way you like.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Souichirou Gunjima
+- id: 441-TG26
+  pioId: swsh10tg-TG26
+  enumId: MELONY_TG26
+  name: Melony
+  number: TG26
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Attach a [W] Energy card from your discard pile to 1 of your Pokémon V. If you
+    do, draw 3 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: nagimiso
+- id: 441-TG27
+  pioId: swsh10tg-TG27
+  enumId: MILO_TG27
+  name: Milo
+  number: TG27
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Discard up to 2 cards from your hand, and draw 2 cards for each card you discarded
+    in this way.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Sanosuke Sakuma
+- id: 441-TG28
+  pioId: swsh10tg-TG28
+  enumId: PIERS_TG28
+  name: Piers
+  number: TG28
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Search your deck for an Energy card and a [D] Pokémon, reveal them, and put them
+    into your hand. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: GOSSAN
+- id: 441-TG29
+  pioId: swsh10tg-TG29
+  enumId: ICE_RIDER_CALYREX_VMAX_TG29
+  name: Ice Rider Calyrex VMAX
+  number: TG29
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Ice Rider Calyrex V
+  hp: 320
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Ride of the High King
+    damage: 10+
+    text: This attack does 30 more damage for each of your opponent's Benched Pokémon.
+  - cost: [W, W]
+    name: Max Lance
+    damage: 10+
+    text: You may discard up to 2 Energy from this Pokémon. If you do, this attack
+      does 120 more damage for each card you discarded in this way.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Secret
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-TG15
+  variantType: Secret Art
+- id: 441-TG30
+  pioId: swsh10tg-TG30
+  enumId: SHADOW_RIDER_CALYREX_VMAX_TG30
+  name: Shadow Rider Calyrex VMAX
+  number: TG30
+  types: [P]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Shadow Rider Calyrex V
+  hp: 320
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Underworld Door
+    text: Once during your turn, you may attach a [P] Energy card from your hand to
+      1 of your Benched [P] Pokémon. If you attached Energy to a Pokémon in this way,
+      draw 2 cards.
+  moves:
+  - cost: [C, C, C]
+    name: Max Geist
+    damage: 10+
+    text: This attack does 30 more damage for each [P] Energy attached to all of your
+      Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Secret
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-TG18
+  variantType: Secret Art

--- a/data/src/main/resources/cards/441-brilliant_stars.yaml
+++ b/data/src/main/resources/cards/441-brilliant_stars.yaml
@@ -1,5 +1,5 @@
 id: '441'
-name: swsh9
+name: Brilliant Stars
 enumId: BRILLIANT_STARS
 abbr: BRS
 pioId: swsh9

--- a/data/src/main/resources/cards/441-brilliant_stars.yaml
+++ b/data/src/main/resources/cards/441-brilliant_stars.yaml
@@ -1,3 +1,4 @@
+schema: E2
 id: '441'
 name: Brilliant Stars
 enumId: BRILLIANT_STARS

--- a/data/src/main/resources/cards/441-brilliant_stars.yaml
+++ b/data/src/main/resources/cards/441-brilliant_stars.yaml
@@ -1,0 +1,4345 @@
+id: FILL_THIS
+name: swsh9
+enumId: FILL_THIS
+abbr: FILL_THIS
+pioId: swsh9
+cards:
+- id: FILL_THIS-1
+  pioId: swsh9-1
+  enumId: EXEGGCUTE_1
+  name: Exeggcute
+  number: '1'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Exeggutor]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Ram
+    damage: '10'
+  - cost: [G, C]
+    name: Seed Bomb
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: '0313'
+- id: FILL_THIS-2
+  pioId: swsh9-2
+  enumId: EXEGGUTOR_2
+  name: Exeggutor
+  number: '2'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Exeggcute
+  hp: 140
+  retreatCost: 3
+  moves:
+  - cost: [G, C, C]
+    name: Mega Drain
+    damage: '70'
+    text: Heal 30 damage from this Pokémon.
+  - cost: [G, C, C, C]
+    name: Seed Bomb
+    damage: '130'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Naoyo Kimura
+- id: FILL_THIS-3
+  pioId: swsh9-3
+  enumId: SHROOMISH_3
+  name: Shroomish
+  number: '3'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Breloom]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Headbutt
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Shigenori Negishi
+- id: FILL_THIS-4
+  pioId: swsh9-4
+  enumId: BRELOOM_4
+  name: Breloom
+  number: '4'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Shroomish
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Spore Ball
+    damage: '30'
+    text: Your opponent's Active Pokémon is now Asleep.
+  - cost: [G]
+    name: Powdery Uppercut
+    damage: '130'
+    text: You can use this attack only if this Pokémon used Spore Ball during your
+      last turn.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare
+  artist: Sekio
+- id: FILL_THIS-5
+  pioId: swsh9-5
+  enumId: TROPIUS_5
+  name: Tropius
+  number: '5'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Curative Bower
+    text: All of your Pokémon that have [G] Energy attached can't be Confused, and
+      if they are already Confused, they recover from that Special Condition.
+  moves:
+  - cost: [G, G, C]
+    name: Slicing Blade
+    damage: '100'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Shin Nagasawa
+- id: FILL_THIS-6
+  pioId: swsh9-6
+  enumId: TURTWIG_6
+  name: Turtwig
+  number: '6'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Grotle]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [G]
+    name: Bite
+    damage: '10'
+  - cost: [G, C]
+    name: Headbutt Bounce
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Narumi Sato
+- id: FILL_THIS-7
+  pioId: swsh9-7
+  enumId: GROTLE_7
+  name: Grotle
+  number: '7'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Turtwig
+  evolvesTo: [Torterra]
+  hp: 100
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Sun-Drenched Shell
+    text: Once during your turn, you may search your deck for a [G] Pokémon, reveal
+      it, and put it into your hand. Then, shuffle your deck.
+  moves:
+  - cost: [G, C, C]
+    name: Razor Leaf
+    damage: '50'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Nisota Niso
+- id: FILL_THIS-8
+  pioId: swsh9-8
+  enumId: TORTERRA_8
+  name: Torterra
+  number: '8'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Grotle
+  hp: 190
+  retreatCost: 4
+  moves:
+  - cost: [G, C]
+    name: Evopress
+    damage: 50x
+    text: This attack does 50 damage for each of your Evolution Pokémon in play.
+  - cost: [G, C, C, C]
+    name: Hammer In
+    damage: '160'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  artist: Oswaldo KATO
+- id: FILL_THIS-9
+  pioId: swsh9-9
+  enumId: BURMY_9
+  name: Burmy
+  number: '9'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Wormadam, Mothim]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Hang Down
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Miki Tanaka
+- id: FILL_THIS-10
+  pioId: swsh9-10
+  enumId: WORMADAM_10
+  name: Wormadam
+  number: '10'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Burmy
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Matron's Anger
+    damage: 30+
+    text: This attack does 10 more damage for each Pokémon in your discard pile.
+  - cost: [G, C, C]
+    name: Leaf Drain
+    damage: '80'
+    text: Heal 30 damage from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare
+  artist: Yuka Morii
+- id: FILL_THIS-11
+  pioId: swsh9-11
+  enumId: MOTHIM_11
+  name: Mothim
+  number: '11'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Burmy
+  hp: 110
+  moves:
+  - cost: [C, C]
+    name: Raid
+    damage: 30+
+    text: If this Pokémon evolved from Burmy during this turn, this attack does 90
+      more damage.
+  - cost: [C, C, C]
+    name: Gust
+    damage: '80'
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Akira Komayama
+- id: FILL_THIS-12
+  pioId: swsh9-12
+  enumId: CHERUBI_12
+  name: Cherubi
+  number: '12'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Cherrim]
+  hp: 40
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Lively Fruit
+    text: Prevent all effects of attacks from your opponent's Pokémon done to this
+      Pokémon. (Damage is not an effect.)
+  moves:
+  - cost: [G, C]
+    name: Leafage
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Naoyo Kimura
+- id: FILL_THIS-13
+  pioId: swsh9-13
+  enumId: SHAYMIN_V_13
+  name: Shaymin V
+  number: '13'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Flap
+    damage: '30'
+  - cost: [G, C]
+    name: Revenge Blast
+    damage: 60+
+    text: This attack does 40 more damage for each Prize card your opponent has taken.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Satoshi Shirai
+- id: FILL_THIS-14
+  pioId: swsh9-14
+  enumId: SHAYMIN_VSTAR_14
+  name: Shaymin VSTAR
+  number: '14'
+  types: [G]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Shaymin V
+  hp: 250
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Star Bloom
+    text: During your turn, you may heal 120 damage from each of your Benched [G]
+      Pokémon. (You can't use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [G, C]
+    name: Revenge Blast
+    damage: 120+
+    text: This attack does 40 more damage for each Prize card your opponent has taken.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-15
+  pioId: swsh9-15
+  enumId: KARRABLAST_15
+  name: Karrablast
+  number: '15'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Escavalier]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Peck
+    damage: '10'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: sowsow
+- id: FILL_THIS-16
+  pioId: swsh9-16
+  enumId: ZARUDE_V_16
+  name: Zarude V
+  number: '16'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [G]
+    name: Leap to Leap
+    damage: '30'
+    text: This attack also does 30 damage to 1 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [G, G, C]
+    name: Jungle Rage
+    damage: 120+
+    text: If your opponent's Active Pokémon is a Pokémon V, this attack does 120 more
+      damage.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-17
+  pioId: swsh9-17
+  enumId: CHARIZARD_V_17
+  name: Charizard V
+  number: '17'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [R, R, C]
+    name: Incinerate
+    damage: '90'
+    text: Before doing damage, discard all Pokémon Tools from your opponent's Active
+      Pokémon.
+  - cost: [R, R, R, C]
+    name: Heat Blast
+    damage: '180'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: N-DESIGN Inc.
+- id: FILL_THIS-18
+  pioId: swsh9-18
+  enumId: CHARIZARD_VSTAR_18
+  name: Charizard VSTAR
+  number: '18'
+  types: [R]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Charizard V
+  hp: 280
+  retreatCost: 2
+  moves:
+  - cost: [R, R, C]
+    name: Explosive Fire
+    damage: 130+
+    text: If this Pokémon has any damage counters on it, this attack does 100 more
+      damage.
+  - cost: [R, R, R, C]
+    name: Star Blaze
+    damage: '320'
+    text: Discard 2 Energy from this Pokémon. (You can't use more than 1 VSTAR Power
+      in a game.)
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-19
+  pioId: swsh9-19
+  enumId: MAGMAR_19
+  name: Magmar
+  number: '19'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Magmortar]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Low Kick
+    damage: '20'
+  - cost: [R, R, C]
+    name: Fiery Punch
+    damage: '70'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: Shinji Kanda
+- id: FILL_THIS-20
+  pioId: swsh9-20
+  enumId: MAGMORTAR_20
+  name: Magmortar
+  number: '20'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Magmar
+  hp: 140
+  retreatCost: 3
+  moves:
+  - cost: [C, C]
+    name: Mega Punch
+    damage: '50'
+  - cost: [R, R, C]
+    name: Boltsplosion
+    damage: 120+
+    text: If Electivire is on your Bench, this attack does 120 more damage.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare
+  artist: AKIRA EGAWA
+- id: FILL_THIS-21
+  pioId: swsh9-21
+  enumId: MOLTRES_21
+  name: Moltres
+  number: '21'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Inferno Wings
+    damage: 20+ damage. If this Pokémon has any damage counters on it, this attack
+      does 70 more
+    text: This attack's damage isn't affected by Weakness.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  artist: otumami
+- id: FILL_THIS-22
+  pioId: swsh9-22
+  enumId: ENTEI_V_22
+  name: Entei V
+  number: '22'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 230
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Fleet-Footed
+    text: Once during your turn, if this Pokémon is in the Active Spot, you may draw
+      a card.
+  moves:
+  - cost: [R, C]
+    name: Burning Rondo
+    damage: 20+
+    text: This attack does 20 more damage for each Benched Pokémon (both yours and
+      your opponent's).
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: FILL_THIS-23
+  pioId: swsh9-23
+  enumId: TORKOAL_23
+  name: Torkoal
+  number: '23'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Firebreathing
+    damage: 30+
+    text: Flip a coin. If heads, this attack does 30 more damage.
+  - cost: [R, C, C]
+    name: Guard Press
+    damage: '90'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Uncommon
+  artist: Kagemaru Himeno
+- id: FILL_THIS-24
+  pioId: swsh9-24
+  enumId: CHIMCHAR_24
+  name: Chimchar
+  number: '24'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Monferno]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Ember
+    damage: '30'
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: Shin Nagasawa
+- id: FILL_THIS-25
+  pioId: swsh9-25
+  enumId: MONFERNO_25
+  name: Monferno
+  number: '25'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Chimchar
+  evolvesTo: [Infernape]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Flare
+    damage: '30'
+  - cost: [R, C]
+    name: Flamethrower
+    damage: '50'
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Uncommon
+  artist: KEIICHIRO ITO
+- id: FILL_THIS-26
+  pioId: swsh9-26
+  enumId: INFERNAPE_26
+  name: Infernape
+  number: '26'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Monferno
+  hp: 150
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Infernal Vortex
+    damage: 80x
+    text: Reveal the top 5 cards of your deck. This attack does 80 damage for each
+      Energy card you find there. Then, discard those Energy cards and shuffle the
+      other cards back into your deck.
+  - cost: [R, C]
+    name: Burning Kick
+    damage: '160'
+    text: Discard all Energy from this Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  artist: Anesaki Dynamic
+- id: FILL_THIS-27
+  pioId: swsh9-27
+  enumId: SIMISEAR_V_27
+  name: Simisear V
+  number: '27'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Bursting Power
+    damage: '20'
+    text: You may attach up to 2 basic Energy cards from your hand to your Pokémon
+      in any way you like.
+  - cost: [R, C, C]
+    name: Flare Juggling
+    damage: 90+
+    text: This attack does 30 more damage for each Energy attached to your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-28
+  pioId: swsh9-28
+  enumId: KINGLER_V_28
+  name: Kingler V
+  number: '28'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [W]
+    name: Falling Bubbles
+    text: Flip a coin. If heads, search your deck for up to 5 [W] Energy cards and
+      attach them to your Pokémon in any way you like. Then, shuffle your deck.
+  - cost: [W, W, C]
+    name: Raging Pincer
+    damage: '200'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: FILL_THIS-29
+  pioId: swsh9-29
+  enumId: KINGLER_VMAX_29
+  name: Kingler VMAX
+  number: '29'
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Kingler V
+  hp: 330
+  retreatCost: 3
+  moves:
+  - cost: [W]
+    name: Bubbles Galore
+    text: Search your deck for up to 5 [W] Energy cards and attach them to your Pokémon
+      in any way you like. Then, shuffle your deck.
+  - cost: [W, W, C]
+    name: G-Max Pincer
+    damage: '240'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-30
+  pioId: swsh9-30
+  enumId: STARYU_30
+  name: Staryu
+  number: '30'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Starmie]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Double Spin
+    damage: 10x
+    text: Flip 2 coins. This attack does 10 damage for each heads.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Yuka Morii
+- id: FILL_THIS-31
+  pioId: swsh9-31
+  enumId: LAPRAS_31
+  name: Lapras
+  number: '31'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [W, W, C]
+    name: Raging Freeze
+    damage: '110'
+    text: If any of your Pokémon were Knocked Out by damage from an attack from your
+      opponent's Pokémon during their last turn, your opponent's Active Pokémon is
+      now Paralyzed.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare
+  artist: Teeziro
+- id: FILL_THIS-32
+  pioId: swsh9-32
+  enumId: CORPHISH_32
+  name: Corphish
+  number: '32'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Crawdaunt]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Water Gun
+    damage: '10'
+  - cost: [W, C, C]
+    name: Crabhammer
+    damage: '50'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Sekio
+- id: FILL_THIS-33
+  pioId: swsh9-33
+  enumId: CRAWDAUNT_33
+  name: Crawdaunt
+  number: '33'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Corphish
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Corkscrew Punch
+    damage: '30'
+  - cost: [W, C, C]
+    name: Crab Impact
+    damage: '150'
+    text: Discard 2 Energy from this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: Shibuzoh.
+- id: FILL_THIS-34
+  pioId: swsh9-34
+  enumId: SNORUNT_34
+  name: Snorunt
+  number: '34'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Glalie, Froslass]
+  hp: 60
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Ice Breath
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [W, C]
+    name: Icy Snow
+    damage: '20'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: HYOGONOSUKE
+- id: FILL_THIS-35
+  pioId: swsh9-35
+  enumId: PIPLUP_35
+  name: Piplup
+  number: '35'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Prinplup]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Bubble
+    damage: '10'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Atsushi Furusawa
+- id: FILL_THIS-36
+  pioId: swsh9-36
+  enumId: PRINPLUP_36
+  name: Prinplup
+  number: '36'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Piplup
+  evolvesTo: [Empoleon]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Peck
+    damage: '30'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: Kagemaru Himeno
+- id: FILL_THIS-37
+  pioId: swsh9-37
+  enumId: EMPOLEON_37
+  name: Empoleon
+  number: '37'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Prinplup
+  hp: 160
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Emergency Surfacing
+    text: Once during your turn, if this Pokémon is in your discard pile and you have
+      no cards in your hand, you may put this Pokémon onto your Bench. If you do,
+      draw 3 cards.
+  moves:
+  - cost: [W]
+    name: Water Arrow
+    text: This attack does 60 damage to 1 of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  artist: Kouki Saitou
+- id: FILL_THIS-38
+  pioId: swsh9-38
+  enumId: BUIZEL_38
+  name: Buizel
+  number: '38'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Floatzel]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [W, C]
+    name: Agility
+    damage: '20'
+    text: Flip a coin. If heads, during your opponent's next turn, prevent all damage
+      from and effects of attacks done to this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Tika Matsuno
+- id: FILL_THIS-39
+  pioId: swsh9-39
+  enumId: FLOATZEL_39
+  name: Floatzel
+  number: '39'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Buizel
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Floatify
+    text: Put up to 2 Item cards from your discard pile into your hand.
+  - cost: [W, C]
+    name: Water Gun
+    damage: '60'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: kodama
+- id: FILL_THIS-40
+  pioId: swsh9-40
+  enumId: LUMINEON_V_40
+  name: Lumineon V
+  number: '40'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 170
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Luminous Sign
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may search your deck for a Supporter card, reveal it, and put it into your
+      hand. Then, shuffle your deck.
+  moves:
+  - cost: [W, C, C]
+    name: Aqua Return
+    damage: '120'
+    text: Shuffle this Pokémon and all attached cards into your deck.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: takuyoa
+- id: FILL_THIS-41
+  pioId: swsh9-41
+  enumId: MANAPHY_41
+  name: Manaphy
+  number: '41'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Wave Veil
+    text: Prevent all damage done to your Benched Pokémon by attacks from your opponent's
+      Pokémon.
+  moves:
+  - cost: [W]
+    name: Rain Splash
+    damage: '20'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare
+  artist: HYOGONOSUKE
+- id: FILL_THIS-42
+  pioId: swsh9-42
+  enumId: CUBCHOO_42
+  name: Cubchoo
+  number: '42'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Beartic]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Chilly
+    damage: '20'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: ryoma uratsuka
+- id: FILL_THIS-43
+  pioId: swsh9-43
+  enumId: BEARTIC_43
+  name: Beartic
+  number: '43'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Cubchoo
+  hp: 140
+  retreatCost: 3
+  moves:
+  - cost: [W, C]
+    name: Sheer Cold
+    damage: '40'
+    text: During your opponent's next turn, the Defending Pokémon can't attack.
+  - cost: [W, W, C]
+    name: Frost Smash
+    damage: '130'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Uncommon
+  artist: Rianti Hidayat
+- id: FILL_THIS-44
+  pioId: swsh9-44
+  enumId: EISCUE_44
+  name: Eiscue
+  number: '44'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [W, C]
+    name: Block Slider
+    text: This attack does 40 damage to 1 of your opponent's Pokémon for each Fusion
+      Strike Energy attached to all of your Pokémon. (Don't apply Weakness and Resistance
+      for Benched Pokémon.)
+  - cost: [W, W, C]
+    name: Icicle Missile
+    damage: '100'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare
+  artist: nagimiso
+- id: FILL_THIS-45
+  pioId: swsh9-45
+  enumId: RAICHU_V_45
+  name: Raichu V
+  number: '45'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Fast Charge
+    text: If you go first, you can use this attack during your first turn. Search
+      your deck for a [L] Energy card and attach it to this Pokémon. Then, shuffle
+      your deck.
+  - cost: [L, L]
+    name: Dynamic Spark
+    damage: 60x
+    text: You may discard any amount of [L] Energy from your Pokémon. This attack
+      does 60 damage for each card you discarded in this way.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: MUGENUP
+- id: FILL_THIS-46
+  pioId: swsh9-46
+  enumId: ELECTABUZZ_46
+  name: Electabuzz
+  number: '46'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Electivire]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [L]
+    name: Thunder Wave
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [L, C]
+    name: Head Bolt
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: OKACHEKE
+- id: FILL_THIS-47
+  pioId: swsh9-47
+  enumId: ELECTIVIRE_47
+  name: Electivire
+  number: '47'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Electabuzz
+  hp: 140
+  retreatCost: 3
+  moves:
+  - cost: [L]
+    name: Explosive Bolt
+    damage: 30+
+    text: If any of your Benched Magmortar have any damage counters on them, this
+      attack does 90 more damage.
+  - cost: [L, L, C]
+    name: High-Voltage Current
+    text: This attack does 50 damage to each of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: AKIRA EGAWA
+- id: FILL_THIS-48
+  pioId: swsh9-48
+  enumId: RAIKOU_V_48
+  name: Raikou V
+  number: '48'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Fleet-Footed
+    text: Once during your turn, if this Pokémon is in the Active Spot, you may draw
+      a card.
+  moves:
+  - cost: [L, C]
+    name: Lightning Rondo
+    damage: 20+
+    text: This attack does 20 more damage for each Benched Pokémon (both yours and
+      your opponent's).
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: FILL_THIS-49
+  pioId: swsh9-49
+  enumId: SHINX_49
+  name: Shinx
+  number: '49'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Luxio]
+  hp: 40
+  moves:
+  - cost: [L]
+    name: Gnaw
+    damage: '10'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Mizue
+- id: FILL_THIS-50
+  pioId: swsh9-50
+  enumId: LUXIO_50
+  name: Luxio
+  number: '50'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Shinx
+  evolvesTo: [Luxray]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Thunder Shock
+    damage: '30'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: kurumitsu
+- id: FILL_THIS-51
+  pioId: swsh9-51
+  enumId: LUXRAY_51
+  name: Luxray
+  number: '51'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Luxio
+  hp: 150
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Energy Crush
+    damage: 50x
+    text: This attack does 50 damage for each Energy attached to all of your opponent's
+      Pokémon.
+  - cost: [L]
+    name: Flash Impact
+    damage: '110'
+    text: This attack also does 30 damage to 1 of your Benched Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Ayaka Yoshida
+- id: FILL_THIS-52
+  pioId: swsh9-52
+  enumId: PACHIRISU_52
+  name: Pachirisu
+  number: '52'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [L, C]
+    name: Windup Thunder
+    damage: 30x
+    text: This attack does 30 damage for each Pokémon Tool attached to all of your
+      Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: HYOGONOSUKE
+- id: FILL_THIS-53
+  pioId: swsh9-53
+  enumId: CLEFAIRY_53
+  name: Clefairy
+  number: '53'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Clefable]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Pound
+    damage: '10'
+  - cost: [P, C]
+    name: Magical Shot
+    damage: '30'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: Yukiko Baba
+- id: FILL_THIS-54
+  pioId: swsh9-54
+  enumId: CLEFABLE_54
+  name: Clefable
+  number: '54'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Clefairy
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Moonlit Miracle
+    text: Flip 3 coins. Choose a number of your Pokémon in play up to the number of
+      heads. For each of those Pokémon, search your deck for a card that evolves from
+      that Pokémon and put it onto that Pokémon to evolve it. Then, shuffle your deck.
+  - cost: [P, C, C]
+    name: Magical Shot
+    damage: '90'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare
+  artist: Mizue
+- id: FILL_THIS-55
+  pioId: swsh9-55
+  enumId: STARMIE_55
+  name: Starmie
+  number: '55'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Staryu
+  hp: 90
+  moves:
+  - cost: [P]
+    name: Psychic
+    damage: 10+
+    text: This attack does 30 more damage for each Energy attached to your opponent's
+      Active Pokémon.
+  - cost: [P]
+    name: Power Gem
+    damage: '60'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Akira Komayama
+- id: FILL_THIS-56
+  pioId: swsh9-56
+  enumId: MEWTWO_56
+  name: Mewtwo
+  number: '56'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [P]
+    name: Life Sucker
+    damage: '20'
+    text: Heal 20 damage from this Pokémon.
+  - cost: [P, P, C]
+    name: Psyburn
+    damage: '110'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Anesaki Dynamic
+- id: FILL_THIS-57
+  pioId: swsh9-57
+  enumId: GRANBULL_V_57
+  name: Granbull V
+  number: '57'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Chomp
+    damage: 30+
+    text: This attack does 10 more damage for each damage counter on this Pokémon.
+  - cost: [P, P, C]
+    name: Bull Dash
+    damage: '190'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: FILL_THIS-58
+  pioId: swsh9-58
+  enumId: BALTOY_58
+  name: Baltoy
+  number: '58'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Claydol]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Triple Spin
+    damage: 20x
+    text: Flip 3 coins. This attack does 20 damage for each heads.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Kyoko Umemoto
+- id: FILL_THIS-59
+  pioId: swsh9-59
+  enumId: CLAYDOL_59
+  name: Claydol
+  number: '59'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Baltoy
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Spinning Attack
+    damage: '40'
+  - cost: [P, C, C]
+    name: Coinciding Figures
+    damage: 90+
+    text: If you and your opponent have the same number of Benched Pokémon, this attack
+      does 90 more damage.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Kazuma Koda
+- id: FILL_THIS-60
+  pioId: swsh9-60
+  enumId: DUSKULL_60
+  name: Duskull
+  number: '60'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Dusclops]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Perplex
+    damage: '10'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Confused.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: SATOSHI NAKAI
+- id: FILL_THIS-61
+  pioId: swsh9-61
+  enumId: DUSCLOPS_61
+  name: Dusclops
+  number: '61'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Duskull
+  evolvesTo: [Dusknoir]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [P]
+    name: Fade to Black
+    damage: '30'
+    text: Your opponent's Active Pokémon is now Confused.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: miki kudo
+- id: FILL_THIS-62
+  pioId: swsh9-62
+  enumId: DUSKNOIR_62
+  name: Dusknoir
+  number: '62'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Dusclops
+  hp: 160
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Special Transfer
+    text: As often as you like during your turn, you may move a Special Energy from
+      1 of your Pokémon to another of your Pokémon.
+  moves:
+  - cost: [P, C, C]
+    name: Devour Soul
+    damage: '120'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: otumami
+- id: FILL_THIS-63
+  pioId: swsh9-63
+  enumId: CHIMECHO_63
+  name: Chimecho
+  number: '63'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Clear Tone
+    text: Search your deck for up to 2 Special Energy cards, reveal them, and put
+      them into your hand. Then, shuffle your deck.
+  - cost: [C, C]
+    name: Hang Down
+    damage: '30'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: MAHOU
+- id: FILL_THIS-64
+  pioId: swsh9-64
+  enumId: WHIMSICOTT_V_64
+  name: Whimsicott V
+  number: '64'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Fluff Gets in the Way
+    damage: '20'
+    text: If the Defending Pokémon is a Basic Pokémon, it can't attack during your
+      opponent's next turn.
+  - cost: [P, C, C]
+    name: Cotton Guard
+    damage: '90'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Saki Hayashiro
+- id: FILL_THIS-65
+  pioId: swsh9-65
+  enumId: WHIMSICOTT_VSTAR_65
+  name: Whimsicott VSTAR
+  number: '65'
+  types: [P]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Whimsicott V
+  hp: 250
+  retreatCost: 1
+  moves:
+  - cost: [P, C, C]
+    name: Trick Wind
+    damage: '160'
+    text: During your opponent's next turn, they can't play any Pokémon Tool or Special
+      Energy cards from their hand.
+  - cost: [P]
+    name: Fluffball Star
+    text: This attack does 60 damage to 1 of your opponent's Pokémon for each Energy
+      attached to this Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)
+      (You can't use more than 1 VSTAR Power in a game.)
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-66
+  pioId: swsh9-66
+  enumId: SIGILYPH_66
+  name: Sigilyph
+  number: '66'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Tri Recharge
+    text: Flip 3 coins. Attach a number of basic Energy cards up to the number of
+      heads from your discard pile to your Benched Pokémon in any way you like.
+  - cost: [P, C]
+    name: Psychic
+    damage: 10+
+    text: This attack does 30 more damage for each Energy attached to your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Sumiyoshi Kizuki
+- id: FILL_THIS-67
+  pioId: swsh9-67
+  enumId: DEDENNE_67
+  name: Dedenne
+  number: '67'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Dede-Flash
+    damage: 20+
+    text: If your opponent has exactly 1 Prize card remaining, this attack does 60
+      more damage, and your opponent's Active Pokémon is now Confused.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: Nagomi Nijo
+- id: FILL_THIS-68
+  pioId: swsh9-68
+  enumId: MIMIKYU_V_68
+  name: Mimikyu V
+  number: '68'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 160
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Dummy Doll
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may prevent all damage done to this Mimikyu V by attacks from your opponent's
+      Pokémon until the end of your opponent's next turn.
+  moves:
+  - cost: [P]
+    name: Jealous Eyes
+    text: Put 3 damage counters on your opponent's Active Pokémon for each Prize card
+      your opponent has taken.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Eske Yoshinob
+- id: FILL_THIS-69
+  pioId: swsh9-69
+  enumId: MIMIKYU_VMAX_69
+  name: Mimikyu VMAX
+  number: '69'
+  types: [P]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Mimikyu V
+  hp: 300
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Ominous Numbers
+    text: Put 4 damage counters on your opponent's Pokémon in any way you like. If
+      you played Acerola's Premonition from your hand during this turn, place 13 damage
+      counters instead.
+  - cost: [P, P]
+    name: Max Shadow
+    damage: '120'
+    text: Discard a random card from your opponent's hand.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: Studio Bora Inc.
+- id: FILL_THIS-70
+  pioId: swsh9-70
+  enumId: MILCERY_70
+  name: Milcery
+  number: '70'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Alcremie]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Lead
+    text: Search your deck for a Supporter card, reveal it, and put it into your hand.
+      Then, shuffle your deck.
+  - cost: [P]
+    name: Ram
+    damage: '10'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: Misa Tsutsui
+- id: FILL_THIS-71
+  pioId: swsh9-71
+  enumId: ALCREMIE_71
+  name: Alcremie
+  number: '71'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Milcery
+  hp: 90
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Additional Order
+    text: As long as this Pokémon is in the Active Spot, your turn does not end when
+      you use Café Master.
+  moves:
+  - cost: [C, C]
+    name: Rainbow Flavor
+    damage: 10+
+    text: This attack does 40 more damage for each type of basic Energy attached to
+      all of your Pokémon.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare
+  artist: sowsow
+- id: FILL_THIS-72
+  pioId: swsh9-72
+  enumId: HITMONTOP_72
+  name: Hitmontop
+  number: '72'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Spinning Draw
+    damage: '20'
+    text: Draw a card.
+  - cost: [F, F, C]
+    name: Cyclone Kick
+    damage: '100'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Uncommon
+  artist: ryoma uratsuka
+- id: FILL_THIS-73
+  pioId: swsh9-73
+  enumId: NOSEPASS_73
+  name: Nosepass
+  number: '73'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Probopass]
+  hp: 90
+  retreatCost: 4
+  moves:
+  - cost: [C]
+    name: Ram
+    damage: '20'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: miki kudo
+- id: FILL_THIS-74
+  pioId: swsh9-74
+  enumId: TRAPINCH_74
+  name: Trapinch
+  number: '74'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Vibrava]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Rising Lunge
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 10 more damage.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: zig
+- id: FILL_THIS-75
+  pioId: swsh9-75
+  enumId: VIBRAVA_75
+  name: Vibrava
+  number: '75'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Trapinch
+  evolvesTo: [Flygon]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Razor Wing
+    damage: '30'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: Tomokazu Komiya
+- id: FILL_THIS-76
+  pioId: swsh9-76
+  enumId: FLYGON_76
+  name: Flygon
+  number: '76'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Vibrava
+  hp: 150
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Desert Pillar
+    damage: 50x
+    text: This attack does 50 damage for each [C] in your opponent's Active Pokémon's
+      Retreat Cost.
+  - cost: [F, C]
+    name: Blasting Wind
+    damage: '110'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: Shin Nagasawa
+- id: FILL_THIS-77
+  pioId: swsh9-77
+  enumId: WORMADAM_77
+  name: Wormadam
+  number: '77'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Burmy
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Matron's Anger
+    damage: 30+
+    text: This attack does 10 more damage for each Pokémon in your discard pile.
+  - cost: [F, C, C]
+    name: Bind Down
+    damage: '80'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: Lee HyunJung
+- id: FILL_THIS-78
+  pioId: swsh9-78
+  enumId: RIOLU_78
+  name: Riolu
+  number: '78'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Lucario]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [F, F]
+    name: Low Kick
+    damage: '50'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Common
+  artist: Teeziro
+- id: FILL_THIS-79
+  pioId: swsh9-79
+  enumId: LUCARIO_79
+  name: Lucario
+  number: '79'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Riolu
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Roaring Resolve
+    text: Once during your turn, you may put 2 damage counters on this Pokémon. If
+      you do, search your deck for a [F] Energy card and attach it to this Pokémon.
+      Then, shuffle your deck.
+  moves:
+  - cost: [F, F]
+    name: Aura Sphere Volley
+    damage: 10+
+    text: Discard all [F] Energy from this Pokémon. This attack does 60 more damage
+      for each card you discarded in this way.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare Holo
+  artist: GIDORA
+- id: FILL_THIS-80
+  pioId: swsh9-80
+  enumId: THROH_80
+  name: Throh
+  number: '80'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 3
+  moves:
+  - cost: [C, C]
+    name: Lunge Out
+    damage: '30'
+  - cost: [F, F, C]
+    name: Seismic Toss
+    damage: '110'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Common
+  artist: Teeziro
+- id: FILL_THIS-81
+  pioId: swsh9-81
+  enumId: SAWK_81
+  name: Sawk
+  number: '81'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Sweep the Leg
+    damage: '30'
+    text: Flip a coin. If heads, discard an Energy from your opponent's Active Pokémon.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Common
+  artist: Shinji Kanda
+- id: FILL_THIS-82
+  pioId: swsh9-82
+  enumId: GOLETT_82
+  name: Golett
+  number: '82'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Golurk]
+  hp: 100
+  retreatCost: 4
+  moves:
+  - cost: [F]
+    name: Mud-Slap
+    damage: '10'
+  - cost: [F, C]
+    name: Pound
+    damage: '20'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Eske Yoshinob
+- id: FILL_THIS-83
+  pioId: swsh9-83
+  enumId: GOLURK_83
+  name: Golurk
+  number: '83'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Golett
+  hp: 150
+  retreatCost: 4
+  moves:
+  - cost: [C, C]
+    name: Big Hand
+    damage: 30+
+    text: This attack does 10 more damage for each card in your hand.
+  - cost: [F, F, C]
+    name: Mega Punch
+    damage: '120'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: Aya Kusube
+- id: FILL_THIS-84
+  pioId: swsh9-84
+  enumId: GRIMER_84
+  name: Grimer
+  number: '84'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Muk]
+  hp: 80
+  retreatCost: 3
+  moves:
+  - cost: [D]
+    name: Poison Gas
+    text: Your opponent's Active Pokémon is now Poisoned.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Masakazu Fukuda
+- id: FILL_THIS-85
+  pioId: swsh9-85
+  enumId: MUK_85
+  name: Muk
+  number: '85'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Grimer
+  hp: 130
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Sludge Street
+    text: The Retreat Cost of your opponent's Poisoned Pokémon is [C] more.
+  moves:
+  - cost: [D, C, C]
+    name: Shrieking Poison
+    damage: '90'
+    text: Your opponent's Active Pokémon is now Confused and Poisoned.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Scav
+- id: FILL_THIS-86
+  pioId: swsh9-86
+  enumId: SNEASEL_86
+  name: Sneasel
+  number: '86'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Weavile]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Scratch
+    damage: '10'
+  - cost: [C, C]
+    name: Slash
+    damage: '20'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: yuu
+- id: FILL_THIS-87
+  pioId: swsh9-87
+  enumId: WEAVILE_87
+  name: Weavile
+  number: '87'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Sneasel
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Ransack
+    text: Flip 2 coins. If either of them is heads, your opponent reveals their hand.
+      For each heads, choose a card you find there and put it on the bottom of your
+      opponent's deck in any order.
+  - cost: [D, C, C]
+    name: Slash
+    damage: '100'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: Hasuno
+- id: FILL_THIS-88
+  pioId: swsh9-88
+  enumId: HONCHKROW_V_88
+  name: Honchkrow V
+  number: '88'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Boss Pockets
+    text: This Pokémon may have up to 4 Pokémon Tools attached to it. If it loses
+      this Ability, discard Pokémon Tools from it until only 1 remains.
+  moves:
+  - cost: [D, D, C]
+    name: Fearsome Shadow
+    damage: '130'
+    text: Your opponent reveals their hand.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: FILL_THIS-89
+  pioId: swsh9-89
+  enumId: SPIRITOMB_89
+  name: Spiritomb
+  number: '89'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Ticking Terror
+    text: Until the end of your next turn, the Defending Pokémon's Weakness is now
+      Darkness. (The amount of Weakness doesn't change.)
+  - cost: [D]
+    name: Cursed Drop
+    text: Put 2 damage counters on your opponent's Pokémon in any way you like.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Uta
+- id: FILL_THIS-90
+  pioId: swsh9-90
+  enumId: PURRLOIN_90
+  name: Purrloin
+  number: '90'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Liepard]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Surprise Attack
+    damage: '30'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Narumi Sato
+- id: FILL_THIS-91
+  pioId: swsh9-91
+  enumId: LIEPARD_91
+  name: Liepard
+  number: '91'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Purrloin
+  hp: 100
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Trade
+    text: You must discard a card from your hand in order to use this Ability. Once
+      during your turn, you may draw 2 cards.
+  moves:
+  - cost: [C, C]
+    name: Slash
+    damage: '60'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: AKIRA EGAWA
+- id: FILL_THIS-92
+  pioId: swsh9-92
+  enumId: IMPIDIMP_92
+  name: Impidimp
+  number: '92'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Morgrem]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Call for Family
+    text: Search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle
+      your deck.
+  - cost: [C, C]
+    name: Bite
+    damage: '30'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Rianti Hidayat
+- id: FILL_THIS-93
+  pioId: swsh9-93
+  enumId: MORGREM_93
+  name: Morgrem
+  number: '93'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Impidimp
+  evolvesTo: [Grimmsnarl]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Smash Kick
+    damage: '30'
+  - cost: [D, C]
+    name: Pierce
+    damage: '50'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: Shiburingaru
+- id: FILL_THIS-94
+  pioId: swsh9-94
+  enumId: GRIMMSNARL_94
+  name: Grimmsnarl
+  number: '94'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Morgrem
+  hp: 160
+  retreatCost: 2
+  moves:
+  - cost: [D]
+    name: Longhair Shot
+    text: This attack does 30 damage to 1 of your opponent's Pokémon for each [D]
+      Energy attached to this Pokémon. (Don't apply Weakness and Resistance for Benched
+      Pokémon.)
+  - cost: [D, C]
+    name: Darkness Fang
+    damage: '110'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: DOM
+- id: FILL_THIS-95
+  pioId: swsh9-95
+  enumId: MORPEKO_V_95
+  name: Morpeko V
+  number: '95'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Gnaw and Run
+    damage: '30'
+    text: You may switch this Pokémon with 1 of your Benched Pokémon.
+  - cost: [D, D, C]
+    name: Hangry Spike
+    damage: 120+
+    text: If you played Marnie's Pride from your hand during this turn, this attack
+      does 120 more damage.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: FILL_THIS-96
+  pioId: swsh9-96
+  enumId: AGGRON_V_96
+  name: Aggron V
+  number: '96'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 230
+  retreatCost: 4
+  moves:
+  - cost: [M, C, C]
+    name: Rock Slide
+    damage: '90'
+    text: This attack also does 30 damage to 2 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [M, C, C, C, C]
+    name: Merciless Strike
+    damage: 150+
+    text: If your opponent's Active Pokémon already has any damage counters on it,
+      this attack does 150 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: FILL_THIS-97
+  pioId: swsh9-97
+  enumId: AGGRON_VMAX_97
+  name: Aggron VMAX
+  number: '97'
+  types: [M]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Aggron V
+  hp: 330
+  retreatCost: 4
+  moves:
+  - cost: [M, C, C]
+    name: Cracking Stomp
+    damage: '150'
+    text: Discard the top card of your opponent's deck.
+  - cost: [M, M, C, C, C]
+    name: Max Take Down
+    damage: '270'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-98
+  pioId: swsh9-98
+  enumId: WORMADAM_98
+  name: Wormadam
+  number: '98'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Burmy
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Matron's Anger
+    damage: 30+
+    text: This attack does 10 more damage for each Pokémon in your discard pile.
+  - cost: [M, C, C]
+    name: Scrap Drop
+    damage: '90'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare
+  artist: Ryo Ueda
+- id: FILL_THIS-99
+  pioId: swsh9-99
+  enumId: PROBOPASS_99
+  name: Probopass
+  number: '99'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Nosepass
+  hp: 140
+  retreatCost: 4
+  moves:
+  - cost: [C, C]
+    name: Magnetic Tension
+    text: Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. This
+      attack does 40 damage to the new Active Pokémon.
+  - cost: [M, C, C]
+    name: Iron Tackle
+    damage: '120'
+    text: This Pokémon also does 20 damage to itself.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Uncommon
+  artist: Pani Kobayashi
+- id: FILL_THIS-100
+  pioId: swsh9-100
+  enumId: HEATRAN_100
+  name: Heatran
+  number: '100'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 140
+  retreatCost: 4
+  moves:
+  - cost: [C, C]
+    name: Guard Claw
+    damage: '30'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  - cost: [M, M, C]
+    name: Iron Hammer
+    damage: 80+
+    text: If this Pokémon has any [R] Energy attached, this attack does 80 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare
+  artist: Yuya Oka
+- id: FILL_THIS-101
+  pioId: swsh9-101
+  enumId: ESCAVALIER_101
+  name: Escavalier
+  number: '101'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Karrablast
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Miraculous Armor
+    text: This Pokémon takes 100 less damage from attacks from your opponent's Pokémon
+      V (after applying Weakness and Resistance).
+  moves:
+  - cost: [M, C, C]
+    name: Pike
+    damage: '90'
+    text: This attack also does 30 damage to 1 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare
+  artist: Nurikabe
+- id: FILL_THIS-102
+  pioId: swsh9-102
+  enumId: KLINK_102
+  name: Klink
+  number: '102'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Klang]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [M]
+    name: Vise Grip
+    damage: '10'
+  - cost: [M, C]
+    name: Spinning Attack
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Common
+  artist: OKACHEKE
+- id: FILL_THIS-103
+  pioId: swsh9-103
+  enumId: KLANG_103
+  name: Klang
+  number: '103'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Klink
+  evolvesTo: [Klinklang]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [M]
+    name: Beam
+    damage: '20'
+  - cost: [M, C, C]
+    name: Guard Press
+    damage: '70'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Uncommon
+  artist: Hataya
+- id: FILL_THIS-104
+  pioId: swsh9-104
+  enumId: KLINKLANG_104
+  name: Klinklang
+  number: '104'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Klang
+  hp: 150
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Gear Wall
+    text: Your Basic Pokémon take 20 less damage from attacks from your opponent's
+      Pokémon (after applying Weakness and Resistance).
+  moves:
+  - cost: [M, C, C]
+    name: Tumbling Attack
+    damage: 90+
+    text: Flip a coin. If heads, this attack does 90 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare
+  artist: Megumi Higuchi
+- id: FILL_THIS-105
+  pioId: swsh9-105
+  enumId: ZAMAZENTA_V_105
+  name: Zamazenta V
+  number: '105'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Regal Stance
+    text: Once during your turn, you may discard your hand and draw 5 cards. If you
+      use this Ability, your turn ends.
+  moves:
+  - cost: [M, C, C]
+    name: Revenge Blast
+    damage: 120+
+    text: This attack does 30 more damage for each Prize card your opponent has taken.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: FILL_THIS-106
+  pioId: swsh9-106
+  enumId: FLYGON_V_106
+  name: Flygon V
+  number: '106'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [G, F]
+    name: Sand Spray
+    damage: '70'
+  - cost: [G, F, F, C]
+    name: Draconic Impulse
+    damage: 160+
+    text: If your opponent's Active Pokémon is a Pokémon VMAX, this attack does 160
+      more damage, and discard 3 Energy from this Pokémon.
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+- id: FILL_THIS-107
+  pioId: swsh9-107
+  enumId: GIBLE_107
+  name: Gible
+  number: '107'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Gabite]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [W, F]
+    name: Gnaw
+    damage: '30'
+  rarity: Common
+  artist: sowsow
+- id: FILL_THIS-108
+  pioId: swsh9-108
+  enumId: GABITE_108
+  name: Gabite
+  number: '108'
+  types: [N]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Gible
+  evolvesTo: [Garchomp]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [W, F]
+    name: Dragon Claw
+    damage: '70'
+  rarity: Uncommon
+  artist: hatachu
+- id: FILL_THIS-109
+  pioId: swsh9-109
+  enumId: GARCHOMP_109
+  name: Garchomp
+  number: '109'
+  types: [N]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Gabite
+  hp: 160
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Sonic Slip
+    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
+      your turn, you may prevent all damage from and effects of attacks from your
+      opponent's Pokémon done to this Pokémon until the end of your opponent's next
+      turn.
+  moves:
+  - cost: [W, F]
+    name: Dragonblade
+    damage: '160'
+    text: Discard the top 2 cards of your deck.
+  rarity: Rare Holo
+  artist: Nurikabe
+- id: FILL_THIS-110
+  pioId: swsh9-110
+  enumId: AXEW_110
+  name: Axew
+  number: '110'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Fraxure]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Ultra Evolution
+    text: Flip a coin. If heads, search your deck for a Haxorus and put it onto this
+      Axew to evolve it. Then, shuffle your deck.
+  rarity: Common
+  artist: Saya Tsuruta
+- id: FILL_THIS-111
+  pioId: swsh9-111
+  enumId: FRAXURE_111
+  name: Fraxure
+  number: '111'
+  types: [N]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Axew
+  evolvesTo: [Haxorus]
+  hp: 100
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Sharp Fang
+    damage: '30'
+  - cost: [F, M]
+    name: Dragon Claw
+    damage: '60'
+  rarity: Uncommon
+  artist: Hataya
+- id: FILL_THIS-112
+  pioId: swsh9-112
+  enumId: HAXORUS_112
+  name: Haxorus
+  number: '112'
+  types: [N]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Fraxure
+  hp: 170
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Slash
+    damage: '60'
+  - cost: [F, M]
+    name: Wild Axe
+    damage: '160'
+    text: This Pokémon also does 30 damage to itself.
+  rarity: Rare
+  artist: Uta
+- id: FILL_THIS-113
+  pioId: swsh9-113
+  enumId: DRUDDIGON_113
+  name: Druddigon
+  number: '113'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [R, W]
+    name: Revenge
+    damage: 40+
+    text: If any of your Pokémon were Knocked Out by damage from an attack from your
+      opponent's Pokémon during their last turn, this attack does 120 more damage.
+  - cost: [R, W, C]
+    name: Dragon Claw
+    damage: '120'
+  rarity: Rare
+  artist: Ryo Ueda
+- id: FILL_THIS-114
+  pioId: swsh9-114
+  enumId: DRACOVISH_V_114
+  name: Dracovish V
+  number: '114'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [G, W]
+    name: Slosh 'n' Crash
+    damage: 60+
+    text: Before doing damage, discard all Pokémon Tools from your opponent's Active
+      Pokémon. If you discarded a Pokémon Tool in this way, this attack does 120 more
+      damage.
+  - cost: [G, W, W]
+    name: Dragon Strike
+    damage: '210'
+    text: During your next turn, this Pokémon can't use Dragon Strike.
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Satoshi Shirai
+- id: FILL_THIS-115
+  pioId: swsh9-115
+  enumId: FARFETCH_D_115
+  name: Farfetch'd
+  number: '115'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Sirfetch'd]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Leek Lash
+    damage: 20+
+    text: This attack does 10 more damage for each damage counter on your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Tomokazu Komiya
+- id: FILL_THIS-116
+  pioId: swsh9-116
+  enumId: CASTFORM_116
+  name: Castform
+  number: '116'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Double Draw
+    text: Draw 2 cards.
+  - cost: [C]
+    name: Hurricane
+    damage: '30'
+    text: Move a basic Energy from this Pokémon to 1 of your Benched Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: kawayoo
+- id: FILL_THIS-117
+  pioId: swsh9-117
+  enumId: STARLY_117
+  name: Starly
+  number: '117'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Staravia]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Claw
+    damage: '30'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Saya Tsuruta
+- id: FILL_THIS-118
+  pioId: swsh9-118
+  enumId: STARAVIA_118
+  name: Staravia
+  number: '118'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Starly
+  evolvesTo: [Staraptor]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Wing Attack
+    damage: '50'
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Kouki Saitou
+- id: FILL_THIS-119
+  pioId: swsh9-119
+  enumId: STARAPTOR_119
+  name: Staraptor
+  number: '119'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Staravia
+  hp: 150
+  retreatCost: 1
+  moves:
+  - cost: [C, C, C]
+    name: Strong Breeze
+    text: Your opponent shuffles their Active Pokémon and all attached cards into
+      their deck.
+  - cost: [C, C, C, C]
+    name: Spinning Bird
+    damage: '180'
+    text: Discard 2 Energy from this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Narumi Sato
+- id: FILL_THIS-120
+  pioId: swsh9-120
+  enumId: BIDOOF_120
+  name: Bidoof
+  number: '120'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Bibarel]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Rollout
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Oswaldo KATO
+- id: FILL_THIS-121
+  pioId: swsh9-121
+  enumId: BIBAREL_121
+  name: Bibarel
+  number: '121'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Bidoof
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Industrious Incisors
+    text: Once during your turn, you may draw cards until you have 5 cards in your
+      hand.
+  moves:
+  - cost: [C, C, C]
+    name: Tail Smash
+    damage: '100'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: OKACHEKE
+- id: FILL_THIS-122
+  pioId: swsh9-122
+  enumId: ARCEUS_V_122
+  name: Arceus V
+  number: '122'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Trinity Charge
+    text: Search your deck for up to 3 basic Energy cards and attach them to your
+      Pokémon V in any way you like. Then, shuffle your deck.
+  - cost: [C, C, C]
+    name: Power Edge
+    damage: '130'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: N-DESIGN Inc.
+- id: FILL_THIS-123
+  pioId: swsh9-123
+  enumId: ARCEUS_VSTAR_123
+  name: Arceus VSTAR
+  number: '123'
+  types: [C]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Arceus V
+  hp: 280
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Starbirth
+    text: During your turn, you may search your deck for up to 2 cards and put them
+      into your hand. Then, shuffle your deck. (You can't use more than 1 VSTAR Power
+      in a game.)
+  moves:
+  - cost: [C, C, C]
+    name: Trinity Nova
+    damage: '200'
+    text: Search your deck for up to 3 basic Energy cards and attach them to your
+      Pokémon V in any way you like. Then, shuffle your deck.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-124
+  pioId: swsh9-124
+  enumId: MINCCINO_124
+  name: Minccino
+  number: '124'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Cinccino]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Call for Family
+    text: Search your deck for up to 2 Basic Pokémon and put them onto your Bench.
+      Then, shuffle your deck.
+  - cost: [C]
+    name: Pound
+    damage: '10'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Mina Nakai
+- id: FILL_THIS-125
+  pioId: swsh9-125
+  enumId: CINCCINO_125
+  name: Cinccino
+  number: '125'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Minccino
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Slap
+    damage: '40'
+  - cost: [C, C]
+    name: Triple Axel
+    damage: 50x
+    text: Flip 3 coins. This attack does 50 damage for each heads.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: Atsuko Nishida
+- id: FILL_THIS-126
+  pioId: swsh9-126
+  enumId: TORNADUS_126
+  name: Tornadus
+  number: '126'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Sudden Cyclone
+    text: When you play this Pokémon from your hand onto your Bench, you may have
+      your opponent switch his or her Active Pokémon with 1 of his or her Benched
+      Pokémon.
+  moves:
+  - cost: [C, C, C]
+    name: Blasting Wind
+    damage: '100'
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Shigenori Negishi
+- id: FILL_THIS-127
+  pioId: swsh9-127
+  enumId: HAWLUCHA_127
+  name: Hawlucha
+  number: '127'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Showboating Pose
+    text: Attach up to 2 basic Energy cards from your discard pile to 1 of your Benched
+      Pokémon.
+  - cost: [C]
+    name: Cross-Cut
+    damage: 30+
+    text: If your opponent's Active Pokémon is an Evolution Pokémon, this attack does
+      30 more damage.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Miki Tanaka
+- id: FILL_THIS-128
+  pioId: swsh9-128
+  enumId: DRAMPA_V_128
+  name: Drampa V
+  number: '128'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Spike Draw
+    damage: '20'
+    text: Draw 2 cards.
+  - cost: [C, C, C]
+    name: Dragon Pulse
+    damage: '160'
+    text: Discard the top 2 cards of your deck.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+- id: FILL_THIS-129
+  pioId: swsh9-129
+  enumId: ACEROLA_S_PREMONITION_129
+  name: Acerola's Premonition
+  number: '129'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Your opponent reveals their hand, and you draw a card for each Trainer card you
+    find there.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Shiburingaru
+- id: FILL_THIS-130
+  pioId: swsh9-130
+  enumId: BARRY_130
+  name: Barry
+  number: '130'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Draw 3 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Ken Sugimori
+- id: FILL_THIS-131
+  pioId: swsh9-131
+  enumId: BLUNDER_POLICY_131
+  name: Blunder Policy
+  number: '131'
+  superType: TRAINER
+  subTypes: [ITEM, ITEM, POKEMON_TOOL]
+  rarity: Uncommon
+  text:
+  - If the Pokémon this card is attached to uses an attack, if you flip any coins
+    for the damage or effect of that attack, and if any of them are tails, draw 3
+    cards at the end of your turn.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
+    have a Pokémon Tool attached.'
+  artist: Ayaka Yoshida
+- id: FILL_THIS-132
+  pioId: swsh9-132
+  enumId: BOSS_S_ORDERS_132
+  name: Boss's Orders
+  number: '132'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Rare Holo
+  text:
+  - Switch 1 of your opponent's Benched Pokémon with their Active Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: GIDORA
+- id: FILL_THIS-133
+  pioId: swsh9-133
+  enumId: CAFE_MASTER_133
+  name: Café Master
+  number: '133'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Choose up to 3 of your Benched Pokémon. For each of those Pokémon, search your
+    deck for a different type of basic Energy card and attach it to that Pokémon.
+    Then, shuffle your deck. Your turn ends.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hasegawa Saki
+- id: FILL_THIS-134
+  pioId: swsh9-134
+  enumId: CHEREN_S_CARE_134
+  name: Cheren's Care
+  number: '134'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Put 1 of your [C] Pokémon that has any damage counters on it and all attached
+    cards into your hand.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yusuke Ohmura
+- id: FILL_THIS-135
+  pioId: swsh9-135
+  enumId: CHOICE_BELT_135
+  name: Choice Belt
+  number: '135'
+  superType: TRAINER
+  subTypes: [ITEM, ITEM, POKEMON_TOOL]
+  rarity: Uncommon
+  text:
+  - The attacks of the Pokémon this card is attached to do 30 more damage to your
+    opponent's Active Pokémon V (before applying Weakness and Resistance).
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
+    have a Pokémon Tool attached.'
+  artist: Studio Bora Inc.
+- id: FILL_THIS-136
+  pioId: swsh9-136
+  enumId: CLEANSING_GLOVES_136
+  name: Cleansing Gloves
+  number: '136'
+  superType: TRAINER
+  subTypes: [ITEM, ITEM, POKEMON_TOOL]
+  rarity: Uncommon
+  text:
+  - The attacks of the Pokémon this card is attached to do 30 more damage to your
+    opponent's Active [P] Pokémon (before applying Weakness and Resistance).
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
+    have a Pokémon Tool attached.'
+  artist: Toyste Beach
+- id: FILL_THIS-137
+  pioId: swsh9-137
+  enumId: COLLAPSED_STADIUM_137
+  name: Collapsed Stadium
+  number: '137'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Uncommon
+  text:
+  - Each player can't have more than 4 Benched Pokémon. If a player has 5 or more
+    Benched Pokémon, they discard Benched Pokémon until they have 4 Pokémon on the
+    Bench. The player who played this card discards first. If more than one effect
+    changes the number of Benched Pokémon allowed, use the smaller number.
+  artist: Oswaldo KATO
+- id: FILL_THIS-138
+  pioId: swsh9-138
+  enumId: CYNTHIA_S_AMBITION_138
+  name: Cynthia's Ambition
+  number: '138'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Draw cards until you have 5 cards in your hand. If any of your Pokémon were Knocked
+    Out during your opponent's last turn, draw cards until you have 8 cards in your
+    hand instead.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Megumi Mizutani
+- id: FILL_THIS-139
+  pioId: swsh9-139
+  enumId: FRESH_WATER_SET_139
+  name: Fresh Water Set
+  number: '139'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Heal 20 damage from each of your Pokémon.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: AYUMI ODASHIMA
+- id: FILL_THIS-140
+  pioId: swsh9-140
+  enumId: FRIENDS_IN_GALAR_140
+  name: Friends in Galar
+  number: '140'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Draw 3 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yuu Nishida
+- id: FILL_THIS-141
+  pioId: swsh9-141
+  enumId: GLORIA_141
+  name: Gloria
+  number: '141'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Search your deck for up to 3 Basic Pokémon that don't have a Rule Box and put
+    them onto your Bench. Then, shuffle your deck. (Pokémon V, Pokémon-GX, etc. have
+    Rule Boxes.)
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Ken Sugimori
+- id: FILL_THIS-142
+  pioId: swsh9-142
+  enumId: HUNTING_GLOVES_142
+  name: Hunting Gloves
+  number: '142'
+  superType: TRAINER
+  subTypes: [ITEM, ITEM, POKEMON_TOOL]
+  rarity: Uncommon
+  text:
+  - The attacks of the Pokémon this card is attached to do 30 more damage to your
+    opponent's Active [N] Pokémon (before applying Weakness and Resistance).
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
+    have a Pokémon Tool attached.'
+  artist: Toyste Beach
+- id: FILL_THIS-143
+  pioId: swsh9-143
+  enumId: KINDLER_143
+  name: Kindler
+  number: '143'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - You can use this card only if you discard a [R] Energy card from your hand. Look
+    at the top 7 cards of your deck and put up to 2 of them into your hand. Shuffle
+    the other cards back into your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hitoshi Ariga
+- id: FILL_THIS-144
+  pioId: swsh9-144
+  enumId: MAGMA_BASIN_144
+  name: Magma Basin
+  number: '144'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Uncommon
+  text:
+  - Once during each player's turn, that player may attach a [R] Energy card from
+    their discard pile to 1 of their Benched [R] Pokémon. If a player attached Energy
+    to a Pokémon in this way, put 2 damage counters on that Pokémon.
+  artist: ORBITALLINK Inc.
+- id: FILL_THIS-145
+  pioId: swsh9-145
+  enumId: MARNIE_S_PRIDE_145
+  name: Marnie's Pride
+  number: '145'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Attach a basic Energy card from your discard pile to 1 of your Benched Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: saino misaki
+- id: FILL_THIS-146
+  pioId: swsh9-146
+  enumId: POT_HELMET_146
+  name: Pot Helmet
+  number: '146'
+  superType: TRAINER
+  subTypes: [ITEM, ITEM, POKEMON_TOOL]
+  rarity: Uncommon
+  text:
+  - If the Pokémon this card is attached to doesn't have a Rule Box, it takes 30 less
+    damage from attacks from your opponent's Pokémon(after applying Weakness and Resistance). (Pokémon
+    V, Pokémon-GX, etc. have Rule Boxes.)
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
+    have a Pokémon Tool attached.'
+  artist: Toyste Beach
+- id: FILL_THIS-147
+  pioId: swsh9-147
+  enumId: PROFESSOR_S_RESEARCH_147
+  name: Professor's Research
+  number: '147'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Rare Holo
+  text:
+  - Discard your hand and draw 7 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Sanosuke Sakuma
+- id: FILL_THIS-148
+  pioId: swsh9-148
+  enumId: ROSEANNE_S_BACKUP_148
+  name: Roseanne's Backup
+  number: '148'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - 'Choose 1 or more: Shuffle a Pokémon from your discard pile into your deck.Shuffle
+    a Pokémon Tool card from your discard pile into your deck.Shuffle a Stadium card
+    from your discard pile into your deck.Shuffle an Energy card from your discard
+    pile into your deck.'
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Nagomi Nijo
+- id: FILL_THIS-149
+  pioId: swsh9-149
+  enumId: TEAM_YELL_S_CHEER_149
+  name: Team Yell's Cheer
+  number: '149'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Shuffle up to 3 in any combination of Pokémon and Supporter cards, except for
+    Team Yell's Cheer, from your discard pile into your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: GOSSAN
+- id: FILL_THIS-150
+  pioId: swsh9-150
+  enumId: ULTRA_BALL_150
+  name: Ultra Ball
+  number: '150'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - You can use this card only if you discard 2 other cards from your hand. Search
+    your deck for a Pokémon, reveal it, and put it into your hand. Then, shuffle your
+    deck.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: sadaji
+- id: FILL_THIS-151
+  pioId: swsh9-151
+  enumId: DOUBLE_TURBO_ENERGY_151
+  name: Double Turbo Energy
+  number: '151'
+  superType: ENERGY
+  subTypes: [SPECIAL_ENERGY]
+  rarity: Uncommon
+  text:
+  - As long as this card is attached to a Pokémon, it provides [C][C] Energy. The
+    attacks of the Pokémon this card is attached to do 20 less damage to your opponent's
+    Pokémon (before applying Weakness and Resistance).
+- id: FILL_THIS-152
+  pioId: swsh9-152
+  enumId: SHAYMIN_V_152
+  name: Shaymin V
+  number: '152'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Flap
+    damage: '30'
+  - cost: [G, C]
+    name: Revenge Blast
+    damage: 60+
+    text: This attack does 40 more damage for each Prize card your opponent has taken.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Eske Yoshinob
+  variantOf: FILL_THIS-13
+  variantType: Full Art
+- id: FILL_THIS-153
+  pioId: swsh9-153
+  enumId: CHARIZARD_V_153
+  name: Charizard V
+  number: '153'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [R, R, C]
+    name: Incinerate
+    damage: '90'
+    text: Before doing damage, discard all Pokémon Tools from your opponent's Active
+      Pokémon.
+  - cost: [R, R, R, C]
+    name: Heat Blast
+    damage: '180'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: N-DESIGN Inc.
+  variantOf: FILL_THIS-17
+  variantType: Full Art
+- id: FILL_THIS-154
+  pioId: swsh9-154
+  enumId: CHARIZARD_V_154
+  name: Charizard V
+  number: '154'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [R, R, C]
+    name: Incinerate
+    damage: '90'
+    text: Before doing damage, discard all Pokémon Tools from your opponent's Active
+      Pokémon.
+  - cost: [R, R, R, C]
+    name: Heat Blast
+    damage: '180'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Ryota Murayama
+  variantOf: FILL_THIS-17
+  variantType: Full Art
+- id: FILL_THIS-155
+  pioId: swsh9-155
+  enumId: LUMINEON_V_155
+  name: Lumineon V
+  number: '155'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 170
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Luminous Sign
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may search your deck for a Supporter card, reveal it, and put it into your
+      hand. Then, shuffle your deck.
+  moves:
+  - cost: [W, C, C]
+    name: Aqua Return
+    damage: '120'
+    text: Shuffle this Pokémon and all attached cards into your deck.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: takuyoa
+  variantOf: FILL_THIS-40
+  variantType: Full Art
+- id: FILL_THIS-156
+  pioId: swsh9-156
+  enumId: LUMINEON_V_156
+  name: Lumineon V
+  number: '156'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 170
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Luminous Sign
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may search your deck for a Supporter card, reveal it, and put it into your
+      hand. Then, shuffle your deck.
+  moves:
+  - cost: [W, C, C]
+    name: Aqua Return
+    damage: '120'
+    text: Shuffle this Pokémon and all attached cards into your deck.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Ligton
+  variantOf: FILL_THIS-40
+  variantType: Full Art
+- id: FILL_THIS-157
+  pioId: swsh9-157
+  enumId: PIKACHU_V_157
+  name: Pikachu V
+  number: '157'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  evolvesTo: [Raichu]
+  hp: 190
+  retreatCost: 1
+  moves:
+  - cost: [L, L, C]
+    name: Lightning Blast
+    damage: 100+
+    text: You may discard all [L] Energy from this Pokémon. If you do, this attack
+      does 120 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-158
+  pioId: swsh9-158
+  enumId: RAICHU_V_158
+  name: Raichu V
+  number: '158'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Fast Charge
+    text: If you go first, you can use this attack during your first turn. Search
+      your deck for a [L] Energy card and attach it to this Pokémon. Then, shuffle
+      your deck.
+  - cost: [L, L]
+    name: Dynamic Spark
+    damage: 60x
+    text: You may discard any amount of [L] Energy from your Pokémon. This attack
+      does 60 damage for each card you discarded in this way.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: MUGENUP
+  variantOf: FILL_THIS-45
+  variantType: Full Art
+- id: FILL_THIS-159
+  pioId: swsh9-159
+  enumId: GRANBULL_V_159
+  name: Granbull V
+  number: '159'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Chomp
+    damage: 30+
+    text: This attack does 10 more damage for each damage counter on this Pokémon.
+  - cost: [P, P, C]
+    name: Bull Dash
+    damage: '190'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Ayaka Yoshida
+  variantOf: FILL_THIS-57
+  variantType: Full Art
+- id: FILL_THIS-160
+  pioId: swsh9-160
+  enumId: WHIMSICOTT_V_160
+  name: Whimsicott V
+  number: '160'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Fluff Gets in the Way
+    damage: '20'
+    text: If the Defending Pokémon is a Basic Pokémon, it can't attack during your
+      opponent's next turn.
+  - cost: [P, C, C]
+    name: Cotton Guard
+    damage: '90'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Saki Hayashiro
+  variantOf: FILL_THIS-64
+  variantType: Full Art
+- id: FILL_THIS-161
+  pioId: swsh9-161
+  enumId: HONCHKROW_V_161
+  name: Honchkrow V
+  number: '161'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Boss Pockets
+    text: This Pokémon may have up to 4 Pokémon Tools attached to it. If it loses
+      this Ability, discard Pokémon Tools from it until only 1 remains.
+  moves:
+  - cost: [D, D, C]
+    name: Fearsome Shadow
+    damage: '130'
+    text: Your opponent reveals their hand.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+  variantOf: FILL_THIS-88
+  variantType: Full Art
+- id: FILL_THIS-162
+  pioId: swsh9-162
+  enumId: HONCHKROW_V_162
+  name: Honchkrow V
+  number: '162'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Boss Pockets
+    text: This Pokémon may have up to 4 Pokémon Tools attached to it. If it loses
+      this Ability, discard Pokémon Tools from it until only 1 remains.
+  moves:
+  - cost: [D, D, C]
+    name: Fearsome Shadow
+    damage: '130'
+    text: Your opponent reveals their hand.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: zig
+  variantOf: FILL_THIS-88
+  variantType: Full Art
+- id: FILL_THIS-163
+  pioId: swsh9-163
+  enumId: ZAMAZENTA_V_163
+  name: Zamazenta V
+  number: '163'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Regal Stance
+    text: Once during your turn, you may discard your hand and draw 5 cards. If you
+      use this Ability, your turn ends.
+  moves:
+  - cost: [M, C, C]
+    name: Revenge Blast
+    damage: 120+
+    text: This attack does 30 more damage for each Prize card your opponent has taken.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Ayaka Yoshida
+  variantOf: FILL_THIS-105
+  variantType: Full Art
+- id: FILL_THIS-164
+  pioId: swsh9-164
+  enumId: FLYGON_V_164
+  name: Flygon V
+  number: '164'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [G, F]
+    name: Sand Spray
+    damage: '70'
+  - cost: [G, F, F, C]
+    name: Draconic Impulse
+    damage: 160+
+    text: If your opponent's Active Pokémon is a Pokémon VMAX, this attack does 160
+      more damage, and discard 3 Energy from this Pokémon.
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Mochizuki
+  variantOf: FILL_THIS-106
+  variantType: Full Art
+- id: FILL_THIS-165
+  pioId: swsh9-165
+  enumId: ARCEUS_V_165
+  name: Arceus V
+  number: '165'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Trinity Charge
+    text: Search your deck for up to 3 basic Energy cards and attach them to your
+      Pokémon V in any way you like. Then, shuffle your deck.
+  - cost: [C, C, C]
+    name: Power Edge
+    damage: '130'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: N-DESIGN Inc.
+  variantOf: FILL_THIS-122
+  variantType: Full Art
+- id: FILL_THIS-166
+  pioId: swsh9-166
+  enumId: ARCEUS_V_166
+  name: Arceus V
+  number: '166'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Trinity Charge
+    text: Search your deck for up to 3 basic Energy cards and attach them to your
+      Pokémon V in any way you like. Then, shuffle your deck.
+  - cost: [C, C, C]
+    name: Power Edge
+    damage: '130'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: kawayoo
+  variantOf: FILL_THIS-122
+  variantType: Full Art
+- id: FILL_THIS-167
+  pioId: swsh9-167
+  enumId: BARRY_167
+  name: Barry
+  number: '167'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 3 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yuu Nishida
+  variantOf: FILL_THIS-130
+  variantType: Full Art
+- id: FILL_THIS-168
+  pioId: swsh9-168
+  enumId: CHEREN_S_CARE_168
+  name: Cheren's Care
+  number: '168'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Put 1 of your [C] Pokémon that has any damage counters on it and all attached
+    cards into your hand.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Ryuta Fuse
+  variantOf: FILL_THIS-134
+  variantType: Full Art
+- id: FILL_THIS-169
+  pioId: swsh9-169
+  enumId: CYNTHIA_S_AMBITION_169
+  name: Cynthia's Ambition
+  number: '169'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw cards until you have 5 cards in your hand. If any of your Pokémon were Knocked
+    Out during your opponent's last turn, draw cards until you have 8 cards in your
+    hand instead.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Megumi Mizutani
+  variantOf: FILL_THIS-138
+  variantType: Full Art
+- id: FILL_THIS-170
+  pioId: swsh9-170
+  enumId: KINDLER_170
+  name: Kindler
+  number: '170'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - You can use this card only if you discard a [R] Energy card from your hand. Look
+    at the top 7 cards of your deck and put up to 2 of them into your hand. Shuffle
+    the other cards back into your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hitoshi Ariga
+  variantOf: FILL_THIS-143
+  variantType: Full Art
+- id: FILL_THIS-171
+  pioId: swsh9-171
+  enumId: MARNIE_S_PRIDE_171
+  name: Marnie's Pride
+  number: '171'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Attach a basic Energy card from your discard pile to 1 of your Benched Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Souichirou Gunjima
+  variantOf: FILL_THIS-145
+  variantType: Full Art
+- id: FILL_THIS-172
+  pioId: swsh9-172
+  enumId: ROSEANNE_S_BACKUP_172
+  name: Roseanne's Backup
+  number: '172'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - 'Choose 1 or more: Shuffle a Pokémon from your discard pile into your deck.Shuffle
+    a Pokémon Tool card from your discard pile into your deck.Shuffle a Stadium card
+    from your discard pile into your deck.Shuffle an Energy card from your discard
+    pile into your deck.'
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: kirisAki
+  variantOf: FILL_THIS-148
+  variantType: Full Art
+- id: FILL_THIS-173
+  pioId: swsh9-173
+  enumId: SHAYMIN_VSTAR_173
+  name: Shaymin VSTAR
+  number: '173'
+  types: [G]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Shaymin V
+  hp: 250
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Star Bloom
+    text: During your turn, you may heal 120 damage from each of your Benched [G]
+      Pokémon. (You can't use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [G, C]
+    name: Revenge Blast
+    damage: 120+
+    text: This attack does 40 more damage for each Prize card your opponent has taken.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-14
+  variantType: Full Art
+- id: FILL_THIS-174
+  pioId: swsh9-174
+  enumId: CHARIZARD_VSTAR_174
+  name: Charizard VSTAR
+  number: '174'
+  types: [R]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Charizard V
+  hp: 280
+  retreatCost: 2
+  moves:
+  - cost: [R, R, C]
+    name: Explosive Fire
+    damage: 130+
+    text: If this Pokémon has any damage counters on it, this attack does 100 more
+      damage.
+  - cost: [R, R, R, C]
+    name: Star Blaze
+    damage: '320'
+    text: Discard 2 Energy from this Pokémon. (You can't use more than 1 VSTAR Power
+      in a game.)
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-18
+  variantType: Full Art
+- id: FILL_THIS-175
+  pioId: swsh9-175
+  enumId: WHIMSICOTT_VSTAR_175
+  name: Whimsicott VSTAR
+  number: '175'
+  types: [P]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Whimsicott V
+  hp: 250
+  retreatCost: 1
+  moves:
+  - cost: [P, C, C]
+    name: Trick Wind
+    damage: '160'
+    text: During your opponent's next turn, they can't play any Pokémon Tool or Special
+      Energy cards from their hand.
+  - cost: [P]
+    name: Fluffball Star
+    text: This attack does 60 damage to 1 of your opponent's Pokémon for each Energy
+      attached to this Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)
+      (You can't use more than 1 VSTAR Power in a game.)
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-65
+  variantType: Full Art
+- id: FILL_THIS-176
+  pioId: swsh9-176
+  enumId: ARCEUS_VSTAR_176
+  name: Arceus VSTAR
+  number: '176'
+  types: [C]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Arceus V
+  hp: 280
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Starbirth
+    text: During your turn, you may search your deck for up to 2 cards and put them
+      into your hand. Then, shuffle your deck. (You can't use more than 1 VSTAR Power
+      in a game.)
+  moves:
+  - cost: [C, C, C]
+    name: Trinity Nova
+    damage: '200'
+    text: Search your deck for up to 3 basic Energy cards and attach them to your
+      Pokémon V in any way you like. Then, shuffle your deck.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-123
+  variantType: Full Art
+- id: FILL_THIS-177
+  pioId: swsh9-177
+  enumId: CHEREN_S_CARE_177
+  name: Cheren's Care
+  number: '177'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Put 1 of your [C] Pokémon that has any damage counters on it and all attached
+    cards into your hand.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Ryuta Fuse
+  variantOf: FILL_THIS-134
+  variantType: Full Art
+- id: FILL_THIS-178
+  pioId: swsh9-178
+  enumId: CYNTHIA_S_AMBITION_178
+  name: Cynthia's Ambition
+  number: '178'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw cards until you have 5 cards in your hand. If any of your Pokémon were Knocked
+    Out during your opponent's last turn, draw cards until you have 8 cards in your
+    hand instead.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Megumi Mizutani
+  variantOf: FILL_THIS-138
+  variantType: Full Art
+- id: FILL_THIS-179
+  pioId: swsh9-179
+  enumId: KINDLER_179
+  name: Kindler
+  number: '179'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - You can use this card only if you discard a [R] Energy card from your hand. Look
+    at the top 7 cards of your deck and put up to 2 of them into your hand. Shuffle
+    the other cards back into your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hitoshi Ariga
+  variantOf: FILL_THIS-143
+  variantType: Full Art
+- id: FILL_THIS-180
+  pioId: swsh9-180
+  enumId: ROSEANNE_S_BACKUP_180
+  name: Roseanne's Backup
+  number: '180'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - 'Choose 1 or more: Shuffle a Pokémon from your discard pile into your deck.Shuffle
+    a Pokémon Tool card from your discard pile into your deck.Shuffle a Stadium card
+    from your discard pile into your deck.Shuffle an Energy card from your discard
+    pile into your deck.'
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: kirisAki
+  variantOf: FILL_THIS-148
+  variantType: Full Art
+- id: FILL_THIS-181
+  pioId: swsh9-181
+  enumId: GALARIAN_ARTICUNO_V_181
+  name: Galarian Articuno V
+  number: '181'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Reconstitute
+    text: You must discard 2 cards from your hand in order to use this Ability. Once
+      during your turn, you may draw a card.
+  moves:
+  - cost: [P, C, C]
+    name: Psyray
+    damage: '110'
+    text: Your opponent's Active Pokémon is now Confused.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Secret
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-182
+  pioId: swsh9-182
+  enumId: GALARIAN_ZAPDOS_V_182
+  name: Galarian Zapdos V
+  number: '182'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Fighting Instinct
+    text: This Pokémon's attacks cost [C] less for each of your opponent's Pokémon
+      V in play.
+  moves:
+  - cost: [F, C, C, C]
+    name: Thunderous Kick
+    damage: '170'
+    text: Before doing damage, discard a Special Energy from your opponent's Active
+      Pokémon.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Secret
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-183
+  pioId: swsh9-183
+  enumId: GALARIAN_MOLTRES_V_183
+  name: Galarian Moltres V
+  number: '183'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Direflame Wings
+    text: Once during your turn, you may attach a [D] Energy card from your discard
+      pile to this Pokémon. You can't use more than 1 Direflame Wings Ability each
+      turn.
+  moves:
+  - cost: [D, D, C]
+    name: Aura Burn
+    damage: '190'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Secret
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: akyCG Works
+- id: FILL_THIS-184
+  pioId: swsh9-184
+  enumId: ARCEUS_VSTAR_184
+  name: Arceus VSTAR
+  number: '184'
+  types: [C]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Arceus V
+  hp: 280
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Starbirth
+    text: During your turn, you may search your deck for up to 2 cards and put them
+      into your hand. Then, shuffle your deck. (You can't use more than 1 VSTAR Power
+      in a game.)
+  moves:
+  - cost: [C, C, C]
+    name: Trinity Nova
+    damage: '200'
+    text: Search your deck for up to 3 basic Energy cards and attach them to your
+      Pokémon V in any way you like. Then, shuffle your deck.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Secret
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-123
+  variantType: Secret Art
+- id: FILL_THIS-185
+  pioId: swsh9-185
+  enumId: MAGMA_BASIN_185
+  name: Magma Basin
+  number: '185'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Secret
+  text:
+  - Once during each player's turn, that player may attach a [R] Energy card from
+    their discard pile to 1 of their Benched [R] Pokémon. If a player attached Energy
+    to a Pokémon in this way, put 2 damage counters on that Pokémon.
+  artist: ORBITALLINK Inc.
+  variantOf: FILL_THIS-144
+  variantType: Secret Art
+- id: FILL_THIS-186
+  pioId: swsh9-186
+  enumId: ULTRA_BALL_186
+  name: Ultra Ball
+  number: '186'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Secret
+  text:
+  - You can use this card only if you discard 2 other cards from your hand. Search
+    your deck for a Pokémon, reveal it, and put it into your hand. Then, shuffle your
+    deck.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: sadaji
+  variantOf: FILL_THIS-150
+  variantType: Secret Art

--- a/data/src/main/resources/cards/441-brilliant_stars.yaml
+++ b/data/src/main/resources/cards/441-brilliant_stars.yaml
@@ -1,10 +1,10 @@
-id: FILL_THIS
+id: '441'
 name: swsh9
-enumId: FILL_THIS
-abbr: FILL_THIS
+enumId: BRILLIANT_STARS
+abbr: BRS
 pioId: swsh9
 cards:
-- id: FILL_THIS-1
+- id: 441-1
   pioId: swsh9-1
   enumId: EXEGGCUTE_1
   name: Exeggcute
@@ -27,7 +27,7 @@ cards:
     value: x2
   rarity: Common
   artist: '0313'
-- id: FILL_THIS-2
+- id: 441-2
   pioId: swsh9-2
   enumId: EXEGGUTOR_2
   name: Exeggutor
@@ -51,7 +51,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Naoyo Kimura
-- id: FILL_THIS-3
+- id: 441-3
   pioId: swsh9-3
   enumId: SHROOMISH_3
   name: Shroomish
@@ -71,7 +71,7 @@ cards:
     value: x2
   rarity: Common
   artist: Shigenori Negishi
-- id: FILL_THIS-4
+- id: 441-4
   pioId: swsh9-4
   enumId: BRELOOM_4
   name: Breloom
@@ -97,7 +97,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Sekio
-- id: FILL_THIS-5
+- id: 441-5
   pioId: swsh9-5
   enumId: TROPIUS_5
   name: Tropius
@@ -121,7 +121,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Shin Nagasawa
-- id: FILL_THIS-6
+- id: 441-6
   pioId: swsh9-6
   enumId: TURTWIG_6
   name: Turtwig
@@ -144,7 +144,7 @@ cards:
     value: x2
   rarity: Common
   artist: Narumi Sato
-- id: FILL_THIS-7
+- id: 441-7
   pioId: swsh9-7
   enumId: GROTLE_7
   name: Grotle
@@ -170,7 +170,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Nisota Niso
-- id: FILL_THIS-8
+- id: 441-8
   pioId: swsh9-8
   enumId: TORTERRA_8
   name: Torterra
@@ -194,7 +194,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Oswaldo KATO
-- id: FILL_THIS-9
+- id: 441-9
   pioId: swsh9-9
   enumId: BURMY_9
   name: Burmy
@@ -214,7 +214,7 @@ cards:
     value: x2
   rarity: Common
   artist: Miki Tanaka
-- id: FILL_THIS-10
+- id: 441-10
   pioId: swsh9-10
   enumId: WORMADAM_10
   name: Wormadam
@@ -239,7 +239,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Yuka Morii
-- id: FILL_THIS-11
+- id: 441-11
   pioId: swsh9-11
   enumId: MOTHIM_11
   name: Mothim
@@ -266,7 +266,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Akira Komayama
-- id: FILL_THIS-12
+- id: 441-12
   pioId: swsh9-12
   enumId: CHERUBI_12
   name: Cherubi
@@ -291,7 +291,7 @@ cards:
     value: x2
   rarity: Common
   artist: Naoyo Kimura
-- id: FILL_THIS-13
+- id: 441-13
   pioId: swsh9-13
   enumId: SHAYMIN_V_13
   name: Shaymin V
@@ -316,7 +316,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Satoshi Shirai
-- id: FILL_THIS-14
+- id: 441-14
   pioId: swsh9-14
   enumId: SHAYMIN_VSTAR_14
   name: Shaymin VSTAR
@@ -345,7 +345,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-15
+- id: 441-15
   pioId: swsh9-15
   enumId: KARRABLAST_15
   name: Karrablast
@@ -365,7 +365,7 @@ cards:
     value: x2
   rarity: Common
   artist: sowsow
-- id: FILL_THIS-16
+- id: 441-16
   pioId: swsh9-16
   enumId: ZARUDE_V_16
   name: Zarude V
@@ -393,7 +393,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-17
+- id: 441-17
   pioId: swsh9-17
   enumId: CHARIZARD_V_17
   name: Charizard V
@@ -419,7 +419,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: N-DESIGN Inc.
-- id: FILL_THIS-18
+- id: 441-18
   pioId: swsh9-18
   enumId: CHARIZARD_VSTAR_18
   name: Charizard VSTAR
@@ -449,7 +449,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-19
+- id: 441-19
   pioId: swsh9-19
   enumId: MAGMAR_19
   name: Magmar
@@ -472,7 +472,7 @@ cards:
     value: x2
   rarity: Common
   artist: Shinji Kanda
-- id: FILL_THIS-20
+- id: 441-20
   pioId: swsh9-20
   enumId: MAGMORTAR_20
   name: Magmortar
@@ -496,7 +496,7 @@ cards:
     value: x2
   rarity: Rare
   artist: AKIRA EGAWA
-- id: FILL_THIS-21
+- id: 441-21
   pioId: swsh9-21
   enumId: MOLTRES_21
   name: Moltres
@@ -517,7 +517,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: otumami
-- id: FILL_THIS-22
+- id: 441-22
   pioId: swsh9-22
   enumId: ENTEI_V_22
   name: Entei V
@@ -545,7 +545,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Mochizuki
-- id: FILL_THIS-23
+- id: 441-23
   pioId: swsh9-23
   enumId: TORKOAL_23
   name: Torkoal
@@ -570,7 +570,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Kagemaru Himeno
-- id: FILL_THIS-24
+- id: 441-24
   pioId: swsh9-24
   enumId: CHIMCHAR_24
   name: Chimchar
@@ -591,7 +591,7 @@ cards:
     value: x2
   rarity: Common
   artist: Shin Nagasawa
-- id: FILL_THIS-25
+- id: 441-25
   pioId: swsh9-25
   enumId: MONFERNO_25
   name: Monferno
@@ -616,7 +616,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: KEIICHIRO ITO
-- id: FILL_THIS-26
+- id: 441-26
   pioId: swsh9-26
   enumId: INFERNAPE_26
   name: Infernape
@@ -643,7 +643,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Anesaki Dynamic
-- id: FILL_THIS-27
+- id: 441-27
   pioId: swsh9-27
   enumId: SIMISEAR_V_27
   name: Simisear V
@@ -671,7 +671,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-28
+- id: 441-28
   pioId: swsh9-28
   enumId: KINGLER_V_28
   name: Kingler V
@@ -697,7 +697,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Mochizuki
-- id: FILL_THIS-29
+- id: 441-29
   pioId: swsh9-29
   enumId: KINGLER_VMAX_29
   name: Kingler VMAX
@@ -725,7 +725,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-30
+- id: 441-30
   pioId: swsh9-30
   enumId: STARYU_30
   name: Staryu
@@ -746,7 +746,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yuka Morii
-- id: FILL_THIS-31
+- id: 441-31
   pioId: swsh9-31
   enumId: LAPRAS_31
   name: Lapras
@@ -768,7 +768,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Teeziro
-- id: FILL_THIS-32
+- id: 441-32
   pioId: swsh9-32
   enumId: CORPHISH_32
   name: Corphish
@@ -791,7 +791,7 @@ cards:
     value: x2
   rarity: Common
   artist: Sekio
-- id: FILL_THIS-33
+- id: 441-33
   pioId: swsh9-33
   enumId: CRAWDAUNT_33
   name: Crawdaunt
@@ -815,7 +815,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Shibuzoh.
-- id: FILL_THIS-34
+- id: 441-34
   pioId: swsh9-34
   enumId: SNORUNT_34
   name: Snorunt
@@ -838,7 +838,7 @@ cards:
     value: x2
   rarity: Common
   artist: HYOGONOSUKE
-- id: FILL_THIS-35
+- id: 441-35
   pioId: swsh9-35
   enumId: PIPLUP_35
   name: Piplup
@@ -859,7 +859,7 @@ cards:
     value: x2
   rarity: Common
   artist: Atsushi Furusawa
-- id: FILL_THIS-36
+- id: 441-36
   pioId: swsh9-36
   enumId: PRINPLUP_36
   name: Prinplup
@@ -880,7 +880,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Kagemaru Himeno
-- id: FILL_THIS-37
+- id: 441-37
   pioId: swsh9-37
   enumId: EMPOLEON_37
   name: Empoleon
@@ -907,7 +907,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Kouki Saitou
-- id: FILL_THIS-38
+- id: 441-38
   pioId: swsh9-38
   enumId: BUIZEL_38
   name: Buizel
@@ -929,7 +929,7 @@ cards:
     value: x2
   rarity: Common
   artist: Tika Matsuno
-- id: FILL_THIS-39
+- id: 441-39
   pioId: swsh9-39
   enumId: FLOATZEL_39
   name: Floatzel
@@ -952,7 +952,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: kodama
-- id: FILL_THIS-40
+- id: 441-40
   pioId: swsh9-40
   enumId: LUMINEON_V_40
   name: Lumineon V
@@ -980,7 +980,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: takuyoa
-- id: FILL_THIS-41
+- id: 441-41
   pioId: swsh9-41
   enumId: MANAPHY_41
   name: Manaphy
@@ -1004,7 +1004,7 @@ cards:
     value: x2
   rarity: Rare
   artist: HYOGONOSUKE
-- id: FILL_THIS-42
+- id: 441-42
   pioId: swsh9-42
   enumId: CUBCHOO_42
   name: Cubchoo
@@ -1024,7 +1024,7 @@ cards:
     value: x2
   rarity: Common
   artist: ryoma uratsuka
-- id: FILL_THIS-43
+- id: 441-43
   pioId: swsh9-43
   enumId: BEARTIC_43
   name: Beartic
@@ -1048,7 +1048,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Rianti Hidayat
-- id: FILL_THIS-44
+- id: 441-44
   pioId: swsh9-44
   enumId: EISCUE_44
   name: Eiscue
@@ -1072,7 +1072,7 @@ cards:
     value: x2
   rarity: Rare
   artist: nagimiso
-- id: FILL_THIS-45
+- id: 441-45
   pioId: swsh9-45
   enumId: RAICHU_V_45
   name: Raichu V
@@ -1100,7 +1100,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: MUGENUP
-- id: FILL_THIS-46
+- id: 441-46
   pioId: swsh9-46
   enumId: ELECTABUZZ_46
   name: Electabuzz
@@ -1123,7 +1123,7 @@ cards:
     value: x2
   rarity: Common
   artist: OKACHEKE
-- id: FILL_THIS-47
+- id: 441-47
   pioId: swsh9-47
   enumId: ELECTIVIRE_47
   name: Electivire
@@ -1149,7 +1149,7 @@ cards:
     value: x2
   rarity: Rare
   artist: AKIRA EGAWA
-- id: FILL_THIS-48
+- id: 441-48
   pioId: swsh9-48
   enumId: RAIKOU_V_48
   name: Raikou V
@@ -1177,7 +1177,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Mochizuki
-- id: FILL_THIS-49
+- id: 441-49
   pioId: swsh9-49
   enumId: SHINX_49
   name: Shinx
@@ -1196,7 +1196,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mizue
-- id: FILL_THIS-50
+- id: 441-50
   pioId: swsh9-50
   enumId: LUXIO_50
   name: Luxio
@@ -1218,7 +1218,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: kurumitsu
-- id: FILL_THIS-51
+- id: 441-51
   pioId: swsh9-51
   enumId: LUXRAY_51
   name: Luxray
@@ -1245,7 +1245,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Ayaka Yoshida
-- id: FILL_THIS-52
+- id: 441-52
   pioId: swsh9-52
   enumId: PACHIRISU_52
   name: Pachirisu
@@ -1266,7 +1266,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: HYOGONOSUKE
-- id: FILL_THIS-53
+- id: 441-53
   pioId: swsh9-53
   enumId: CLEFAIRY_53
   name: Clefairy
@@ -1289,7 +1289,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yukiko Baba
-- id: FILL_THIS-54
+- id: 441-54
   pioId: swsh9-54
   enumId: CLEFABLE_54
   name: Clefable
@@ -1314,7 +1314,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Mizue
-- id: FILL_THIS-55
+- id: 441-55
   pioId: swsh9-55
   enumId: STARMIE_55
   name: Starmie
@@ -1341,7 +1341,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Akira Komayama
-- id: FILL_THIS-56
+- id: 441-56
   pioId: swsh9-56
   enumId: MEWTWO_56
   name: Mewtwo
@@ -1367,7 +1367,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Anesaki Dynamic
-- id: FILL_THIS-57
+- id: 441-57
   pioId: swsh9-57
   enumId: GRANBULL_V_57
   name: Granbull V
@@ -1393,7 +1393,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Mochizuki
-- id: FILL_THIS-58
+- id: 441-58
   pioId: swsh9-58
   enumId: BALTOY_58
   name: Baltoy
@@ -1417,7 +1417,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Kyoko Umemoto
-- id: FILL_THIS-59
+- id: 441-59
   pioId: swsh9-59
   enumId: CLAYDOL_59
   name: Claydol
@@ -1445,7 +1445,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Kazuma Koda
-- id: FILL_THIS-60
+- id: 441-60
   pioId: swsh9-60
   enumId: DUSKULL_60
   name: Duskull
@@ -1469,7 +1469,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: SATOSHI NAKAI
-- id: FILL_THIS-61
+- id: 441-61
   pioId: swsh9-61
   enumId: DUSCLOPS_61
   name: Dusclops
@@ -1494,7 +1494,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: miki kudo
-- id: FILL_THIS-62
+- id: 441-62
   pioId: swsh9-62
   enumId: DUSKNOIR_62
   name: Dusknoir
@@ -1522,7 +1522,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: otumami
-- id: FILL_THIS-63
+- id: 441-63
   pioId: swsh9-63
   enumId: CHIMECHO_63
   name: Chimecho
@@ -1548,7 +1548,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: MAHOU
-- id: FILL_THIS-64
+- id: 441-64
   pioId: swsh9-64
   enumId: WHIMSICOTT_V_64
   name: Whimsicott V
@@ -1576,7 +1576,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Saki Hayashiro
-- id: FILL_THIS-65
+- id: 441-65
   pioId: swsh9-65
   enumId: WHIMSICOTT_VSTAR_65
   name: Whimsicott VSTAR
@@ -1606,7 +1606,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-66
+- id: 441-66
   pioId: swsh9-66
   enumId: SIGILYPH_66
   name: Sigilyph
@@ -1634,7 +1634,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Sumiyoshi Kizuki
-- id: FILL_THIS-67
+- id: 441-67
   pioId: swsh9-67
   enumId: DEDENNE_67
   name: Dedenne
@@ -1655,7 +1655,7 @@ cards:
     value: x2
   rarity: Common
   artist: Nagomi Nijo
-- id: FILL_THIS-68
+- id: 441-68
   pioId: swsh9-68
   enumId: MIMIKYU_V_68
   name: Mimikyu V
@@ -1686,7 +1686,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Eske Yoshinob
-- id: FILL_THIS-69
+- id: 441-69
   pioId: swsh9-69
   enumId: MIMIKYU_VMAX_69
   name: Mimikyu VMAX
@@ -1718,7 +1718,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: Studio Bora Inc.
-- id: FILL_THIS-70
+- id: 441-70
   pioId: swsh9-70
   enumId: MILCERY_70
   name: Milcery
@@ -1742,7 +1742,7 @@ cards:
     value: x2
   rarity: Common
   artist: Misa Tsutsui
-- id: FILL_THIS-71
+- id: 441-71
   pioId: swsh9-71
   enumId: ALCREMIE_71
   name: Alcremie
@@ -1769,7 +1769,7 @@ cards:
     value: x2
   rarity: Rare
   artist: sowsow
-- id: FILL_THIS-72
+- id: 441-72
   pioId: swsh9-72
   enumId: HITMONTOP_72
   name: Hitmontop
@@ -1792,7 +1792,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: ryoma uratsuka
-- id: FILL_THIS-73
+- id: 441-73
   pioId: swsh9-73
   enumId: NOSEPASS_73
   name: Nosepass
@@ -1812,7 +1812,7 @@ cards:
     value: x2
   rarity: Common
   artist: miki kudo
-- id: FILL_THIS-74
+- id: 441-74
   pioId: swsh9-74
   enumId: TRAPINCH_74
   name: Trapinch
@@ -1833,7 +1833,7 @@ cards:
     value: x2
   rarity: Common
   artist: zig
-- id: FILL_THIS-75
+- id: 441-75
   pioId: swsh9-75
   enumId: VIBRAVA_75
   name: Vibrava
@@ -1854,7 +1854,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Tomokazu Komiya
-- id: FILL_THIS-76
+- id: 441-76
   pioId: swsh9-76
   enumId: FLYGON_76
   name: Flygon
@@ -1879,7 +1879,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Shin Nagasawa
-- id: FILL_THIS-77
+- id: 441-77
   pioId: swsh9-77
   enumId: WORMADAM_77
   name: Wormadam
@@ -1904,7 +1904,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Lee HyunJung
-- id: FILL_THIS-78
+- id: 441-78
   pioId: swsh9-78
   enumId: RIOLU_78
   name: Riolu
@@ -1924,7 +1924,7 @@ cards:
     value: x2
   rarity: Common
   artist: Teeziro
-- id: FILL_THIS-79
+- id: 441-79
   pioId: swsh9-79
   enumId: LUCARIO_79
   name: Lucario
@@ -1952,7 +1952,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: GIDORA
-- id: FILL_THIS-80
+- id: 441-80
   pioId: swsh9-80
   enumId: THROH_80
   name: Throh
@@ -1974,7 +1974,7 @@ cards:
     value: x2
   rarity: Common
   artist: Teeziro
-- id: FILL_THIS-81
+- id: 441-81
   pioId: swsh9-81
   enumId: SAWK_81
   name: Sawk
@@ -1994,7 +1994,7 @@ cards:
     value: x2
   rarity: Common
   artist: Shinji Kanda
-- id: FILL_THIS-82
+- id: 441-82
   pioId: swsh9-82
   enumId: GOLETT_82
   name: Golett
@@ -2017,7 +2017,7 @@ cards:
     value: x2
   rarity: Common
   artist: Eske Yoshinob
-- id: FILL_THIS-83
+- id: 441-83
   pioId: swsh9-83
   enumId: GOLURK_83
   name: Golurk
@@ -2041,7 +2041,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Aya Kusube
-- id: FILL_THIS-84
+- id: 441-84
   pioId: swsh9-84
   enumId: GRIMER_84
   name: Grimer
@@ -2061,7 +2061,7 @@ cards:
     value: x2
   rarity: Common
   artist: Masakazu Fukuda
-- id: FILL_THIS-85
+- id: 441-85
   pioId: swsh9-85
   enumId: MUK_85
   name: Muk
@@ -2086,7 +2086,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Scav
-- id: FILL_THIS-86
+- id: 441-86
   pioId: swsh9-86
   enumId: SNEASEL_86
   name: Sneasel
@@ -2109,7 +2109,7 @@ cards:
     value: x2
   rarity: Common
   artist: yuu
-- id: FILL_THIS-87
+- id: 441-87
   pioId: swsh9-87
   enumId: WEAVILE_87
   name: Weavile
@@ -2134,7 +2134,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Hasuno
-- id: FILL_THIS-88
+- id: 441-88
   pioId: swsh9-88
   enumId: HONCHKROW_V_88
   name: Honchkrow V
@@ -2164,7 +2164,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Mochizuki
-- id: FILL_THIS-89
+- id: 441-89
   pioId: swsh9-89
   enumId: SPIRITOMB_89
   name: Spiritomb
@@ -2187,7 +2187,7 @@ cards:
     value: x2
   rarity: Common
   artist: Uta
-- id: FILL_THIS-90
+- id: 441-90
   pioId: swsh9-90
   enumId: PURRLOIN_90
   name: Purrloin
@@ -2208,7 +2208,7 @@ cards:
     value: x2
   rarity: Common
   artist: Narumi Sato
-- id: FILL_THIS-91
+- id: 441-91
   pioId: swsh9-91
   enumId: LIEPARD_91
   name: Liepard
@@ -2233,7 +2233,7 @@ cards:
     value: x2
   rarity: Rare
   artist: AKIRA EGAWA
-- id: FILL_THIS-92
+- id: 441-92
   pioId: swsh9-92
   enumId: IMPIDIMP_92
   name: Impidimp
@@ -2257,7 +2257,7 @@ cards:
     value: x2
   rarity: Common
   artist: Rianti Hidayat
-- id: FILL_THIS-93
+- id: 441-93
   pioId: swsh9-93
   enumId: MORGREM_93
   name: Morgrem
@@ -2281,7 +2281,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Shiburingaru
-- id: FILL_THIS-94
+- id: 441-94
   pioId: swsh9-94
   enumId: GRIMMSNARL_94
   name: Grimmsnarl
@@ -2306,7 +2306,7 @@ cards:
     value: x2
   rarity: Rare
   artist: DOM
-- id: FILL_THIS-95
+- id: 441-95
   pioId: swsh9-95
   enumId: MORPEKO_V_95
   name: Morpeko V
@@ -2333,7 +2333,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Mochizuki
-- id: FILL_THIS-96
+- id: 441-96
   pioId: swsh9-96
   enumId: AGGRON_V_96
   name: Aggron V
@@ -2364,7 +2364,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Mochizuki
-- id: FILL_THIS-97
+- id: 441-97
   pioId: swsh9-97
   enumId: AGGRON_VMAX_97
   name: Aggron VMAX
@@ -2395,7 +2395,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-98
+- id: 441-98
   pioId: swsh9-98
   enumId: WORMADAM_98
   name: Wormadam
@@ -2422,7 +2422,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Ryo Ueda
-- id: FILL_THIS-99
+- id: 441-99
   pioId: swsh9-99
   enumId: PROBOPASS_99
   name: Probopass
@@ -2450,7 +2450,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Pani Kobayashi
-- id: FILL_THIS-100
+- id: 441-100
   pioId: swsh9-100
   enumId: HEATRAN_100
   name: Heatran
@@ -2478,7 +2478,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Yuya Oka
-- id: FILL_THIS-101
+- id: 441-101
   pioId: swsh9-101
   enumId: ESCAVALIER_101
   name: Escavalier
@@ -2508,7 +2508,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Nurikabe
-- id: FILL_THIS-102
+- id: 441-102
   pioId: swsh9-102
   enumId: KLINK_102
   name: Klink
@@ -2534,7 +2534,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: OKACHEKE
-- id: FILL_THIS-103
+- id: 441-103
   pioId: swsh9-103
   enumId: KLANG_103
   name: Klang
@@ -2563,7 +2563,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Hataya
-- id: FILL_THIS-104
+- id: 441-104
   pioId: swsh9-104
   enumId: KLINKLANG_104
   name: Klinklang
@@ -2592,7 +2592,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Megumi Higuchi
-- id: FILL_THIS-105
+- id: 441-105
   pioId: swsh9-105
   enumId: ZAMAZENTA_V_105
   name: Zamazenta V
@@ -2622,7 +2622,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Mochizuki
-- id: FILL_THIS-106
+- id: 441-106
   pioId: swsh9-106
   enumId: FLYGON_V_106
   name: Flygon V
@@ -2645,7 +2645,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Mochizuki
-- id: FILL_THIS-107
+- id: 441-107
   pioId: swsh9-107
   enumId: GIBLE_107
   name: Gible
@@ -2662,7 +2662,7 @@ cards:
     damage: '30'
   rarity: Common
   artist: sowsow
-- id: FILL_THIS-108
+- id: 441-108
   pioId: swsh9-108
   enumId: GABITE_108
   name: Gabite
@@ -2680,7 +2680,7 @@ cards:
     damage: '70'
   rarity: Uncommon
   artist: hatachu
-- id: FILL_THIS-109
+- id: 441-109
   pioId: swsh9-109
   enumId: GARCHOMP_109
   name: Garchomp
@@ -2705,7 +2705,7 @@ cards:
     text: Discard the top 2 cards of your deck.
   rarity: Rare Holo
   artist: Nurikabe
-- id: FILL_THIS-110
+- id: 441-110
   pioId: swsh9-110
   enumId: AXEW_110
   name: Axew
@@ -2723,7 +2723,7 @@ cards:
       Axew to evolve it. Then, shuffle your deck.
   rarity: Common
   artist: Saya Tsuruta
-- id: FILL_THIS-111
+- id: 441-111
   pioId: swsh9-111
   enumId: FRAXURE_111
   name: Fraxure
@@ -2744,7 +2744,7 @@ cards:
     damage: '60'
   rarity: Uncommon
   artist: Hataya
-- id: FILL_THIS-112
+- id: 441-112
   pioId: swsh9-112
   enumId: HAXORUS_112
   name: Haxorus
@@ -2765,7 +2765,7 @@ cards:
     text: This Pokémon also does 30 damage to itself.
   rarity: Rare
   artist: Uta
-- id: FILL_THIS-113
+- id: 441-113
   pioId: swsh9-113
   enumId: DRUDDIGON_113
   name: Druddigon
@@ -2786,7 +2786,7 @@ cards:
     damage: '120'
   rarity: Rare
   artist: Ryo Ueda
-- id: FILL_THIS-114
+- id: 441-114
   pioId: swsh9-114
   enumId: DRACOVISH_V_114
   name: Dracovish V
@@ -2811,7 +2811,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Satoshi Shirai
-- id: FILL_THIS-115
+- id: 441-115
   pioId: swsh9-115
   enumId: FARFETCH_D_115
   name: Farfetch'd
@@ -2836,7 +2836,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Tomokazu Komiya
-- id: FILL_THIS-116
+- id: 441-116
   pioId: swsh9-116
   enumId: CASTFORM_116
   name: Castform
@@ -2859,7 +2859,7 @@ cards:
     value: x2
   rarity: Common
   artist: kawayoo
-- id: FILL_THIS-117
+- id: 441-117
   pioId: swsh9-117
   enumId: STARLY_117
   name: Starly
@@ -2883,7 +2883,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Saya Tsuruta
-- id: FILL_THIS-118
+- id: 441-118
   pioId: swsh9-118
   enumId: STARAVIA_118
   name: Staravia
@@ -2907,7 +2907,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Kouki Saitou
-- id: FILL_THIS-119
+- id: 441-119
   pioId: swsh9-119
   enumId: STARAPTOR_119
   name: Staraptor
@@ -2935,7 +2935,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Narumi Sato
-- id: FILL_THIS-120
+- id: 441-120
   pioId: swsh9-120
   enumId: BIDOOF_120
   name: Bidoof
@@ -2955,7 +2955,7 @@ cards:
     value: x2
   rarity: Common
   artist: Oswaldo KATO
-- id: FILL_THIS-121
+- id: 441-121
   pioId: swsh9-121
   enumId: BIBAREL_121
   name: Bibarel
@@ -2981,7 +2981,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: OKACHEKE
-- id: FILL_THIS-122
+- id: 441-122
   pioId: swsh9-122
   enumId: ARCEUS_V_122
   name: Arceus V
@@ -3006,7 +3006,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: N-DESIGN Inc.
-- id: FILL_THIS-123
+- id: 441-123
   pioId: swsh9-123
   enumId: ARCEUS_VSTAR_123
   name: Arceus VSTAR
@@ -3037,7 +3037,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-124
+- id: 441-124
   pioId: swsh9-124
   enumId: MINCCINO_124
   name: Minccino
@@ -3061,7 +3061,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mina Nakai
-- id: FILL_THIS-125
+- id: 441-125
   pioId: swsh9-125
   enumId: CINCCINO_125
   name: Cinccino
@@ -3085,7 +3085,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Atsuko Nishida
-- id: FILL_THIS-126
+- id: 441-126
   pioId: swsh9-126
   enumId: TORNADUS_126
   name: Tornadus
@@ -3113,7 +3113,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Shigenori Negishi
-- id: FILL_THIS-127
+- id: 441-127
   pioId: swsh9-127
   enumId: HAWLUCHA_127
   name: Hawlucha
@@ -3141,7 +3141,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Miki Tanaka
-- id: FILL_THIS-128
+- id: 441-128
   pioId: swsh9-128
   enumId: DRAMPA_V_128
   name: Drampa V
@@ -3167,7 +3167,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: aky CG Works
-- id: FILL_THIS-129
+- id: 441-129
   pioId: swsh9-129
   enumId: ACEROLA_S_PREMONITION_129
   name: Acerola's Premonition
@@ -3180,7 +3180,7 @@ cards:
     find there.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Shiburingaru
-- id: FILL_THIS-130
+- id: 441-130
   pioId: swsh9-130
   enumId: BARRY_130
   name: Barry
@@ -3192,7 +3192,7 @@ cards:
   - Draw 3 cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Ken Sugimori
-- id: FILL_THIS-131
+- id: 441-131
   pioId: swsh9-131
   enumId: BLUNDER_POLICY_131
   name: Blunder Policy
@@ -3208,7 +3208,7 @@ cards:
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
     have a Pokémon Tool attached.'
   artist: Ayaka Yoshida
-- id: FILL_THIS-132
+- id: 441-132
   pioId: swsh9-132
   enumId: BOSS_S_ORDERS_132
   name: Boss's Orders
@@ -3220,7 +3220,7 @@ cards:
   - Switch 1 of your opponent's Benched Pokémon with their Active Pokémon.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: GIDORA
-- id: FILL_THIS-133
+- id: 441-133
   pioId: swsh9-133
   enumId: CAFE_MASTER_133
   name: Café Master
@@ -3234,7 +3234,7 @@ cards:
     Then, shuffle your deck. Your turn ends.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Hasegawa Saki
-- id: FILL_THIS-134
+- id: 441-134
   pioId: swsh9-134
   enumId: CHEREN_S_CARE_134
   name: Cheren's Care
@@ -3247,7 +3247,7 @@ cards:
     cards into your hand.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Yusuke Ohmura
-- id: FILL_THIS-135
+- id: 441-135
   pioId: swsh9-135
   enumId: CHOICE_BELT_135
   name: Choice Belt
@@ -3262,7 +3262,7 @@ cards:
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
     have a Pokémon Tool attached.'
   artist: Studio Bora Inc.
-- id: FILL_THIS-136
+- id: 441-136
   pioId: swsh9-136
   enumId: CLEANSING_GLOVES_136
   name: Cleansing Gloves
@@ -3277,7 +3277,7 @@ cards:
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
     have a Pokémon Tool attached.'
   artist: Toyste Beach
-- id: FILL_THIS-137
+- id: 441-137
   pioId: swsh9-137
   enumId: COLLAPSED_STADIUM_137
   name: Collapsed Stadium
@@ -3291,7 +3291,7 @@ cards:
     Bench. The player who played this card discards first. If more than one effect
     changes the number of Benched Pokémon allowed, use the smaller number.
   artist: Oswaldo KATO
-- id: FILL_THIS-138
+- id: 441-138
   pioId: swsh9-138
   enumId: CYNTHIA_S_AMBITION_138
   name: Cynthia's Ambition
@@ -3305,7 +3305,7 @@ cards:
     hand instead.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Megumi Mizutani
-- id: FILL_THIS-139
+- id: 441-139
   pioId: swsh9-139
   enumId: FRESH_WATER_SET_139
   name: Fresh Water Set
@@ -3317,7 +3317,7 @@ cards:
   - Heal 20 damage from each of your Pokémon.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: AYUMI ODASHIMA
-- id: FILL_THIS-140
+- id: 441-140
   pioId: swsh9-140
   enumId: FRIENDS_IN_GALAR_140
   name: Friends in Galar
@@ -3329,7 +3329,7 @@ cards:
   - Draw 3 cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Yuu Nishida
-- id: FILL_THIS-141
+- id: 441-141
   pioId: swsh9-141
   enumId: GLORIA_141
   name: Gloria
@@ -3343,7 +3343,7 @@ cards:
     Rule Boxes.)
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Ken Sugimori
-- id: FILL_THIS-142
+- id: 441-142
   pioId: swsh9-142
   enumId: HUNTING_GLOVES_142
   name: Hunting Gloves
@@ -3358,7 +3358,7 @@ cards:
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
     have a Pokémon Tool attached.'
   artist: Toyste Beach
-- id: FILL_THIS-143
+- id: 441-143
   pioId: swsh9-143
   enumId: KINDLER_143
   name: Kindler
@@ -3372,7 +3372,7 @@ cards:
     the other cards back into your deck.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Hitoshi Ariga
-- id: FILL_THIS-144
+- id: 441-144
   pioId: swsh9-144
   enumId: MAGMA_BASIN_144
   name: Magma Basin
@@ -3385,7 +3385,7 @@ cards:
     their discard pile to 1 of their Benched [R] Pokémon. If a player attached Energy
     to a Pokémon in this way, put 2 damage counters on that Pokémon.
   artist: ORBITALLINK Inc.
-- id: FILL_THIS-145
+- id: 441-145
   pioId: swsh9-145
   enumId: MARNIE_S_PRIDE_145
   name: Marnie's Pride
@@ -3397,7 +3397,7 @@ cards:
   - Attach a basic Energy card from your discard pile to 1 of your Benched Pokémon.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: saino misaki
-- id: FILL_THIS-146
+- id: 441-146
   pioId: swsh9-146
   enumId: POT_HELMET_146
   name: Pot Helmet
@@ -3413,7 +3413,7 @@ cards:
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
     have a Pokémon Tool attached.'
   artist: Toyste Beach
-- id: FILL_THIS-147
+- id: 441-147
   pioId: swsh9-147
   enumId: PROFESSOR_S_RESEARCH_147
   name: Professor's Research
@@ -3425,7 +3425,7 @@ cards:
   - Discard your hand and draw 7 cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Sanosuke Sakuma
-- id: FILL_THIS-148
+- id: 441-148
   pioId: swsh9-148
   enumId: ROSEANNE_S_BACKUP_148
   name: Roseanne's Backup
@@ -3440,7 +3440,7 @@ cards:
     pile into your deck.'
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Nagomi Nijo
-- id: FILL_THIS-149
+- id: 441-149
   pioId: swsh9-149
   enumId: TEAM_YELL_S_CHEER_149
   name: Team Yell's Cheer
@@ -3453,7 +3453,7 @@ cards:
     Team Yell's Cheer, from your discard pile into your deck.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: GOSSAN
-- id: FILL_THIS-150
+- id: 441-150
   pioId: swsh9-150
   enumId: ULTRA_BALL_150
   name: Ultra Ball
@@ -3467,7 +3467,7 @@ cards:
     deck.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: sadaji
-- id: FILL_THIS-151
+- id: 441-151
   pioId: swsh9-151
   enumId: DOUBLE_TURBO_ENERGY_151
   name: Double Turbo Energy
@@ -3479,7 +3479,7 @@ cards:
   - As long as this card is attached to a Pokémon, it provides [C][C] Energy. The
     attacks of the Pokémon this card is attached to do 20 less damage to your opponent's
     Pokémon (before applying Weakness and Resistance).
-- id: FILL_THIS-152
+- id: 441-152
   pioId: swsh9-152
   enumId: SHAYMIN_V_152
   name: Shaymin V
@@ -3506,7 +3506,7 @@ cards:
   artist: Eske Yoshinob
   variantOf: FILL_THIS-13
   variantType: Full Art
-- id: FILL_THIS-153
+- id: 441-153
   pioId: swsh9-153
   enumId: CHARIZARD_V_153
   name: Charizard V
@@ -3534,7 +3534,7 @@ cards:
   artist: N-DESIGN Inc.
   variantOf: FILL_THIS-17
   variantType: Full Art
-- id: FILL_THIS-154
+- id: 441-154
   pioId: swsh9-154
   enumId: CHARIZARD_V_154
   name: Charizard V
@@ -3562,7 +3562,7 @@ cards:
   artist: Ryota Murayama
   variantOf: FILL_THIS-17
   variantType: Full Art
-- id: FILL_THIS-155
+- id: 441-155
   pioId: swsh9-155
   enumId: LUMINEON_V_155
   name: Lumineon V
@@ -3592,7 +3592,7 @@ cards:
   artist: takuyoa
   variantOf: FILL_THIS-40
   variantType: Full Art
-- id: FILL_THIS-156
+- id: 441-156
   pioId: swsh9-156
   enumId: LUMINEON_V_156
   name: Lumineon V
@@ -3622,7 +3622,7 @@ cards:
   artist: Ligton
   variantOf: FILL_THIS-40
   variantType: Full Art
-- id: FILL_THIS-157
+- id: 441-157
   pioId: swsh9-157
   enumId: PIKACHU_V_157
   name: Pikachu V
@@ -3646,7 +3646,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-158
+- id: 441-158
   pioId: swsh9-158
   enumId: RAICHU_V_158
   name: Raichu V
@@ -3676,7 +3676,7 @@ cards:
   artist: MUGENUP
   variantOf: FILL_THIS-45
   variantType: Full Art
-- id: FILL_THIS-159
+- id: 441-159
   pioId: swsh9-159
   enumId: GRANBULL_V_159
   name: Granbull V
@@ -3704,7 +3704,7 @@ cards:
   artist: Ayaka Yoshida
   variantOf: FILL_THIS-57
   variantType: Full Art
-- id: FILL_THIS-160
+- id: 441-160
   pioId: swsh9-160
   enumId: WHIMSICOTT_V_160
   name: Whimsicott V
@@ -3734,7 +3734,7 @@ cards:
   artist: Saki Hayashiro
   variantOf: FILL_THIS-64
   variantType: Full Art
-- id: FILL_THIS-161
+- id: 441-161
   pioId: swsh9-161
   enumId: HONCHKROW_V_161
   name: Honchkrow V
@@ -3766,7 +3766,7 @@ cards:
   artist: PLANETA Mochizuki
   variantOf: FILL_THIS-88
   variantType: Full Art
-- id: FILL_THIS-162
+- id: 441-162
   pioId: swsh9-162
   enumId: HONCHKROW_V_162
   name: Honchkrow V
@@ -3798,7 +3798,7 @@ cards:
   artist: zig
   variantOf: FILL_THIS-88
   variantType: Full Art
-- id: FILL_THIS-163
+- id: 441-163
   pioId: swsh9-163
   enumId: ZAMAZENTA_V_163
   name: Zamazenta V
@@ -3830,7 +3830,7 @@ cards:
   artist: Ayaka Yoshida
   variantOf: FILL_THIS-105
   variantType: Full Art
-- id: FILL_THIS-164
+- id: 441-164
   pioId: swsh9-164
   enumId: FLYGON_V_164
   name: Flygon V
@@ -3855,7 +3855,7 @@ cards:
   artist: PLANETA Mochizuki
   variantOf: FILL_THIS-106
   variantType: Full Art
-- id: FILL_THIS-165
+- id: 441-165
   pioId: swsh9-165
   enumId: ARCEUS_V_165
   name: Arceus V
@@ -3882,7 +3882,7 @@ cards:
   artist: N-DESIGN Inc.
   variantOf: FILL_THIS-122
   variantType: Full Art
-- id: FILL_THIS-166
+- id: 441-166
   pioId: swsh9-166
   enumId: ARCEUS_V_166
   name: Arceus V
@@ -3909,7 +3909,7 @@ cards:
   artist: kawayoo
   variantOf: FILL_THIS-122
   variantType: Full Art
-- id: FILL_THIS-167
+- id: 441-167
   pioId: swsh9-167
   enumId: BARRY_167
   name: Barry
@@ -3923,7 +3923,7 @@ cards:
   artist: Yuu Nishida
   variantOf: FILL_THIS-130
   variantType: Full Art
-- id: FILL_THIS-168
+- id: 441-168
   pioId: swsh9-168
   enumId: CHEREN_S_CARE_168
   name: Cheren's Care
@@ -3938,7 +3938,7 @@ cards:
   artist: Ryuta Fuse
   variantOf: FILL_THIS-134
   variantType: Full Art
-- id: FILL_THIS-169
+- id: 441-169
   pioId: swsh9-169
   enumId: CYNTHIA_S_AMBITION_169
   name: Cynthia's Ambition
@@ -3954,7 +3954,7 @@ cards:
   artist: Megumi Mizutani
   variantOf: FILL_THIS-138
   variantType: Full Art
-- id: FILL_THIS-170
+- id: 441-170
   pioId: swsh9-170
   enumId: KINDLER_170
   name: Kindler
@@ -3970,7 +3970,7 @@ cards:
   artist: Hitoshi Ariga
   variantOf: FILL_THIS-143
   variantType: Full Art
-- id: FILL_THIS-171
+- id: 441-171
   pioId: swsh9-171
   enumId: MARNIE_S_PRIDE_171
   name: Marnie's Pride
@@ -3984,7 +3984,7 @@ cards:
   artist: Souichirou Gunjima
   variantOf: FILL_THIS-145
   variantType: Full Art
-- id: FILL_THIS-172
+- id: 441-172
   pioId: swsh9-172
   enumId: ROSEANNE_S_BACKUP_172
   name: Roseanne's Backup
@@ -4001,7 +4001,7 @@ cards:
   artist: kirisAki
   variantOf: FILL_THIS-148
   variantType: Full Art
-- id: FILL_THIS-173
+- id: 441-173
   pioId: swsh9-173
   enumId: SHAYMIN_VSTAR_173
   name: Shaymin VSTAR
@@ -4032,7 +4032,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-14
   variantType: Full Art
-- id: FILL_THIS-174
+- id: 441-174
   pioId: swsh9-174
   enumId: CHARIZARD_VSTAR_174
   name: Charizard VSTAR
@@ -4064,7 +4064,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-18
   variantType: Full Art
-- id: FILL_THIS-175
+- id: 441-175
   pioId: swsh9-175
   enumId: WHIMSICOTT_VSTAR_175
   name: Whimsicott VSTAR
@@ -4096,7 +4096,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-65
   variantType: Full Art
-- id: FILL_THIS-176
+- id: 441-176
   pioId: swsh9-176
   enumId: ARCEUS_VSTAR_176
   name: Arceus VSTAR
@@ -4129,7 +4129,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-123
   variantType: Full Art
-- id: FILL_THIS-177
+- id: 441-177
   pioId: swsh9-177
   enumId: CHEREN_S_CARE_177
   name: Cheren's Care
@@ -4144,7 +4144,7 @@ cards:
   artist: Ryuta Fuse
   variantOf: FILL_THIS-134
   variantType: Full Art
-- id: FILL_THIS-178
+- id: 441-178
   pioId: swsh9-178
   enumId: CYNTHIA_S_AMBITION_178
   name: Cynthia's Ambition
@@ -4160,7 +4160,7 @@ cards:
   artist: Megumi Mizutani
   variantOf: FILL_THIS-138
   variantType: Full Art
-- id: FILL_THIS-179
+- id: 441-179
   pioId: swsh9-179
   enumId: KINDLER_179
   name: Kindler
@@ -4176,7 +4176,7 @@ cards:
   artist: Hitoshi Ariga
   variantOf: FILL_THIS-143
   variantType: Full Art
-- id: FILL_THIS-180
+- id: 441-180
   pioId: swsh9-180
   enumId: ROSEANNE_S_BACKUP_180
   name: Roseanne's Backup
@@ -4193,7 +4193,7 @@ cards:
   artist: kirisAki
   variantOf: FILL_THIS-148
   variantType: Full Art
-- id: FILL_THIS-181
+- id: 441-181
   pioId: swsh9-181
   enumId: GALARIAN_ARTICUNO_V_181
   name: Galarian Articuno V
@@ -4223,7 +4223,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-182
+- id: 441-182
   pioId: swsh9-182
   enumId: GALARIAN_ZAPDOS_V_182
   name: Galarian Zapdos V
@@ -4251,7 +4251,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-183
+- id: 441-183
   pioId: swsh9-183
   enumId: GALARIAN_MOLTRES_V_183
   name: Galarian Moltres V
@@ -4279,7 +4279,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: akyCG Works
-- id: FILL_THIS-184
+- id: 441-184
   pioId: swsh9-184
   enumId: ARCEUS_VSTAR_184
   name: Arceus VSTAR
@@ -4312,7 +4312,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-123
   variantType: Secret Art
-- id: FILL_THIS-185
+- id: 441-185
   pioId: swsh9-185
   enumId: MAGMA_BASIN_185
   name: Magma Basin
@@ -4327,7 +4327,7 @@ cards:
   artist: ORBITALLINK Inc.
   variantOf: FILL_THIS-144
   variantType: Secret Art
-- id: FILL_THIS-186
+- id: 441-186
   pioId: swsh9-186
   enumId: ULTRA_BALL_186
   name: Ultra Ball

--- a/data/src/main/resources/cards/441-brilliant_stars.yaml
+++ b/data/src/main/resources/cards/441-brilliant_stars.yaml
@@ -324,7 +324,7 @@ cards:
   number: '14'
   types: [G]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Shaymin V
   hp: 250
   retreatCost: 1
@@ -427,7 +427,7 @@ cards:
   number: '18'
   types: [R]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Charizard V
   hp: 280
   retreatCost: 2
@@ -1584,7 +1584,7 @@ cards:
   number: '65'
   types: [P]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Whimsicott V
   hp: 250
   retreatCost: 1
@@ -3014,7 +3014,7 @@ cards:
   number: '123'
   types: [C]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Arceus V
   hp: 280
   retreatCost: 2
@@ -4009,7 +4009,7 @@ cards:
   number: '173'
   types: [G]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Shaymin V
   hp: 250
   retreatCost: 1
@@ -4040,7 +4040,7 @@ cards:
   number: '174'
   types: [R]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Charizard V
   hp: 280
   retreatCost: 2
@@ -4072,7 +4072,7 @@ cards:
   number: '175'
   types: [P]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Whimsicott V
   hp: 250
   retreatCost: 1
@@ -4104,7 +4104,7 @@ cards:
   number: '176'
   types: [C]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Arceus V
   hp: 280
   retreatCost: 2
@@ -4287,7 +4287,7 @@ cards:
   number: '184'
   types: [C]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Arceus V
   hp: 280
   retreatCost: 2

--- a/data/src/main/resources/cards/441-brilliant_stars.yaml
+++ b/data/src/main/resources/cards/441-brilliant_stars.yaml
@@ -1056,7 +1056,7 @@ cards:
   number: '44'
   types: [W]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [BASIC, FUSION_STRIKE]
   hp: 110
   retreatCost: 1
   moves:

--- a/data/src/main/resources/cards/442-astral_radiance.yaml
+++ b/data/src/main/resources/cards/442-astral_radiance.yaml
@@ -409,7 +409,7 @@ cards:
   number: '18'
   types: [G]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Hisuian Lilligant V
   hp: 260
   retreatCost: 1
@@ -950,7 +950,7 @@ cards:
   number: '40'
   types: [W]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Origin Forme Palkia V
   hp: 280
   retreatCost: 2
@@ -1304,7 +1304,7 @@ cards:
   number: '54'
   types: [P]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Hisuian Typhlosion V
   hp: 260
   retreatCost: 2
@@ -2073,7 +2073,7 @@ cards:
   number: '84'
   types: [F]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Hisuian Decidueye V
   hp: 270
   retreatCost: 2
@@ -2443,7 +2443,7 @@ cards:
   number: '99'
   types: [D]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Darkrai V
   hp: 270
   retreatCost: 2
@@ -2525,7 +2525,7 @@ cards:
   number: '102'
   types: [D]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Hisuian Samurott V
   hp: 270
   retreatCost: 2
@@ -2846,7 +2846,7 @@ cards:
   number: '114'
   types: [M]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Origin Forme Dialga V
   hp: 280
   retreatCost: 3
@@ -4435,7 +4435,7 @@ cards:
   number: '190'
   types: [G]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Hisuian Lilligant V
   hp: 260
   retreatCost: 1
@@ -4499,7 +4499,7 @@ cards:
   number: '192'
   types: [W]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Origin Forme Palkia V
   hp: 280
   retreatCost: 2
@@ -4532,7 +4532,7 @@ cards:
   number: '193'
   types: [P]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Hisuian Typhlosion V
   hp: 260
   retreatCost: 2
@@ -4597,7 +4597,7 @@ cards:
   number: '195'
   types: [F]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Hisuian Decidueye V
   hp: 270
   retreatCost: 2
@@ -4629,7 +4629,7 @@ cards:
   number: '196'
   types: [F]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Kleavor V
   hp: 270
   retreatCost: 2
@@ -4659,7 +4659,7 @@ cards:
   number: '197'
   types: [D]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Hisuian Samurott V
   hp: 270
   retreatCost: 2
@@ -4691,7 +4691,7 @@ cards:
   number: '198'
   types: [M]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Origin Forme Dialga V
   hp: 280
   retreatCost: 3
@@ -4862,7 +4862,7 @@ cards:
   number: '208'
   types: [W]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Origin Forme Palkia V
   hp: 280
   retreatCost: 2
@@ -4895,7 +4895,7 @@ cards:
   number: '209'
   types: [D]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Hisuian Samurott V
   hp: 270
   retreatCost: 2
@@ -4927,7 +4927,7 @@ cards:
   number: '210'
   types: [M]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Origin Forme Dialga V
   hp: 280
   retreatCost: 3

--- a/data/src/main/resources/cards/442-astral_radiance.yaml
+++ b/data/src/main/resources/cards/442-astral_radiance.yaml
@@ -1,10 +1,10 @@
-id: FILL_THIS
+id: '442'
 name: swsh10
-enumId: FILL_THIS
-abbr: FILL_THIS
+enumId: ASTRAL_RADIANCE
+abbr: ASR
 pioId: swsh10
 cards:
-- id: FILL_THIS-1
+- id: 442-1
   pioId: swsh10-1
   enumId: BEEDRILL_V_1
   name: Beedrill V
@@ -30,7 +30,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Ayaka Yoshida
-- id: FILL_THIS-2
+- id: 442-2
   pioId: swsh10-2
   enumId: HISUIAN_VOLTORB_2
   name: Hisuian Voltorb
@@ -56,7 +56,7 @@ cards:
     value: x2
   rarity: Common
   artist: nagimiso
-- id: FILL_THIS-3
+- id: 442-3
   pioId: swsh10-3
   enumId: HISUIAN_ELECTRODE_3
   name: Hisuian Electrode
@@ -79,7 +79,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Akira Komayama
-- id: FILL_THIS-4
+- id: 442-4
   pioId: swsh10-4
   enumId: SCYTHER_4
   name: Scyther
@@ -99,7 +99,7 @@ cards:
     value: x2
   rarity: Common
   artist: GIDORA
-- id: FILL_THIS-5
+- id: 442-5
   pioId: swsh10-5
   enumId: SCYTHER_5
   name: Scyther
@@ -120,7 +120,7 @@ cards:
     value: x2
   rarity: Common
   artist: Uta
-- id: FILL_THIS-6
+- id: 442-6
   pioId: swsh10-6
   enumId: YANMA_6
   name: Yanma
@@ -139,7 +139,7 @@ cards:
     value: x2
   rarity: Common
   artist: OKACHEKE
-- id: FILL_THIS-7
+- id: 442-7
   pioId: swsh10-7
   enumId: YANMEGA_7
   name: Yanmega
@@ -163,7 +163,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Masakazu Fukuda
-- id: FILL_THIS-8
+- id: 442-8
   pioId: swsh10-8
   enumId: HERACROSS_8
   name: Heracross
@@ -187,7 +187,7 @@ cards:
     value: x2
   rarity: Common
   artist: aoki
-- id: FILL_THIS-9
+- id: 442-9
   pioId: swsh10-9
   enumId: KRICKETOT_9
   name: Kricketot
@@ -208,7 +208,7 @@ cards:
     value: x2
   rarity: Common
   artist: Masakazu Fukuda
-- id: FILL_THIS-10
+- id: 442-10
   pioId: swsh10-10
   enumId: KRICKETUNE_10
   name: Kricketune
@@ -233,7 +233,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Mitsuhiro Arita
-- id: FILL_THIS-11
+- id: 442-11
   pioId: swsh10-11
   enumId: COMBEE_11
   name: Combee
@@ -257,7 +257,7 @@ cards:
     value: x2
   rarity: Common
   artist: sowsow
-- id: FILL_THIS-12
+- id: 442-12
   pioId: swsh10-12
   enumId: VESPIQUEN_12
   name: Vespiquen
@@ -282,7 +282,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Yuya Oka
-- id: FILL_THIS-13
+- id: 442-13
   pioId: swsh10-13
   enumId: LEAFEON_13
   name: Leafeon
@@ -307,7 +307,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Atsushi Furusawa
-- id: FILL_THIS-14
+- id: 442-14
   pioId: swsh10-14
   enumId: SHAYMIN_14
   name: Shaymin
@@ -331,7 +331,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Kouki Saitou
-- id: FILL_THIS-15
+- id: 442-15
   pioId: swsh10-15
   enumId: PETILIL_15
   name: Petilil
@@ -352,7 +352,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yukiko Baba
-- id: FILL_THIS-16
+- id: 442-16
   pioId: swsh10-16
   enumId: HISUIAN_LILLIGANT_16
   name: Hisuian Lilligant
@@ -377,7 +377,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Mizue
-- id: FILL_THIS-17
+- id: 442-17
   pioId: swsh10-17
   enumId: HISUIAN_LILLIGANT_V_17
   name: Hisuian Lilligant V
@@ -401,7 +401,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-18
+- id: 442-18
   pioId: swsh10-18
   enumId: HISUIAN_LILLIGANT_VSTAR_18
   name: Hisuian Lilligant VSTAR
@@ -432,7 +432,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-19
+- id: 442-19
   pioId: swsh10-19
   enumId: ROWLET_19
   name: Rowlet
@@ -453,7 +453,7 @@ cards:
     value: x2
   rarity: Common
   artist: kawayoo
-- id: FILL_THIS-20
+- id: 442-20
   pioId: swsh10-20
   enumId: DARTRIX_20
   name: Dartrix
@@ -477,7 +477,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: '0313'
-- id: FILL_THIS-21
+- id: 442-21
   pioId: swsh10-21
   enumId: PONYTA_21
   name: Ponyta
@@ -497,7 +497,7 @@ cards:
     value: x2
   rarity: Common
   artist: Jiro Sasumo
-- id: FILL_THIS-22
+- id: 442-22
   pioId: swsh10-22
   enumId: RAPIDASH_22
   name: Rapidash
@@ -522,7 +522,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Ligton
-- id: FILL_THIS-23
+- id: 442-23
   pioId: swsh10-23
   enumId: CYNDAQUIL_23
   name: Cyndaquil
@@ -546,7 +546,7 @@ cards:
     value: x2
   rarity: Common
   artist: sui
-- id: FILL_THIS-24
+- id: 442-24
   pioId: swsh10-24
   enumId: QUILAVA_24
   name: Quilava
@@ -570,7 +570,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Pani Kobayashi
-- id: FILL_THIS-25
+- id: 442-25
   pioId: swsh10-25
   enumId: HEATRAN_V_25
   name: Heatran V
@@ -596,7 +596,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Mitsuhiro Arita
-- id: FILL_THIS-26
+- id: 442-26
   pioId: swsh10-26
   enumId: HEATRAN_VMAX_26
   name: Heatran VMAX
@@ -625,7 +625,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: N-DESIGN Inc.
-- id: FILL_THIS-27
+- id: 442-27
   pioId: swsh10-27
   enumId: RADIANT_HEATRAN_27
   name: Radiant Heatran
@@ -647,7 +647,7 @@ cards:
   text:
   - 'Radiant Pokémon Rule: You can''t have more than 1 Radiant Pokémon in your deck.'
   artist: Shigenori Negishi
-- id: FILL_THIS-28
+- id: 442-28
   pioId: swsh10-28
   enumId: PSYDUCK_28
   name: Psyduck
@@ -670,7 +670,7 @@ cards:
     value: x2
   rarity: Common
   artist: GOSSAN
-- id: FILL_THIS-29
+- id: 442-29
   pioId: swsh10-29
   enumId: GOLDUCK_29
   name: Golduck
@@ -694,7 +694,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: otumami
-- id: FILL_THIS-30
+- id: 442-30
   pioId: swsh10-30
   enumId: STARMIE_V_30
   name: Starmie V
@@ -721,7 +721,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Eske Yoshinob
-- id: FILL_THIS-31
+- id: 442-31
   pioId: swsh10-31
   enumId: SWINUB_31
   name: Swinub
@@ -745,7 +745,7 @@ cards:
     value: x2
   rarity: Common
   artist: Kouki Saitou
-- id: FILL_THIS-32
+- id: 442-32
   pioId: swsh10-32
   enumId: PILOSWINE_32
   name: Piloswine
@@ -771,7 +771,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: yuu
-- id: FILL_THIS-33
+- id: 442-33
   pioId: swsh10-33
   enumId: MAMOSWINE_33
   name: Mamoswine
@@ -798,7 +798,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Uta
-- id: FILL_THIS-34
+- id: 442-34
   pioId: swsh10-34
   enumId: MANTINE_34
   name: Mantine
@@ -821,7 +821,7 @@ cards:
     value: x2
   rarity: Common
   artist: OKACHEKE
-- id: FILL_THIS-35
+- id: 442-35
   pioId: swsh10-35
   enumId: BARBOACH_35
   name: Barboach
@@ -841,7 +841,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mizue
-- id: FILL_THIS-36
+- id: 442-36
   pioId: swsh10-36
   enumId: WHISCASH_36
   name: Whiscash
@@ -866,7 +866,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Shinji Kanda
-- id: FILL_THIS-37
+- id: 442-37
   pioId: swsh10-37
   enumId: REGICE_37
   name: Regice
@@ -891,7 +891,7 @@ cards:
     value: x2
   rarity: Rare
   artist: aoki
-- id: FILL_THIS-38
+- id: 442-38
   pioId: swsh10-38
   enumId: GLACEON_38
   name: Glaceon
@@ -916,7 +916,7 @@ cards:
     value: x2
   rarity: Rare
   artist: saino misaki
-- id: FILL_THIS-39
+- id: 442-39
   pioId: swsh10-39
   enumId: ORIGIN_FORME_PALKIA_V_39
   name: Origin Forme Palkia V
@@ -942,7 +942,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: aky CG Works
-- id: FILL_THIS-40
+- id: 442-40
   pioId: swsh10-40
   enumId: ORIGIN_FORME_PALKIA_VSTAR_40
   name: Origin Forme Palkia VSTAR
@@ -973,7 +973,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: aky CG Works
-- id: FILL_THIS-41
+- id: 442-41
   pioId: swsh10-41
   enumId: OSHAWOTT_41
   name: Oshawott
@@ -993,7 +993,7 @@ cards:
     value: x2
   rarity: Common
   artist: Saya Tsuruta
-- id: FILL_THIS-42
+- id: 442-42
   pioId: swsh10-42
   enumId: DEWOTT_42
   name: Dewott
@@ -1015,7 +1015,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Mina Nakai
-- id: FILL_THIS-43
+- id: 442-43
   pioId: swsh10-43
   enumId: HISUIAN_BASCULIN_43
   name: Hisuian Basculin
@@ -1038,7 +1038,7 @@ cards:
     value: x2
   rarity: Common
   artist: Kagemaru Himeno
-- id: FILL_THIS-44
+- id: 442-44
   pioId: swsh10-44
   enumId: HISUIAN_BASCULEGION_44
   name: Hisuian Basculegion
@@ -1064,7 +1064,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Akira Komayama
-- id: FILL_THIS-45
+- id: 442-45
   pioId: swsh10-45
   enumId: KELDEO_45
   name: Keldeo
@@ -1087,7 +1087,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Naoyo Kimura
-- id: FILL_THIS-46
+- id: 442-46
   pioId: swsh10-46
   enumId: RADIANT_GRENINJA_46
   name: Radiant Greninja
@@ -1114,7 +1114,7 @@ cards:
   text:
   - 'Radiant Pokémon Rule: You can''t have more than 1 Radiant Pokémon in your deck.'
   artist: Souichirou Gunjima
-- id: FILL_THIS-47
+- id: 442-47
   pioId: swsh10-47
   enumId: BERGMITE_47
   name: Bergmite
@@ -1134,7 +1134,7 @@ cards:
     value: x2
   rarity: Common
   artist: Kouki Saitou
-- id: FILL_THIS-48
+- id: 442-48
   pioId: swsh10-48
   enumId: HISUIAN_AVALUGG_48
   name: Hisuian Avalugg
@@ -1160,7 +1160,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Kagemaru Himeno
-- id: FILL_THIS-49
+- id: 442-49
   pioId: swsh10-49
   enumId: GALARIAN_MR_RIME_V_49
   name: Galarian Mr. Rime V
@@ -1186,7 +1186,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-50
+- id: 442-50
   pioId: swsh10-50
   enumId: LUXRAY_V_50
   name: Luxray V
@@ -1213,7 +1213,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: AKIRA EGAWA
-- id: FILL_THIS-51
+- id: 442-51
   pioId: swsh10-51
   enumId: REGIELEKI_51
   name: Regieleki
@@ -1237,7 +1237,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Shiburingaru
-- id: FILL_THIS-52
+- id: 442-52
   pioId: swsh10-52
   enumId: HISUIAN_TYPHLOSION_52
   name: Hisuian Typhlosion
@@ -1267,7 +1267,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Kouki Saitou
-- id: FILL_THIS-53
+- id: 442-53
   pioId: swsh10-53
   enumId: HISUIAN_TYPHLOSION_V_53
   name: Hisuian Typhlosion V
@@ -1296,7 +1296,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Shin Nagasawa
-- id: FILL_THIS-54
+- id: 442-54
   pioId: swsh10-54
   enumId: HISUIAN_TYPHLOSION_VSTAR_54
   name: Hisuian Typhlosion VSTAR
@@ -1328,7 +1328,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-55
+- id: 442-55
   pioId: swsh10-55
   enumId: TOGEPI_55
   name: Togepi
@@ -1353,7 +1353,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mizue
-- id: FILL_THIS-56
+- id: 442-56
   pioId: swsh10-56
   enumId: TOGETIC_56
   name: Togetic
@@ -1379,7 +1379,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Tika Matsuno
-- id: FILL_THIS-57
+- id: 442-57
   pioId: swsh10-57
   enumId: TOGEKISS_57
   name: Togekiss
@@ -1404,7 +1404,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: sui
-- id: FILL_THIS-58
+- id: 442-58
   pioId: swsh10-58
   enumId: MISDREAVUS_58
   name: Misdreavus
@@ -1427,7 +1427,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: AKIRA EGAWA
-- id: FILL_THIS-59
+- id: 442-59
   pioId: swsh10-59
   enumId: MISMAGIUS_59
   name: Mismagius
@@ -1456,7 +1456,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Ligton
-- id: FILL_THIS-60
+- id: 442-60
   pioId: swsh10-60
   enumId: RALTS_60
   name: Ralts
@@ -1480,7 +1480,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Hataya
-- id: FILL_THIS-61
+- id: 442-61
   pioId: swsh10-61
   enumId: KIRLIA_61
   name: Kirlia
@@ -1505,7 +1505,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Saya Tsuruta
-- id: FILL_THIS-62
+- id: 442-62
   pioId: swsh10-62
   enumId: GALLADE_62
   name: Gallade
@@ -1534,7 +1534,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Atsushi Furusawa
-- id: FILL_THIS-63
+- id: 442-63
   pioId: swsh10-63
   enumId: DRIFLOON_63
   name: Drifloon
@@ -1558,7 +1558,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Narumi Sato
-- id: FILL_THIS-64
+- id: 442-64
   pioId: swsh10-64
   enumId: DRIFBLIM_64
   name: Drifblim
@@ -1582,7 +1582,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Kyoko Umemoto
-- id: FILL_THIS-65
+- id: 442-65
   pioId: swsh10-65
   enumId: UXIE_65
   name: Uxie
@@ -1608,7 +1608,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: sui
-- id: FILL_THIS-66
+- id: 442-66
   pioId: swsh10-66
   enumId: MESPRIT_66
   name: Mesprit
@@ -1634,7 +1634,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: zig
-- id: FILL_THIS-67
+- id: 442-67
   pioId: swsh10-67
   enumId: AZELF_67
   name: Azelf
@@ -1657,7 +1657,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Taira Akitsu
-- id: FILL_THIS-68
+- id: 442-68
   pioId: swsh10-68
   enumId: DIANCIE_68
   name: Diancie
@@ -1683,7 +1683,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Yuu Nishida
-- id: FILL_THIS-69
+- id: 442-69
   pioId: swsh10-69
   enumId: WYRDEER_69
   name: Wyrdeer
@@ -1712,7 +1712,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Mizue
-- id: FILL_THIS-70
+- id: 442-70
   pioId: swsh10-70
   enumId: HISUIAN_GROWLITHE_70
   name: Hisuian Growlithe
@@ -1736,7 +1736,7 @@ cards:
     value: x2
   rarity: Common
   artist: Akira Komayama
-- id: FILL_THIS-71
+- id: 442-71
   pioId: swsh10-71
   enumId: HISUIAN_ARCANINE_71
   name: Hisuian Arcanine
@@ -1761,7 +1761,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Kagemaru Himeno
-- id: FILL_THIS-72
+- id: 442-72
   pioId: swsh10-72
   enumId: MACHAMP_V_72
   name: Machamp V
@@ -1787,7 +1787,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: kawayoo
-- id: FILL_THIS-73
+- id: 442-73
   pioId: swsh10-73
   enumId: MACHAMP_VMAX_73
   name: Machamp VMAX
@@ -1816,7 +1816,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: N-DESIGN Inc.
-- id: FILL_THIS-74
+- id: 442-74
   pioId: swsh10-74
   enumId: SUDOWOODO_74
   name: Sudowoodo
@@ -1840,7 +1840,7 @@ cards:
     value: x2
   rarity: Common
   artist: HYOGONOSUKE
-- id: FILL_THIS-75
+- id: 442-75
   pioId: swsh10-75
   enumId: REGIROCK_75
   name: Regirock
@@ -1864,7 +1864,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Souichirou Gunjima
-- id: FILL_THIS-76
+- id: 442-76
   pioId: swsh10-76
   enumId: CRANIDOS_76
   name: Cranidos
@@ -1889,7 +1889,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Hataya
-- id: FILL_THIS-77
+- id: 442-77
   pioId: swsh10-77
   enumId: RAMPARDOS_77
   name: Rampardos
@@ -1913,7 +1913,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Nisota Niso
-- id: FILL_THIS-78
+- id: 442-78
   pioId: swsh10-78
   enumId: LUCARIO_V_78
   name: Lucario V
@@ -1938,7 +1938,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: takuyoa
-- id: FILL_THIS-79
+- id: 442-79
   pioId: swsh10-79
   enumId: HIPPOPOTAS_79
   name: Hippopotas
@@ -1961,7 +1961,7 @@ cards:
     value: x2
   rarity: Common
   artist: nagimiso
-- id: FILL_THIS-80
+- id: 442-80
   pioId: swsh10-80
   enumId: HIPPOWDON_80
   name: Hippowdon
@@ -1985,7 +1985,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Kyoko Umemoto
-- id: FILL_THIS-81
+- id: 442-81
   pioId: swsh10-81
   enumId: RADIANT_HAWLUCHA_81
   name: Radiant Hawlucha
@@ -2012,7 +2012,7 @@ cards:
   text:
   - 'Radiant Pokémon Rule: You can''t have more than 1 Radiant Pokémon in your deck.'
   artist: Masakazu Fukuda
-- id: FILL_THIS-82
+- id: 442-82
   pioId: swsh10-82
   enumId: HISUIAN_DECIDUEYE_82
   name: Hisuian Decidueye
@@ -2038,7 +2038,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Kouki Saitou
-- id: FILL_THIS-83
+- id: 442-83
   pioId: swsh10-83
   enumId: HISUIAN_DECIDUEYE_V_83
   name: Hisuian Decidueye V
@@ -2065,7 +2065,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Shin Nagasawa
-- id: FILL_THIS-84
+- id: 442-84
   pioId: swsh10-84
   enumId: HISUIAN_DECIDUEYE_VSTAR_84
   name: Hisuian Decidueye VSTAR
@@ -2095,7 +2095,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-85
+- id: 442-85
   pioId: swsh10-85
   enumId: KLEAVOR_85
   name: Kleavor
@@ -2120,7 +2120,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Shin Nagasawa
-- id: FILL_THIS-86
+- id: 442-86
   pioId: swsh10-86
   enumId: KLEAVOR_86
   name: Kleavor
@@ -2145,7 +2145,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Anesaki Dynamic
-- id: FILL_THIS-87
+- id: 442-87
   pioId: swsh10-87
   enumId: KLEAVOR_V_87
   name: Kleavor V
@@ -2171,7 +2171,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-88
+- id: 442-88
   pioId: swsh10-88
   enumId: HISUIAN_QWILFISH_88
   name: Hisuian Qwilfish
@@ -2193,7 +2193,7 @@ cards:
     value: x2
   rarity: Common
   artist: Kagemaru Himeno
-- id: FILL_THIS-89
+- id: 442-89
   pioId: swsh10-89
   enumId: HISUIAN_QWILFISH_89
   name: Hisuian Qwilfish
@@ -2213,7 +2213,7 @@ cards:
     value: x2
   rarity: Common
   artist: OKACHEKE
-- id: FILL_THIS-90
+- id: 442-90
   pioId: swsh10-90
   enumId: HISUIAN_OVERQWIL_90
   name: Hisuian Overqwil
@@ -2238,7 +2238,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: AKIRA EGAWA
-- id: FILL_THIS-91
+- id: 442-91
   pioId: swsh10-91
   enumId: HISUIAN_OVERQWIL_91
   name: Hisuian Overqwil
@@ -2262,7 +2262,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Anesaki Dynamic
-- id: FILL_THIS-92
+- id: 442-92
   pioId: swsh10-92
   enumId: HISUIAN_SNEASEL_92
   name: Hisuian Sneasel
@@ -2285,7 +2285,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mizue
-- id: FILL_THIS-93
+- id: 442-93
   pioId: swsh10-93
   enumId: HISUIAN_SNEASLER_93
   name: Hisuian Sneasler
@@ -2310,7 +2310,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Kouki Saitou
-- id: FILL_THIS-94
+- id: 442-94
   pioId: swsh10-94
   enumId: HISUIAN_SNEASLER_V_94
   name: Hisuian Sneasler V
@@ -2335,7 +2335,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-95
+- id: 442-95
   pioId: swsh10-95
   enumId: POOCHYENA_95
   name: Poochyena
@@ -2359,7 +2359,7 @@ cards:
     value: x2
   rarity: Common
   artist: KIYOTAKA OSHIYAMA
-- id: FILL_THIS-96
+- id: 442-96
   pioId: swsh10-96
   enumId: MIGHTYENA_96
   name: Mightyena
@@ -2385,7 +2385,7 @@ cards:
     value: x2
   rarity: Rare
   artist: otumami
-- id: FILL_THIS-97
+- id: 442-97
   pioId: swsh10-97
   enumId: ABSOL_97
   name: Absol
@@ -2410,7 +2410,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: GIDORA
-- id: FILL_THIS-98
+- id: 442-98
   pioId: swsh10-98
   enumId: DARKRAI_V_98
   name: Darkrai V
@@ -2435,7 +2435,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: takuyoa
-- id: FILL_THIS-99
+- id: 442-99
   pioId: swsh10-99
   enumId: DARKRAI_VSTAR_99
   name: Darkrai VSTAR
@@ -2465,7 +2465,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-100
+- id: 442-100
   pioId: swsh10-100
   enumId: HISUIAN_SAMUROTT_100
   name: Hisuian Samurott
@@ -2492,7 +2492,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Kouki Saitou
-- id: FILL_THIS-101
+- id: 442-101
   pioId: swsh10-101
   enumId: HISUIAN_SAMUROTT_V_101
   name: Hisuian Samurott V
@@ -2517,7 +2517,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Shin Nagasawa
-- id: FILL_THIS-102
+- id: 442-102
   pioId: swsh10-102
   enumId: HISUIAN_SAMUROTT_VSTAR_102
   name: Hisuian Samurott VSTAR
@@ -2547,7 +2547,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-103
+- id: 442-103
   pioId: swsh10-103
   enumId: NICKIT_103
   name: Nickit
@@ -2567,7 +2567,7 @@ cards:
     value: x2
   rarity: Common
   artist: Naoyo Kimura
-- id: FILL_THIS-104
+- id: 442-104
   pioId: swsh10-104
   enumId: THIEVUL_104
   name: Thievul
@@ -2593,7 +2593,7 @@ cards:
     value: x2
   rarity: Rare
   artist: KIYOTAKA OSHIYAMA
-- id: FILL_THIS-105
+- id: 442-105
   pioId: swsh10-105
   enumId: MAGNEMITE_105
   name: Magnemite
@@ -2619,7 +2619,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Mitsuhiro Arita
-- id: FILL_THIS-106
+- id: 442-106
   pioId: swsh10-106
   enumId: MAGNETON_106
   name: Magneton
@@ -2644,7 +2644,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Saya Tsuruta
-- id: FILL_THIS-107
+- id: 442-107
   pioId: swsh10-107
   enumId: MAGNEZONE_107
   name: Magnezone
@@ -2673,7 +2673,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: GOSSAN
-- id: FILL_THIS-108
+- id: 442-108
   pioId: swsh10-108
   enumId: REGISTEEL_108
   name: Registeel
@@ -2701,7 +2701,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: hatachu
-- id: FILL_THIS-109
+- id: 442-109
   pioId: swsh10-109
   enumId: SHIELDON_109
   name: Shieldon
@@ -2730,7 +2730,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Yuka Morii
-- id: FILL_THIS-110
+- id: 442-110
   pioId: swsh10-110
   enumId: BASTIODON_110
   name: Bastiodon
@@ -2759,7 +2759,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Yuya Oka
-- id: FILL_THIS-111
+- id: 442-111
   pioId: swsh10-111
   enumId: BRONZOR_111
   name: Bronzor
@@ -2783,7 +2783,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Kouki Saitou
-- id: FILL_THIS-112
+- id: 442-112
   pioId: swsh10-112
   enumId: BRONZONG_112
   name: Bronzong
@@ -2811,7 +2811,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Shinji Kanda
-- id: FILL_THIS-113
+- id: 442-113
   pioId: swsh10-113
   enumId: ORIGIN_FORME_DIALGA_V_113
   name: Origin Forme Dialga V
@@ -2838,7 +2838,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-114
+- id: 442-114
   pioId: swsh10-114
   enumId: ORIGIN_FORME_DIALGA_VSTAR_114
   name: Origin Forme Dialga VSTAR
@@ -2870,7 +2870,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-115
+- id: 442-115
   pioId: swsh10-115
   enumId: PAWNIARD_115
   name: Pawniard
@@ -2894,7 +2894,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Tomokazu Komiya
-- id: FILL_THIS-116
+- id: 442-116
   pioId: swsh10-116
   enumId: BISHARP_116
   name: Bisharp
@@ -2922,7 +2922,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: NC Empire
-- id: FILL_THIS-117
+- id: 442-117
   pioId: swsh10-117
   enumId: GARCHOMP_V_117
   name: Garchomp V
@@ -2943,7 +2943,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: N-DESIGN Inc.
-- id: FILL_THIS-118
+- id: 442-118
   pioId: swsh10-118
   enumId: REGIDRAGO_118
   name: Regidrago
@@ -2965,7 +2965,7 @@ cards:
     damage: '160'
   rarity: Rare
   artist: DOM
-- id: FILL_THIS-119
+- id: 442-119
   pioId: swsh10-119
   enumId: EEVEE_119
   name: Eevee
@@ -2991,7 +2991,7 @@ cards:
     value: x2
   rarity: Common
   artist: sowsow
-- id: FILL_THIS-120
+- id: 442-120
   pioId: swsh10-120
   enumId: HOOTHOOT_120
   name: Hoothoot
@@ -3019,7 +3019,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Pani Kobayashi
-- id: FILL_THIS-121
+- id: 442-121
   pioId: swsh10-121
   enumId: NOCTOWL_121
   name: Noctowl
@@ -3047,7 +3047,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Nisota Niso
-- id: FILL_THIS-122
+- id: 442-122
   pioId: swsh10-122
   enumId: TEDDIURSA_122
   name: Teddiursa
@@ -3071,7 +3071,7 @@ cards:
     value: x2
   rarity: Common
   artist: Nagomi Nijo
-- id: FILL_THIS-123
+- id: 442-123
   pioId: swsh10-123
   enumId: URSARING_123
   name: Ursaring
@@ -3095,7 +3095,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Teeziro
-- id: FILL_THIS-124
+- id: 442-124
   pioId: swsh10-124
   enumId: URSALUNA_124
   name: Ursaluna
@@ -3119,7 +3119,7 @@ cards:
     value: x2
   rarity: Rare
   artist: nagimiso
-- id: FILL_THIS-125
+- id: 442-125
   pioId: swsh10-125
   enumId: STANTLER_125
   name: Stantler
@@ -3140,7 +3140,7 @@ cards:
     value: x2
   rarity: Common
   artist: Teeziro
-- id: FILL_THIS-126
+- id: 442-126
   pioId: swsh10-126
   enumId: MILTANK_126
   name: Miltank
@@ -3165,7 +3165,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: saino misaki
-- id: FILL_THIS-127
+- id: 442-127
   pioId: swsh10-127
   enumId: GLAMEOW_127
   name: Glameow
@@ -3186,7 +3186,7 @@ cards:
     value: x2
   rarity: Common
   artist: Naoyo Kimura
-- id: FILL_THIS-128
+- id: 442-128
   pioId: swsh10-128
   enumId: PURUGLY_128
   name: Purugly
@@ -3210,7 +3210,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Mina Nakai
-- id: FILL_THIS-129
+- id: 442-129
   pioId: swsh10-129
   enumId: CHATOT_129
   name: Chatot
@@ -3236,7 +3236,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Shin Nagasawa
-- id: FILL_THIS-130
+- id: 442-130
   pioId: swsh10-130
   enumId: REGIGIGAS_130
   name: Regigigas
@@ -3263,7 +3263,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Yuya Oka
-- id: FILL_THIS-131
+- id: 442-131
   pioId: swsh10-131
   enumId: RUFFLET_131
   name: Rufflet
@@ -3287,7 +3287,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Eri Yamaki
-- id: FILL_THIS-132
+- id: 442-132
   pioId: swsh10-132
   enumId: HISUIAN_BRAVIARY_132
   name: Hisuian Braviary
@@ -3316,7 +3316,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Shin Nagasawa
-- id: FILL_THIS-133
+- id: 442-133
   pioId: swsh10-133
   enumId: ORANGURU_V_133
   name: Oranguru V
@@ -3345,7 +3345,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Uta
-- id: FILL_THIS-134
+- id: 442-134
   pioId: swsh10-134
   enumId: WYRDEER_V_134
   name: Wyrdeer V
@@ -3372,7 +3372,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: aky CG Works
-- id: FILL_THIS-135
+- id: 442-135
   pioId: swsh10-135
   enumId: ADAMAN_135
   name: Adaman
@@ -3385,7 +3385,7 @@ cards:
     your deck for up to 2 cards and put them into your hand. Then, shuffle your deck.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Souichirou Gunjima
-- id: FILL_THIS-136
+- id: 442-136
   pioId: swsh10-136
   enumId: CANCELING_COLOGNE_136
   name: Canceling Cologne
@@ -3398,7 +3398,7 @@ cards:
     includes Pokémon that come into play during that turn.)
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: Studio Bora Inc.
-- id: FILL_THIS-137
+- id: 442-137
   pioId: swsh10-137
   enumId: CHOY_137
   name: Choy
@@ -3410,7 +3410,7 @@ cards:
   - Each player reveals their hand. Draw 3 cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Hitoshi Ariga
-- id: FILL_THIS-138
+- id: 442-138
   pioId: swsh10-138
   enumId: CYLLENE_138
   name: Cyllene
@@ -3423,7 +3423,7 @@ cards:
     pile on top of your deck in any order.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: nagimiso
-- id: FILL_THIS-139
+- id: 442-139
   pioId: swsh10-139
   enumId: DARK_PATCH_139
   name: Dark Patch
@@ -3436,7 +3436,7 @@ cards:
     Pokémon.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: Ryo Ueda
-- id: FILL_THIS-140
+- id: 442-140
   pioId: swsh10-140
   enumId: ENERGY_LOTO_140
   name: Energy Loto
@@ -3449,7 +3449,7 @@ cards:
     and put it into your hand. Shuffle the other cards back into your deck.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: ORBITALLINK Inc.
-- id: FILL_THIS-141
+- id: 442-141
   pioId: swsh10-141
   enumId: FEATHER_BALL_141
   name: Feather Ball
@@ -3462,7 +3462,7 @@ cards:
     into your hand. Then, shuffle your deck.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: Studio Bora Inc.
-- id: FILL_THIS-142
+- id: 442-142
   pioId: swsh10-142
   enumId: GAPEJAW_BOG_142
   name: Gapejaw Bog
@@ -3474,7 +3474,7 @@ cards:
   - Whenever either player puts a Basic Pokémon from their hand onto their Bench,
     put 2 damage counters on that Pokémon.
   artist: Oswaldo KATO
-- id: FILL_THIS-143
+- id: 442-143
   pioId: swsh10-143
   enumId: GARDENIA_S_VIGOR_143
   name: Gardenia's Vigor
@@ -3487,7 +3487,7 @@ cards:
     from your hand to 1 of your Benched Pokémon.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Yuu Nishida
-- id: FILL_THIS-144
+- id: 442-144
   pioId: swsh10-144
   enumId: GRANT_144
   name: Grant
@@ -3503,7 +3503,7 @@ cards:
     use up your Supporter card for the turn.)
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Hideki Ishikawa
-- id: FILL_THIS-145
+- id: 442-145
   pioId: swsh10-145
   enumId: GUTSY_PICKAXE_145
   name: Gutsy Pickaxe
@@ -3517,7 +3517,7 @@ cards:
     hand.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: Eske Yoshinob
-- id: FILL_THIS-146
+- id: 442-146
   pioId: swsh10-146
   enumId: HISUIAN_HEAVY_BALL_146
   name: Hisuian Heavy Ball
@@ -3532,7 +3532,7 @@ cards:
     pile.) Then, shuffle your face-down Prize cards.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: Studio Bora Inc.
-- id: FILL_THIS-147
+- id: 442-147
   pioId: swsh10-147
   enumId: IRIDA_147
   name: Irida
@@ -3545,7 +3545,7 @@ cards:
     into your hand. Then, shuffle your deck.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: kirisAki
-- id: FILL_THIS-148
+- id: 442-148
   pioId: swsh10-148
   enumId: JUBILIFE_VILLAGE_148
   name: Jubilife Village
@@ -3557,7 +3557,7 @@ cards:
   - Once during each player's turn, that player may shuffle their hand into their
     deck and draw 5 cards. If they do, their turn ends.
   artist: Oswaldo KATO
-- id: FILL_THIS-149
+- id: 442-149
   pioId: swsh10-149
   enumId: KAMADO_149
   name: Kamado
@@ -3570,7 +3570,7 @@ cards:
     (If you have no other cards in your hand, you can't use this card.)
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Hitoshi Ariga
-- id: FILL_THIS-150
+- id: 442-150
   pioId: swsh10-150
   enumId: ROXANNE_150
   name: Roxanne
@@ -3584,7 +3584,7 @@ cards:
     opponent draws 2 cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: Megumi Mizutani
-- id: FILL_THIS-151
+- id: 442-151
   pioId: swsh10-151
   enumId: SPICY_SEASONED_CURRY_151
   name: Spicy Seasoned Curry
@@ -3596,7 +3596,7 @@ cards:
   - Your Active Pokémon is now Burned. Heal 40 damage from it.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: AYUMI ODASHIMA
-- id: FILL_THIS-152
+- id: 442-152
   pioId: swsh10-152
   enumId: SUPEREFFECTIVE_GLASSES_152
   name: Supereffective Glasses
@@ -3611,7 +3611,7 @@ cards:
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
     have a Pokémon Tool attached.'
   artist: Ryo Ueda
-- id: FILL_THIS-153
+- id: 442-153
   pioId: swsh10-153
   enumId: SWEET_HONEY_153
   name: Sweet Honey
@@ -3624,7 +3624,7 @@ cards:
     heal 40 damage from that Pokémon.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: ORBITALLINK Inc.
-- id: FILL_THIS-154
+- id: 442-154
   pioId: swsh10-154
   enumId: SWITCH_CART_154
   name: Switch Cart
@@ -3637,7 +3637,7 @@ cards:
     30 damage from the Pokémon you moved to your Bench.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: Toyste Beach
-- id: FILL_THIS-155
+- id: 442-155
   pioId: swsh10-155
   enumId: TEMPLE_OF_SINNOH_155
   name: Temple of Sinnoh
@@ -3649,7 +3649,7 @@ cards:
   - All Special Energy attached to Pokémon (both yours and your opponent's) provide
     [C] Energy and have no other effect.
   artist: Oswaldo KATO
-- id: FILL_THIS-156
+- id: 442-156
   pioId: swsh10-156
   enumId: TREKKING_SHOES_156
   name: Trekking Shoes
@@ -3662,7 +3662,7 @@ cards:
     don't, discard that card and draw a card.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: Toyste Beach
-- id: FILL_THIS-157
+- id: 442-157
   pioId: swsh10-157
   enumId: UNIDENTIFIED_FOSSIL_157
   name: Unidentified Fossil
@@ -3675,7 +3675,7 @@ cards:
     turn, you may discard this card from play. This card can't retreat.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: AYUMI ODASHIMA
-- id: FILL_THIS-158
+- id: 442-158
   pioId: swsh10-158
   enumId: WAIT_AND_SEE_TURBO_158
   name: Wait and See Turbo
@@ -3689,7 +3689,7 @@ cards:
     shuffle your deck. Your turn ends.
   - 'Item rule: You may play any number of Item cards during your turn.'
   artist: sadaji
-- id: FILL_THIS-159
+- id: 442-159
   pioId: swsh10-159
   enumId: ZISU_159
   name: Zisu
@@ -3701,7 +3701,7 @@ cards:
   - Draw cards until you have 1 more card in your hand than your opponent.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   artist: kirisAki
-- id: FILL_THIS-160
+- id: 442-160
   pioId: swsh10-160
   enumId: BEEDRILL_V_160
   name: Beedrill V
@@ -3729,7 +3729,7 @@ cards:
   artist: Ayaka Yoshida
   variantOf: FILL_THIS-1
   variantType: Full Art
-- id: FILL_THIS-161
+- id: 442-161
   pioId: swsh10-161
   enumId: BEEDRILL_V_161
   name: Beedrill V
@@ -3757,7 +3757,7 @@ cards:
   artist: Narumi Sato
   variantOf: FILL_THIS-1
   variantType: Full Art
-- id: FILL_THIS-162
+- id: 442-162
   pioId: swsh10-162
   enumId: HISUIAN_LILLIGANT_V_162
   name: Hisuian Lilligant V
@@ -3783,7 +3783,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-17
   variantType: Full Art
-- id: FILL_THIS-163
+- id: 442-163
   pioId: swsh10-163
   enumId: HISUIAN_LILLIGANT_V_163
   name: Hisuian Lilligant V
@@ -3809,7 +3809,7 @@ cards:
   artist: kodama
   variantOf: FILL_THIS-17
   variantType: Full Art
-- id: FILL_THIS-164
+- id: 442-164
   pioId: swsh10-164
   enumId: VIRIZION_V_164
   name: Virizion V
@@ -3836,7 +3836,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Saki Hayashiro
-- id: FILL_THIS-165
+- id: 442-165
   pioId: swsh10-165
   enumId: HEATRAN_V_165
   name: Heatran V
@@ -3864,7 +3864,7 @@ cards:
   artist: Studio Bora Inc.
   variantOf: FILL_THIS-25
   variantType: Full Art
-- id: FILL_THIS-166
+- id: 442-166
   pioId: swsh10-166
   enumId: STARMIE_V_166
   name: Starmie V
@@ -3893,7 +3893,7 @@ cards:
   artist: Eske Yoshinob
   variantOf: FILL_THIS-30
   variantType: Full Art
-- id: FILL_THIS-167
+- id: 442-167
   pioId: swsh10-167
   enumId: ORIGIN_FORME_PALKIA_V_167
   name: Origin Forme Palkia V
@@ -3921,7 +3921,7 @@ cards:
   artist: Oswaldo KATO
   variantOf: FILL_THIS-39
   variantType: Full Art
-- id: FILL_THIS-168
+- id: 442-168
   pioId: swsh10-168
   enumId: LUXRAY_V_168
   name: Luxray V
@@ -3950,7 +3950,7 @@ cards:
   artist: MUGENUP
   variantOf: FILL_THIS-50
   variantType: Full Art
-- id: FILL_THIS-169
+- id: 442-169
   pioId: swsh10-169
   enumId: HISUIAN_TYPHLOSION_V_169
   name: Hisuian Typhlosion V
@@ -3981,7 +3981,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-53
   variantType: Full Art
-- id: FILL_THIS-170
+- id: 442-170
   pioId: swsh10-170
   enumId: JIRACHI_V_170
   name: Jirachi V
@@ -4012,7 +4012,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: N-DESIGN Inc.
-- id: FILL_THIS-171
+- id: 442-171
   pioId: swsh10-171
   enumId: MACHAMP_V_171
   name: Machamp V
@@ -4040,7 +4040,7 @@ cards:
   artist: Ryo Ueda
   variantOf: FILL_THIS-72
   variantType: Full Art
-- id: FILL_THIS-172
+- id: 442-172
   pioId: swsh10-172
   enumId: MACHAMP_V_172
   name: Machamp V
@@ -4068,7 +4068,7 @@ cards:
   artist: Shinya Komatsu
   variantOf: FILL_THIS-72
   variantType: Full Art
-- id: FILL_THIS-173
+- id: 442-173
   pioId: swsh10-173
   enumId: HISUIAN_DECIDUEYE_V_173
   name: Hisuian Decidueye V
@@ -4097,7 +4097,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-83
   variantType: Full Art
-- id: FILL_THIS-174
+- id: 442-174
   pioId: swsh10-174
   enumId: HISUIAN_SNEASLER_V_174
   name: Hisuian Sneasler V
@@ -4124,7 +4124,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-94
   variantType: Full Art
-- id: FILL_THIS-175
+- id: 442-175
   pioId: swsh10-175
   enumId: HISUIAN_SNEASLER_V_175
   name: Hisuian Sneasler V
@@ -4151,7 +4151,7 @@ cards:
   artist: OKACHEKE
   variantOf: FILL_THIS-94
   variantType: Full Art
-- id: FILL_THIS-176
+- id: 442-176
   pioId: swsh10-176
   enumId: HISUIAN_SAMUROTT_V_176
   name: Hisuian Samurott V
@@ -4178,7 +4178,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-101
   variantType: Full Art
-- id: FILL_THIS-177
+- id: 442-177
   pioId: swsh10-177
   enumId: ORIGIN_FORME_DIALGA_V_177
   name: Origin Forme Dialga V
@@ -4207,7 +4207,7 @@ cards:
   artist: Mitsuhiro Arita
   variantOf: FILL_THIS-113
   variantType: Full Art
-- id: FILL_THIS-178
+- id: 442-178
   pioId: swsh10-178
   enumId: GARCHOMP_V_178
   name: Garchomp V
@@ -4230,7 +4230,7 @@ cards:
   artist: N-DESIGN Inc.
   variantOf: FILL_THIS-117
   variantType: Full Art
-- id: FILL_THIS-179
+- id: 442-179
   pioId: swsh10-179
   enumId: ORANGURU_V_179
   name: Oranguru V
@@ -4261,7 +4261,7 @@ cards:
   artist: Toyste Beach
   variantOf: FILL_THIS-133
   variantType: Full Art
-- id: FILL_THIS-180
+- id: 442-180
   pioId: swsh10-180
   enumId: WYRDEER_V_180
   name: Wyrdeer V
@@ -4290,7 +4290,7 @@ cards:
   artist: aky CG Works
   variantOf: FILL_THIS-134
   variantType: Full Art
-- id: FILL_THIS-181
+- id: 442-181
   pioId: swsh10-181
   enumId: ADAMAN_181
   name: Adaman
@@ -4305,7 +4305,7 @@ cards:
   artist: Souichirou Gunjima
   variantOf: FILL_THIS-135
   variantType: Full Art
-- id: FILL_THIS-182
+- id: 442-182
   pioId: swsh10-182
   enumId: CHOY_182
   name: Choy
@@ -4319,7 +4319,7 @@ cards:
   artist: Hitoshi Ariga
   variantOf: FILL_THIS-137
   variantType: Full Art
-- id: FILL_THIS-183
+- id: 442-183
   pioId: swsh10-183
   enumId: CYLLENE_183
   name: Cyllene
@@ -4334,7 +4334,7 @@ cards:
   artist: nagimiso
   variantOf: FILL_THIS-138
   variantType: Full Art
-- id: FILL_THIS-184
+- id: 442-184
   pioId: swsh10-184
   enumId: GARDENIA_S_VIGOR_184
   name: Gardenia's Vigor
@@ -4349,7 +4349,7 @@ cards:
   artist: En Morikura
   variantOf: FILL_THIS-143
   variantType: Full Art
-- id: FILL_THIS-185
+- id: 442-185
   pioId: swsh10-185
   enumId: GRANT_185
   name: Grant
@@ -4367,7 +4367,7 @@ cards:
   artist: Hideki Ishikawa
   variantOf: FILL_THIS-144
   variantType: Full Art
-- id: FILL_THIS-186
+- id: 442-186
   pioId: swsh10-186
   enumId: IRIDA_186
   name: Irida
@@ -4382,7 +4382,7 @@ cards:
   artist: kirisAki
   variantOf: FILL_THIS-147
   variantType: Full Art
-- id: FILL_THIS-187
+- id: 442-187
   pioId: swsh10-187
   enumId: KAMADO_187
   name: Kamado
@@ -4397,7 +4397,7 @@ cards:
   artist: Hitoshi Ariga
   variantOf: FILL_THIS-149
   variantType: Full Art
-- id: FILL_THIS-188
+- id: 442-188
   pioId: swsh10-188
   enumId: ROXANNE_188
   name: Roxanne
@@ -4413,7 +4413,7 @@ cards:
   artist: Sanosuke Sakuma
   variantOf: FILL_THIS-150
   variantType: Full Art
-- id: FILL_THIS-189
+- id: 442-189
   pioId: swsh10-189
   enumId: ZISU_189
   name: Zisu
@@ -4427,7 +4427,7 @@ cards:
   artist: kirisAki
   variantOf: FILL_THIS-159
   variantType: Full Art
-- id: FILL_THIS-190
+- id: 442-190
   pioId: swsh10-190
   enumId: HISUIAN_LILLIGANT_VSTAR_190
   name: Hisuian Lilligant VSTAR
@@ -4460,7 +4460,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-18
   variantType: Full Art
-- id: FILL_THIS-191
+- id: 442-191
   pioId: swsh10-191
   enumId: HEATRAN_VMAX_191
   name: Heatran VMAX
@@ -4491,7 +4491,7 @@ cards:
   artist: N-DESIGN Inc.
   variantOf: FILL_THIS-26
   variantType: Full Art
-- id: FILL_THIS-192
+- id: 442-192
   pioId: swsh10-192
   enumId: ORIGIN_FORME_PALKIA_VSTAR_192
   name: Origin Forme Palkia VSTAR
@@ -4524,7 +4524,7 @@ cards:
   artist: aky CG Works
   variantOf: FILL_THIS-40
   variantType: Full Art
-- id: FILL_THIS-193
+- id: 442-193
   pioId: swsh10-193
   enumId: HISUIAN_TYPHLOSION_VSTAR_193
   name: Hisuian Typhlosion VSTAR
@@ -4558,7 +4558,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-54
   variantType: Full Art
-- id: FILL_THIS-194
+- id: 442-194
   pioId: swsh10-194
   enumId: MACHAMP_VMAX_194
   name: Machamp VMAX
@@ -4589,7 +4589,7 @@ cards:
   artist: N-DESIGN Inc.
   variantOf: FILL_THIS-73
   variantType: Full Art
-- id: FILL_THIS-195
+- id: 442-195
   pioId: swsh10-195
   enumId: HISUIAN_DECIDUEYE_VSTAR_195
   name: Hisuian Decidueye VSTAR
@@ -4621,7 +4621,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-84
   variantType: Full Art
-- id: FILL_THIS-196
+- id: 442-196
   pioId: swsh10-196
   enumId: KLEAVOR_VSTAR_196
   name: Kleavor VSTAR
@@ -4651,7 +4651,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-197
+- id: 442-197
   pioId: swsh10-197
   enumId: HISUIAN_SAMUROTT_VSTAR_197
   name: Hisuian Samurott VSTAR
@@ -4683,7 +4683,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-102
   variantType: Full Art
-- id: FILL_THIS-198
+- id: 442-198
   pioId: swsh10-198
   enumId: ORIGIN_FORME_DIALGA_VSTAR_198
   name: Origin Forme Dialga VSTAR
@@ -4717,7 +4717,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-114
   variantType: Full Art
-- id: FILL_THIS-199
+- id: 442-199
   pioId: swsh10-199
   enumId: ADAMAN_199
   name: Adaman
@@ -4732,7 +4732,7 @@ cards:
   artist: Souichirou Gunjima
   variantOf: FILL_THIS-135
   variantType: Full Art
-- id: FILL_THIS-200
+- id: 442-200
   pioId: swsh10-200
   enumId: CHOY_200
   name: Choy
@@ -4746,7 +4746,7 @@ cards:
   artist: Hitoshi Ariga
   variantOf: FILL_THIS-137
   variantType: Full Art
-- id: FILL_THIS-201
+- id: 442-201
   pioId: swsh10-201
   enumId: CYLLENE_201
   name: Cyllene
@@ -4761,7 +4761,7 @@ cards:
   artist: nagimiso
   variantOf: FILL_THIS-138
   variantType: Full Art
-- id: FILL_THIS-202
+- id: 442-202
   pioId: swsh10-202
   enumId: GARDENIA_S_VIGOR_202
   name: Gardenia's Vigor
@@ -4776,7 +4776,7 @@ cards:
   artist: En Morikura
   variantOf: FILL_THIS-143
   variantType: Full Art
-- id: FILL_THIS-203
+- id: 442-203
   pioId: swsh10-203
   enumId: GRANT_203
   name: Grant
@@ -4794,7 +4794,7 @@ cards:
   artist: Hideki Ishikawa
   variantOf: FILL_THIS-144
   variantType: Full Art
-- id: FILL_THIS-204
+- id: 442-204
   pioId: swsh10-204
   enumId: IRIDA_204
   name: Irida
@@ -4809,7 +4809,7 @@ cards:
   artist: kirisAki
   variantOf: FILL_THIS-147
   variantType: Full Art
-- id: FILL_THIS-205
+- id: 442-205
   pioId: swsh10-205
   enumId: KAMADO_205
   name: Kamado
@@ -4824,7 +4824,7 @@ cards:
   artist: Hitoshi Ariga
   variantOf: FILL_THIS-149
   variantType: Full Art
-- id: FILL_THIS-206
+- id: 442-206
   pioId: swsh10-206
   enumId: ROXANNE_206
   name: Roxanne
@@ -4840,7 +4840,7 @@ cards:
   artist: Sanosuke Sakuma
   variantOf: FILL_THIS-150
   variantType: Full Art
-- id: FILL_THIS-207
+- id: 442-207
   pioId: swsh10-207
   enumId: ZISU_207
   name: Zisu
@@ -4854,7 +4854,7 @@ cards:
   artist: kirisAki
   variantOf: FILL_THIS-159
   variantType: Full Art
-- id: FILL_THIS-208
+- id: 442-208
   pioId: swsh10-208
   enumId: ORIGIN_FORME_PALKIA_VSTAR_208
   name: Origin Forme Palkia VSTAR
@@ -4887,7 +4887,7 @@ cards:
   artist: aky CG Works
   variantOf: FILL_THIS-40
   variantType: Secret Art
-- id: FILL_THIS-209
+- id: 442-209
   pioId: swsh10-209
   enumId: HISUIAN_SAMUROTT_VSTAR_209
   name: Hisuian Samurott VSTAR
@@ -4919,7 +4919,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-102
   variantType: Secret Art
-- id: FILL_THIS-210
+- id: 442-210
   pioId: swsh10-210
   enumId: ORIGIN_FORME_DIALGA_VSTAR_210
   name: Origin Forme Dialga VSTAR
@@ -4953,7 +4953,7 @@ cards:
   artist: 5ban Graphics
   variantOf: FILL_THIS-114
   variantType: Secret Art
-- id: FILL_THIS-211
+- id: 442-211
   pioId: swsh10-211
   enumId: CHOICE_BELT_211
   name: Choice Belt
@@ -4968,7 +4968,7 @@ cards:
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
     have a Pokémon Tool attached.'
   artist: Studio Bora Inc.
-- id: FILL_THIS-212
+- id: 442-212
   pioId: swsh10-212
   enumId: JUBILIFE_VILLAGE_212
   name: Jubilife Village
@@ -4982,7 +4982,7 @@ cards:
   artist: Oswaldo KATO
   variantOf: FILL_THIS-148
   variantType: Secret Art
-- id: FILL_THIS-213
+- id: 442-213
   pioId: swsh10-213
   enumId: PATH_TO_THE_PEAK_213
   name: Path to the Peak
@@ -4994,7 +4994,7 @@ cards:
   - Pokémon with a Rule Box in play (both yours and your opponent's) have no Abilities.
     (Pokémon V, Pokémon-GX, etc. have Rule Boxes.)
   artist: Oswaldo KATO
-- id: FILL_THIS-214
+- id: 442-214
   pioId: swsh10-214
   enumId: TEMPLE_OF_SINNOH_214
   name: Temple of Sinnoh
@@ -5008,7 +5008,7 @@ cards:
   artist: Oswaldo KATO
   variantOf: FILL_THIS-155
   variantType: Secret Art
-- id: FILL_THIS-215
+- id: 442-215
   pioId: swsh10-215
   enumId: TREKKING_SHOES_215
   name: Trekking Shoes
@@ -5023,7 +5023,7 @@ cards:
   artist: Toyste Beach
   variantOf: FILL_THIS-156
   variantType: Secret Art
-- id: FILL_THIS-216
+- id: 442-216
   pioId: swsh10-216
   enumId: DOUBLE_TURBO_ENERGY_216
   name: Double Turbo Energy

--- a/data/src/main/resources/cards/442-astral_radiance.yaml
+++ b/data/src/main/resources/cards/442-astral_radiance.yaml
@@ -1,5 +1,5 @@
 id: '442'
-name: swsh10
+name: Astral Radiance
 enumId: ASTRAL_RADIANCE
 abbr: ASR
 pioId: swsh10

--- a/data/src/main/resources/cards/442-astral_radiance.yaml
+++ b/data/src/main/resources/cards/442-astral_radiance.yaml
@@ -1,0 +1,5037 @@
+id: FILL_THIS
+name: swsh10
+enumId: FILL_THIS
+abbr: FILL_THIS
+pioId: swsh10
+cards:
+- id: FILL_THIS-1
+  pioId: swsh10-1
+  enumId: BEEDRILL_V_1
+  name: Beedrill V
+  number: '1'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Twineedle
+    damage: 40x
+    text: Flip 2 coins. This attack does 40 damage for each heads.
+  - cost: [G, G, C]
+    name: Swarming Sting
+    text: This attack does 50 damage to 1 of your opponent's Pokémon for each of your
+      Beedrill V in play. (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Ayaka Yoshida
+- id: FILL_THIS-2
+  pioId: swsh10-2
+  enumId: HISUIAN_VOLTORB_2
+  name: Hisuian Voltorb
+  number: '2'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Electrode]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: []
+    name: Cheerful Charge
+    text: You can use this attack only if you go second, and only during your first
+      turn. Choose up to 2 of your Benched Pokémon. For each of those Pokémon, search
+      your deck for a basic Energy card and attach it to that Pokémon. Then, shuffle
+      your deck.
+  - cost: [G]
+    name: Ram
+    damage: '10'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: nagimiso
+- id: FILL_THIS-3
+  pioId: swsh10-3
+  enumId: HISUIAN_ELECTRODE_3
+  name: Hisuian Electrode
+  number: '3'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Hisuian Voltorb
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: []
+    name: Triple Draw
+    text: Draw 3 cards.
+  - cost: []
+    name: Irritated Bomb
+    damage: '50'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Akira Komayama
+- id: FILL_THIS-4
+  pioId: swsh10-4
+  enumId: SCYTHER_4
+  name: Scyther
+  number: '4'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Scizor]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Blinding Scythe
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: GIDORA
+- id: FILL_THIS-5
+  pioId: swsh10-5
+  enumId: SCYTHER_5
+  name: Scyther
+  number: '5'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Scizor]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Quick Blow
+    damage: 30+
+    text: Flip a coin. If heads, this attack does 30 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Uta
+- id: FILL_THIS-6
+  pioId: swsh10-6
+  enumId: YANMA_6
+  name: Yanma
+  number: '6'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Yanmega]
+  hp: 60
+  moves:
+  - cost: [G]
+    name: Speed Dive
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: OKACHEKE
+- id: FILL_THIS-7
+  pioId: swsh10-7
+  enumId: YANMEGA_7
+  name: Yanmega
+  number: '7'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Yanma
+  hp: 120
+  moves:
+  - cost: [G]
+    name: Razor Wing
+    damage: '30'
+  - cost: [C, C]
+    name: Wide Wing
+    damage: 40+
+    text: If you have more cards in your hand than your opponent, this attack does
+      80 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Masakazu Fukuda
+- id: FILL_THIS-8
+  pioId: swsh10-8
+  enumId: HERACROSS_8
+  name: Heracross
+  number: '8'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [G, C]
+    name: Horn Attack
+    damage: '40'
+  - cost: [G, G, C]
+    name: Overhead Throw
+    damage: '120'
+    text: This attack also does 30 damage to 1 of your Benched Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: aoki
+- id: FILL_THIS-9
+  pioId: swsh10-9
+  enumId: KRICKETOT_9
+  name: Kricketot
+  number: '9'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Kricketune]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Trip Over
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 20 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Masakazu Fukuda
+- id: FILL_THIS-10
+  pioId: swsh10-10
+  enumId: KRICKETUNE_10
+  name: Kricketune
+  number: '10'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Kricketot
+  hp: 90
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Swelling Tune
+    text: Your [G] Pokémon in play, except any Kricketune, get +40 HP. You can't apply
+      more than 1 Swelling Tune Ability at a time.
+  moves:
+  - cost: [G, C]
+    name: Slash
+    damage: '50'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Mitsuhiro Arita
+- id: FILL_THIS-11
+  pioId: swsh10-11
+  enumId: COMBEE_11
+  name: Combee
+  number: '11'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Vespiquen]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Honey Courier
+    text: Search your deck for an Item card, reveal it, and put it into your hand.
+      Then, shuffle your deck.
+  - cost: [C, C]
+    name: Bug Bite
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: sowsow
+- id: FILL_THIS-12
+  pioId: swsh10-12
+  enumId: VESPIQUEN_12
+  name: Vespiquen
+  number: '12'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Combee
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Honey Rush
+    damage: 60x
+    text: Reveal any number of Sweet Honey cards from your hand. This attack does
+      60 damage for each card you revealed in this way.
+  - cost: [G, C, C]
+    name: Pierce
+    damage: '90'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare
+  artist: Yuya Oka
+- id: FILL_THIS-13
+  pioId: swsh10-13
+  enumId: LEAFEON_13
+  name: Leafeon
+  number: '13'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Eevee
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Energy Garden
+    text: Search your deck for up to 3 basic Energy cards of different types and attach
+      them to your Pokémon in any way you like. Then, shuffle your deck.
+  - cost: [G, C, C]
+    name: Leafy Cyclone
+    damage: '120'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare
+  artist: Atsushi Furusawa
+- id: FILL_THIS-14
+  pioId: swsh10-14
+  enumId: SHAYMIN_14
+  name: Shaymin
+  number: '14'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Encouraging Gift
+    text: You can use this attack only if you go second, and only during your first
+      turn. Search your deck for up to 3 cards and put them into your hand. Then,
+      shuffle your deck.
+  - cost: [G]
+    name: Flop
+    damage: '30'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare
+  artist: Kouki Saitou
+- id: FILL_THIS-15
+  pioId: swsh10-15
+  enumId: PETILIL_15
+  name: Petilil
+  number: '15'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Lilligant]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Spin Turn
+    damage: '10'
+    text: Switch this Pokémon with 1 of your Benched Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Yukiko Baba
+- id: FILL_THIS-16
+  pioId: swsh10-16
+  enumId: HISUIAN_LILLIGANT_16
+  name: Hisuian Lilligant
+  number: '16'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Petilil
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Twister Lutz
+    text: This attack does 20 damage to each of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.) Switch this Pokémon with 1 of
+      your Benched Pokémon.
+  - cost: [G, C, C]
+    name: Leaf Step
+    damage: '100'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  artist: Mizue
+- id: FILL_THIS-17
+  pioId: swsh10-17
+  enumId: HISUIAN_LILLIGANT_V_17
+  name: Hisuian Lilligant V
+  number: '17'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 2
+  moves:
+  - cost: []
+    name: Dance Gracefully
+    text: Draw cards until you have 6 cards in your hand.
+  - cost: [G, G, C]
+    name: Leaf Step
+    damage: '130'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-18
+  pioId: swsh10-18
+  enumId: HISUIAN_LILLIGANT_VSTAR_18
+  name: Hisuian Lilligant VSTAR
+  number: '18'
+  types: [G]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Hisuian Lilligant V
+  hp: 260
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Star Perfume
+    text: During your turn, you may search your deck for up to 5 in any combination
+      of [G] Pokémon and [G] Energy cards, reveal them, and put them into your hand.
+      Then, shuffle your deck. (You can't use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [G, G, C]
+    name: Parallel Spin
+    damage: 130+
+    text: You may put an Energy attached to this Pokémon into your hand. If you do,
+      this attack does 100 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-19
+  pioId: swsh10-19
+  enumId: ROWLET_19
+  name: Rowlet
+  number: '19'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Dartrix]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Jump On
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 10 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: kawayoo
+- id: FILL_THIS-20
+  pioId: swsh10-20
+  enumId: DARTRIX_20
+  name: Dartrix
+  number: '20'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Rowlet
+  evolvesTo: [Decidueye]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Flap
+    damage: '30'
+  - cost: [C, C, C]
+    name: Razor Wing
+    damage: '60'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: '0313'
+- id: FILL_THIS-21
+  pioId: swsh10-21
+  enumId: PONYTA_21
+  name: Ponyta
+  number: '21'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Rapidash]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Flame Tail
+    damage: '20'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: Jiro Sasumo
+- id: FILL_THIS-22
+  pioId: swsh10-22
+  enumId: RAPIDASH_22
+  name: Rapidash
+  number: '22'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Ponyta
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Combustion
+    damage: '30'
+  - cost: [R, C]
+    name: Ring of Fire
+    damage: '50'
+    text: Your opponent's Active Pokémon is now Burned. During your opponent's next
+      turn, that Pokémon can't retreat.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare
+  artist: Ligton
+- id: FILL_THIS-23
+  pioId: swsh10-23
+  enumId: CYNDAQUIL_23
+  name: Cyndaquil
+  number: '23'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Quilava]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Charge Energy
+    text: Search your deck for up to 2 basic Energy cards, reveal them, and put them
+      into your hand. Then, shuffle your deck.
+  - cost: [C]
+    name: Live Coal
+    damage: '10'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: sui
+- id: FILL_THIS-24
+  pioId: swsh10-24
+  enumId: QUILAVA_24
+  name: Quilava
+  number: '24'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Cyndaquil
+  evolvesTo: [Typhlosion]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Tackle
+    damage: '20'
+  - cost: [C, C]
+    name: Flare
+    damage: '40'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Uncommon
+  artist: Pani Kobayashi
+- id: FILL_THIS-25
+  pioId: swsh10-25
+  enumId: HEATRAN_V_25
+  name: Heatran V
+  number: '25'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [R, C]
+    name: Heat Burn
+    damage: '30'
+    text: Your opponent's Active Pokémon is now Burned.
+  - cost: [R, R, C]
+    name: Magma Fall
+    damage: 90+
+    text: If you have a Stadium in play, this attack does 90 more damage.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Mitsuhiro Arita
+- id: FILL_THIS-26
+  pioId: swsh10-26
+  enumId: HEATRAN_VMAX_26
+  name: Heatran VMAX
+  number: '26'
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Heatran V
+  hp: 330
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Magma Gain
+    text: Once during your turn, if you have a Stadium in play, you may heal 50 damage
+      from this Pokémon.
+  moves:
+  - cost: [R, R, C]
+    name: Max Heat Burst
+    damage: '180'
+    text: Your opponent's Active Pokémon is now Burned.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: N-DESIGN Inc.
+- id: FILL_THIS-27
+  pioId: swsh10-27
+  enumId: RADIANT_HEATRAN_27
+  name: Radiant Heatran
+  number: '27'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 160
+  retreatCost: 3
+  moves:
+  - cost: [R, C, C]
+    name: Raging Blast
+    damage: 70x
+    text: This attack does 70 damage for each damage counter on this Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare
+  text:
+  - 'Radiant Pokémon Rule: You can''t have more than 1 Radiant Pokémon in your deck.'
+  artist: Shigenori Negishi
+- id: FILL_THIS-28
+  pioId: swsh10-28
+  enumId: PSYDUCK_28
+  name: Psyduck
+  number: '28'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Golduck]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Spacing Out
+    text: Flip a coin. If heads, heal 10 damage from this Pokémon.
+  - cost: [W, C]
+    name: Ram
+    damage: '20'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: GOSSAN
+- id: FILL_THIS-29
+  pioId: swsh10-29
+  enumId: GOLDUCK_29
+  name: Golduck
+  number: '29'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Psyduck
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [W, C]
+    name: Aqua Edge
+    damage: '50'
+  - cost: [W, W, C]
+    name: Entangled Dive
+    text: Discard each player's Active Pokémon and all attached cards. (You choose
+      a new Active Pokémon first.)
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: otumami
+- id: FILL_THIS-30
+  pioId: swsh10-30
+  enumId: STARMIE_V_30
+  name: Starmie V
+  number: '30'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  moves:
+  - cost: [C, C]
+    name: Swift
+    damage: '50'
+    text: This attack's damage isn't affected by Weakness or Resistance, or by any
+      effects on your opponent's Active Pokémon.
+  - cost: [W, W]
+    name: Energy Spiral
+    damage: 50x
+    text: This attack does 50 damage for each Energy attached to all of your opponent's
+      Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Eske Yoshinob
+- id: FILL_THIS-31
+  pioId: swsh10-31
+  enumId: SWINUB_31
+  name: Swinub
+  number: '31'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Piloswine]
+  hp: 60
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Stampede
+    damage: '20'
+  - cost: [W, C, C]
+    name: Icy Wind
+    damage: '40'
+    text: Your opponent's Active Pokémon is now Asleep.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: Kouki Saitou
+- id: FILL_THIS-32
+  pioId: swsh10-32
+  enumId: PILOSWINE_32
+  name: Piloswine
+  number: '32'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Swinub
+  evolvesTo: [Mamoswine]
+  hp: 90
+  retreatCost: 3
+  moves:
+  - cost: [C, C]
+    name: Stampede
+    damage: '30'
+  - cost: [W, C, C]
+    name: Blizzard
+    damage: '50'
+    text: This attack also does 10 damage to each of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Uncommon
+  artist: yuu
+- id: FILL_THIS-33
+  pioId: swsh10-33
+  enumId: MAMOSWINE_33
+  name: Mamoswine
+  number: '33'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Piloswine
+  hp: 180
+  retreatCost: 4
+  moves:
+  - cost: [W, C, C]
+    name: Blizzard
+    damage: '80'
+    text: This attack also does 10 damage to each of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [W, W, C, C]
+    name: Iceberg Press
+    damage: '170'
+    text: Discard an Energy from this Pokémon. During your opponent's next turn, the
+      Defending Pokémon can't attack.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare
+  artist: Uta
+- id: FILL_THIS-34
+  pioId: swsh10-34
+  enumId: MANTINE_34
+  name: Mantine
+  number: '34'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Borne Ashore
+    text: Put a Basic Pokémon from either player's discard pile onto that player's
+      Bench.
+  - cost: [W, W, C]
+    name: Aqua Edge
+    damage: '100'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: OKACHEKE
+- id: FILL_THIS-35
+  pioId: swsh10-35
+  enumId: BARBOACH_35
+  name: Barboach
+  number: '35'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Whiscash]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [W, C, C]
+    name: Rain Splash
+    damage: '40'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Mizue
+- id: FILL_THIS-36
+  pioId: swsh10-36
+  enumId: WHISCASH_36
+  name: Whiscash
+  number: '36'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Barboach
+  hp: 120
+  retreatCost: 3
+  moves:
+  - cost: [W, C, C]
+    name: Mud Shot
+    damage: '80'
+  - cost: [W, C, C, C]
+    name: Thrash
+    damage: 120+
+    text: Flip a coin. If tails, this Pokémon also does 60 damage to itself. If heads,
+      this attack does 60 more damage.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: Shinji Kanda
+- id: FILL_THIS-37
+  pioId: swsh10-37
+  enumId: REGICE_37
+  name: Regice
+  number: '37'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Regi Gate
+    text: Search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle
+      your deck.
+  - cost: [W, W, C]
+    name: Blizzard Bind
+    damage: '100'
+    text: If the Defending Pokémon is a Pokémon V, it can't attack during your opponent's
+      next turn.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare
+  artist: aoki
+- id: FILL_THIS-38
+  pioId: swsh10-38
+  enumId: GLACEON_38
+  name: Glaceon
+  number: '38'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Eevee
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Frost Wall
+    damage: '30'
+    text: During your opponent's next turn, prevent all damage done to this Pokémon
+      by attacks from Evolution Pokémon.
+  - cost: [W, W, C]
+    name: Ice Blast
+    damage: '120'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare
+  artist: saino misaki
+- id: FILL_THIS-39
+  pioId: swsh10-39
+  enumId: ORIGIN_FORME_PALKIA_V_39
+  name: Origin Forme Palkia V
+  number: '39'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Rule the Region
+    text: Search your deck for a Stadium card, reveal it, and put it into your hand.
+      Then, shuffle your deck.
+  - cost: [W, W, C]
+    name: Hydro Break
+    damage: '200'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+- id: FILL_THIS-40
+  pioId: swsh10-40
+  enumId: ORIGIN_FORME_PALKIA_VSTAR_40
+  name: Origin Forme Palkia VSTAR
+  number: '40'
+  types: [W]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Origin Forme Palkia V
+  hp: 280
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Star Portal
+    text: During your turn, you may attach up to 3 [W] Energy cards from your discard
+      pile to your [W] Pokémon in any way you like. (You can't use more than 1 VSTAR
+      Power in a game.)
+  moves:
+  - cost: [W, W]
+    name: Subspace Swell
+    damage: 60+
+    text: This attack does 20 more damage for each Benched Pokémon (both yours and
+      your opponent's).
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: aky CG Works
+- id: FILL_THIS-41
+  pioId: swsh10-41
+  enumId: OSHAWOTT_41
+  name: Oshawott
+  number: '41'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Dewott]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Beat
+    damage: '10'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Saya Tsuruta
+- id: FILL_THIS-42
+  pioId: swsh10-42
+  enumId: DEWOTT_42
+  name: Dewott
+  number: '42'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Oshawott
+  evolvesTo: [Samurott]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Razor Shell
+    damage: 20+
+    text: Flip a coin. If heads, this attack does 20 more damage.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: Mina Nakai
+- id: FILL_THIS-43
+  pioId: swsh10-43
+  enumId: HISUIAN_BASCULIN_43
+  name: Hisuian Basculin
+  number: '43'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: []
+    name: Gather the Crew
+    text: Search your deck for up to 2 Basic Pokémon and put them onto your Bench.
+      Then, shuffle your deck.
+  - cost: [W]
+    name: Tackle
+    damage: '10'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Kagemaru Himeno
+- id: FILL_THIS-44
+  pioId: swsh10-44
+  enumId: HISUIAN_BASCULEGION_44
+  name: Hisuian Basculegion
+  number: '44'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Hisuian Basculin
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Grudge Dive
+    damage: 30+
+    text: If any of your Pokémon were Knocked Out by damage from an attack from your
+      opponent's Pokémon during their last turn, this attack does 90 more damage,
+      and your opponent's Active Pokémon is now Confused.
+  - cost: [W, C, C]
+    name: Jet Headbutt
+    damage: '80'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare
+  artist: Akira Komayama
+- id: FILL_THIS-45
+  pioId: swsh10-45
+  enumId: KELDEO_45
+  name: Keldeo
+  number: '45'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Smash Kick
+    damage: '20'
+  - cost: [W, C]
+    name: Line Force
+    damage: 10+
+    text: This attack does 20 more damage for each of your Benched Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  artist: Naoyo Kimura
+- id: FILL_THIS-46
+  pioId: swsh10-46
+  enumId: RADIANT_GRENINJA_46
+  name: Radiant Greninja
+  number: '46'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Concealed Cards
+    text: You must discard an Energy card from your hand in order to use this Ability.
+      Once during your turn, you may draw 2 cards.
+  moves:
+  - cost: [W, W, C]
+    name: Moonlight Shuriken
+    text: Discard 2 Energy from this Pokémon. This attack does 90 damage to 2 of your
+      opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare
+  text:
+  - 'Radiant Pokémon Rule: You can''t have more than 1 Radiant Pokémon in your deck.'
+  artist: Souichirou Gunjima
+- id: FILL_THIS-47
+  pioId: swsh10-47
+  enumId: BERGMITE_47
+  name: Bergmite
+  number: '47'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Avalugg]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [W, C, C]
+    name: Icicle
+    damage: '40'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: Kouki Saitou
+- id: FILL_THIS-48
+  pioId: swsh10-48
+  enumId: HISUIAN_AVALUGG_48
+  name: Hisuian Avalugg
+  number: '48'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Bergmite
+  hp: 140
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Massive Ice
+    text: This Pokémon takes 30 less damage from attacks (after applying Weakness
+      and Resistance).
+  moves:
+  - cost: [W, W, C, C]
+    name: Mountain Gale
+    damage: 100+ damage. If a Stadium is in play, this attack does 120 more
+    text: Then, discard that Stadium.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare
+  artist: Kagemaru Himeno
+- id: FILL_THIS-49
+  pioId: swsh10-49
+  enumId: GALARIAN_MR_RIME_V_49
+  name: Galarian Mr. Rime V
+  number: '49'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Surprising Hand
+    text: Search your deck for up to 3 Item cards, reveal them, and put them into
+      your hand. Then, shuffle your deck.
+  - cost: [W, W, C]
+    name: Customized Cane
+    damage: 90+
+    text: If this Pokémon has a Pokémon Tool attached, this attack does 90 more damage.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-50
+  pioId: swsh10-50
+  enumId: LUXRAY_V_50
+  name: Luxray V
+  number: '50'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Fang Snipe
+    damage: '30'
+    text: Your opponent reveals their hand. Discard a Trainer card you find there.
+  - cost: [L, L, C]
+    name: Radiating Pulse
+    damage: '120'
+    text: Discard 2 Energy from this Pokémon. Your opponent's Active Pokémon is now
+      Paralyzed.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: AKIRA EGAWA
+- id: FILL_THIS-51
+  pioId: swsh10-51
+  enumId: REGIELEKI_51
+  name: Regieleki
+  number: '51'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Electromagnetic Sonar
+    text: Put a Trainer card from your discard pile into your hand.
+  - cost: [L, L, C]
+    name: Targeted Bolt
+    text: Discard 2 [L] Energy from this Pokémon. This attack does 120 damage to 1
+      of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for
+      Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Shiburingaru
+- id: FILL_THIS-52
+  pioId: swsh10-52
+  enumId: HISUIAN_TYPHLOSION_52
+  name: Hisuian Typhlosion
+  number: '52'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Quilava
+  hp: 150
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Supernatural Orb
+    text: You must discard a [P] Energy card from your hand in order to use this Ability.
+      Once during your turn, you may make your opponent's Active Pokémon Burned and
+      Confused.
+  moves:
+  - cost: [P, C]
+    name: Shadow Bind
+    damage: '90'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: Kouki Saitou
+- id: FILL_THIS-53
+  pioId: swsh10-53
+  enumId: HISUIAN_TYPHLOSION_V_53
+  name: Hisuian Typhlosion V
+  number: '53'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: []
+    name: Singe
+    text: Your opponent's Active Pokémon is now Burned.
+  - cost: [P, P, C]
+    name: Petrifying Flame
+    damage: '120'
+    text: Choose a random card from your opponent's hand. Your opponent reveals that
+      card and shuffles it into their deck.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Shin Nagasawa
+- id: FILL_THIS-54
+  pioId: swsh10-54
+  enumId: HISUIAN_TYPHLOSION_VSTAR_54
+  name: Hisuian Typhlosion VSTAR
+  number: '54'
+  types: [P]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Hisuian Typhlosion V
+  hp: 260
+  retreatCost: 2
+  moves:
+  - cost: [P, P, C]
+    name: Hollow Flame
+    damage: '180'
+    text: Put 3 damage counters on your opponent's Benched Pokémon in any way you
+      like.
+  - cost: [P]
+    name: Shimmering Star
+    text: If your opponent's Active Pokémon has exactly 4 damage counters on it, that
+      Pokémon is Knocked Out. (You can't use more than 1 VSTAR Power in a game.)
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-55
+  pioId: swsh10-55
+  enumId: TOGEPI_55
+  name: Togepi
+  number: '55'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Togetic]
+  hp: 50
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Touch of Happiness
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may heal 10 damage from your Active Pokémon.
+  moves:
+  - cost: [P]
+    name: Rollout
+    damage: '10'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: Mizue
+- id: FILL_THIS-56
+  pioId: swsh10-56
+  enumId: TOGETIC_56
+  name: Togetic
+  number: '56'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Togepi
+  evolvesTo: [Togekiss]
+  hp: 80
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Voice of Happiness
+    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
+      your turn, you may heal 30 damage from your Active Pokémon.
+  moves:
+  - cost: [P, C]
+    name: Fairy Wind
+    damage: '30'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Uncommon
+  artist: Tika Matsuno
+- id: FILL_THIS-57
+  pioId: swsh10-57
+  enumId: TOGEKISS_57
+  name: Togekiss
+  number: '57'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Togetic
+  hp: 130
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Shine of Happiness
+    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
+      your turn, you may heal 90 damage from your Active Pokémon.
+  moves:
+  - cost: [P, C, C]
+    name: Magical Shot
+    damage: '120'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  artist: sui
+- id: FILL_THIS-58
+  pioId: swsh10-58
+  enumId: MISDREAVUS_58
+  name: Misdreavus
+  number: '58'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Mismagius]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Mumble
+    damage: '10'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: AKIRA EGAWA
+- id: FILL_THIS-59
+  pioId: swsh10-59
+  enumId: MISMAGIUS_59
+  name: Mismagius
+  number: '59'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Misdreavus
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Ominous Prose
+    text: Your opponent reveals their hand. If they have 4 or more cards in their
+      hand, choose all but 3, and your opponent shuffles the chosen cards into their
+      deck.
+  - cost: [P, C]
+    name: Psybeam
+    damage: '50'
+    text: Your opponent's Active Pokémon is now Confused.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Ligton
+- id: FILL_THIS-60
+  pioId: swsh10-60
+  enumId: RALTS_60
+  name: Ralts
+  number: '60'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Kirlia]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Teleportation Burst
+    damage: '10'
+    text: Switch this Pokémon with 1 of your Benched Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Hataya
+- id: FILL_THIS-61
+  pioId: swsh10-61
+  enumId: KIRLIA_61
+  name: Kirlia
+  number: '61'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Ralts
+  evolvesTo: [Gardevoir, Gallade]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Teleportation Burst
+    damage: '30'
+    text: Switch this Pokémon with 1 of your Benched Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Saya Tsuruta
+- id: FILL_THIS-62
+  pioId: swsh10-62
+  enumId: GALLADE_62
+  name: Gallade
+  number: '62'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Kirlia
+  hp: 160
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Buddy Catch
+    text: Once during your turn, you may search your deck for a Supporter card, reveal
+      it, and put it into your hand. Then, shuffle your deck.
+  moves:
+  - cost: [P, C, C]
+    name: Swirling Slice
+    damage: '160'
+    text: Move an Energy from this Pokémon to 1 of your Benched Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: Atsushi Furusawa
+- id: FILL_THIS-63
+  pioId: swsh10-63
+  enumId: DRIFLOON_63
+  name: Drifloon
+  number: '63'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Drifblim]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Triple Spin
+    damage: 10x
+    text: Flip 3 coins. This attack does 10 damage for each heads.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Narumi Sato
+- id: FILL_THIS-64
+  pioId: swsh10-64
+  enumId: DRIFBLIM_64
+  name: Drifblim
+  number: '64'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Drifloon
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Spooky Balloon
+    damage: '50'
+    text: Put 2 damage counters on 1 of your opponent's Benched Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Kyoko Umemoto
+- id: FILL_THIS-65
+  pioId: swsh10-65
+  enumId: UXIE_65
+  name: Uxie
+  number: '65'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Wise Guidance
+    text: Search your deck for a card and put it into your hand. Then, shuffle your
+      deck.
+  - cost: [P]
+    name: Psyshot
+    damage: '20'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: sui
+- id: FILL_THIS-66
+  pioId: swsh10-66
+  enumId: MESPRIT_66
+  name: Mesprit
+  number: '66'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Mental Shroud
+    text: If you have Uxie and Azelf in play, each of your Pokémon has no Weakness.
+  moves:
+  - cost: [P, P]
+    name: Zen Headbutt
+    damage: '30'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: zig
+- id: FILL_THIS-67
+  pioId: swsh10-67
+  enumId: AZELF_67
+  name: Azelf
+  number: '67'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Mind Bend
+    damage: '30'
+    text: Your opponent's Active Pokémon is now Confused.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Taira Akitsu
+- id: FILL_THIS-68
+  pioId: swsh10-68
+  enumId: DIANCIE_68
+  name: Diancie
+  number: '68'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Princess's Curtain
+    text: As long as this Pokémon is in the Active Spot, whenever your opponent plays
+      a Supporter card from their hand, prevent all effects of that card done to your
+      Benched Basic Pokémon.
+  moves:
+  - cost: [C]
+    name: Spike Draw
+    damage: '20'
+    text: Draw 2 cards.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  artist: Yuu Nishida
+- id: FILL_THIS-69
+  pioId: swsh10-69
+  enumId: WYRDEER_69
+  name: Wyrdeer
+  number: '69'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Stantler
+  hp: 140
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Hurried Gait
+    text: Once during your turn, you may draw a card.
+  moves:
+  - cost: [C, C]
+    name: Extrasensory
+    damage: 40+
+    text: If you have the same number of cards in your hand as your opponent, this
+      attack does 80 more damage.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: Mizue
+- id: FILL_THIS-70
+  pioId: swsh10-70
+  enumId: HISUIAN_GROWLITHE_70
+  name: Hisuian Growlithe
+  number: '70'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Arcanine]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: []
+    name: Defensive Posture
+    text: Flip a coin. If heads, during your opponent's next turn, prevent all damage
+      done to this Pokémon by attacks.
+  - cost: [F, C]
+    name: Bite
+    damage: '30'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Akira Komayama
+- id: FILL_THIS-71
+  pioId: swsh10-71
+  enumId: HISUIAN_ARCANINE_71
+  name: Hisuian Arcanine
+  number: '71'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Hisuian Growlithe
+  hp: 150
+  retreatCost: 2
+  moves:
+  - cost: [F, C]
+    name: Boulder Crush
+    damage: '50'
+  - cost: [F, F, C]
+    name: Scorching Horn
+    damage: 80+
+    text: If this Pokémon has any [R] Energy attached, this attack does 80 more damage,
+      and your opponent's Active Pokémon is now Burned.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: Kagemaru Himeno
+- id: FILL_THIS-72
+  pioId: swsh10-72
+  enumId: MACHAMP_V_72
+  name: Machamp V
+  number: '72'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [F, C]
+    name: Revenge Buster
+    damage: 50+
+    text: If your Benched Pokémon have any damage counters on them, this attack does
+      50 more damage.
+  - cost: [F, F, C]
+    name: Seismic Toss
+    damage: '140'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: kawayoo
+- id: FILL_THIS-73
+  pioId: swsh10-73
+  enumId: MACHAMP_VMAX_73
+  name: Machamp VMAX
+  number: '73'
+  types: [F]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Machamp V
+  hp: 330
+  retreatCost: 3
+  moves:
+  - cost: [F, C]
+    name: Revenge Buster
+    damage: 80+
+    text: If your Benched Pokémon have any damage counters on them, this attack does
+      140 more damage.
+  - cost: [F, F, C]
+    name: G-Max Chi Strike
+    damage: '240'
+    text: During your next turn, this Pokémon can't use G-Max Chi Strike.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: N-DESIGN Inc.
+- id: FILL_THIS-74
+  pioId: swsh10-74
+  enumId: SUDOWOODO_74
+  name: Sudowoodo
+  number: '74'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Vamoose
+    text: If this Pokémon has any damage counters on it, it has no Retreat Cost.
+  moves:
+  - cost: [F, F]
+    name: Double-Edge
+    damage: '90'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: HYOGONOSUKE
+- id: FILL_THIS-75
+  pioId: swsh10-75
+  enumId: REGIROCK_75
+  name: Regirock
+  number: '75'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Regi Gate
+    text: Search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle
+      your deck.
+  - cost: [F, F, C]
+    name: Giga Impact
+    damage: '140'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: Souichirou Gunjima
+- id: FILL_THIS-76
+  pioId: swsh10-76
+  enumId: CRANIDOS_76
+  name: Cranidos
+  number: '76'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Unidentified Fossil
+  evolvesTo: [Rampardos]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Ram
+    damage: '20'
+  - cost: [F, F]
+    name: Stone Edge
+    damage: 40+
+    text: Flip a coin. If heads, this attack does 40 more damage.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: Hataya
+- id: FILL_THIS-77
+  pioId: swsh10-77
+  enumId: RAMPARDOS_77
+  name: Rampardos
+  number: '77'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Cranidos
+  hp: 170
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Headbutt Bounce
+    damage: '60'
+  - cost: [F, F]
+    name: Jurassic Hammer
+    damage: '240'
+    text: If your opponent has 3 or fewer cards in their hand, this attack does nothing.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: Nisota Niso
+- id: FILL_THIS-78
+  pioId: swsh10-78
+  enumId: LUCARIO_V_78
+  name: Lucario V
+  number: '78'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Crushing Punch
+    damage: '50'
+    text: Discard a Special Energy from your opponent's Active Pokémon.
+  - cost: [F, C, C]
+    name: Cyclone Kick
+    damage: '120'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: takuyoa
+- id: FILL_THIS-79
+  pioId: swsh10-79
+  enumId: HIPPOPOTAS_79
+  name: Hippopotas
+  number: '79'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Hippowdon]
+  hp: 100
+  retreatCost: 4
+  moves:
+  - cost: [F, C]
+    name: Mud-Slap
+    damage: '30'
+  - cost: [F, C, C, C]
+    name: Rolling Tackle
+    damage: '90'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: nagimiso
+- id: FILL_THIS-80
+  pioId: swsh10-80
+  enumId: HIPPOWDON_80
+  name: Hippowdon
+  number: '80'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Hippopotas
+  hp: 150
+  retreatCost: 4
+  moves:
+  - cost: [F, C, C]
+    name: Bite
+    damage: '80'
+  - cost: [F, C, C, C]
+    name: Sand Breath
+    damage: '180'
+    text: Discard 2 Energy from this Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: Kyoko Umemoto
+- id: FILL_THIS-81
+  pioId: swsh10-81
+  enumId: RADIANT_HAWLUCHA_81
+  name: Radiant Hawlucha
+  number: '81'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Big Match
+    text: As long as this Pokémon is on your Bench, your Pokémon's attacks do 30 more
+      damage to your opponent's Active Pokémon VMAX (before applying Weakness and
+      Resistance).
+  moves:
+  - cost: [F, C]
+    name: Spiral Kick
+    damage: '50'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare
+  text:
+  - 'Radiant Pokémon Rule: You can''t have more than 1 Radiant Pokémon in your deck.'
+  artist: Masakazu Fukuda
+- id: FILL_THIS-82
+  pioId: swsh10-82
+  enumId: HISUIAN_DECIDUEYE_82
+  name: Hisuian Decidueye
+  number: '82'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Dartrix
+  hp: 160
+  retreatCost: 2
+  moves:
+  - cost: []
+    name: Piercing Claw
+    damage: 30x
+    text: This attack does 30 damage for each damage counter on your opponent's Active
+      Pokémon.
+  - cost: [F, C, C]
+    name: Direct Arrow
+    text: This attack does 80 damage to 1 of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare Holo
+  artist: Kouki Saitou
+- id: FILL_THIS-83
+  pioId: swsh10-83
+  enumId: HISUIAN_DECIDUEYE_V_83
+  name: Hisuian Decidueye V
+  number: '83'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Mountain Hunt
+    text: Search your deck for up to 2 cards and put them into your hand. Then, shuffle
+      your deck.
+  - cost: [F, C, C]
+    name: Close-Quarters Shooting
+    damage: '100'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Shin Nagasawa
+- id: FILL_THIS-84
+  pioId: swsh10-84
+  enumId: HISUIAN_DECIDUEYE_VSTAR_84
+  name: Hisuian Decidueye VSTAR
+  number: '84'
+  types: [F]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Hisuian Decidueye V
+  hp: 270
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Star of Fortune
+    text: During your turn, you may draw cards until you have 8 cards in your hand.
+      (You can't use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [F, C, C]
+    name: Somersault Feathers
+    damage: 160+
+    text: You may discard up to 3 Energy cards from your hand. This attack does 30
+      more damage for each card you discarded in this way.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-85
+  pioId: swsh10-85
+  enumId: KLEAVOR_85
+  name: Kleavor
+  number: '85'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Scyther
+  hp: 140
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Rout
+    damage: 10+
+    text: This attack does 30 more damage for each of your opponent's Benched Pokémon.
+  - cost: [F, C, C]
+    name: Rocky Tackle
+    damage: '150'
+    text: This Pokémon also does 50 damage to itself.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: Shin Nagasawa
+- id: FILL_THIS-86
+  pioId: swsh10-86
+  enumId: KLEAVOR_86
+  name: Kleavor
+  number: '86'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Scyther
+  hp: 140
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Timber Cleave
+    text: Flip 2 coins. If both of them are heads, your opponent's Active Pokémon
+      is Knocked Out.
+  - cost: [F, F]
+    name: Berserker Tackle
+    damage: '120'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: Anesaki Dynamic
+- id: FILL_THIS-87
+  pioId: swsh10-87
+  enumId: KLEAVOR_V_87
+  name: Kleavor V
+  number: '87'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Cut
+    damage: '40'
+  - cost: [F, F, C]
+    name: Axe Slash
+    damage: '150'
+    text: Discard an Energy from this Pokémon. If you do, discard an Energy from your
+      opponent's Active Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-88
+  pioId: swsh10-88
+  enumId: HISUIAN_QWILFISH_88
+  name: Hisuian Qwilfish
+  number: '88'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Ram
+    damage: '10'
+  - cost: [D, C]
+    name: Rolling Tackle
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Kagemaru Himeno
+- id: FILL_THIS-89
+  pioId: swsh10-89
+  enumId: HISUIAN_QWILFISH_89
+  name: Hisuian Qwilfish
+  number: '89'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: []
+    name: Spiny Rush
+    damage: 10x
+    text: Flip a coin until you get tails. This attack does 10 damage for each heads.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: OKACHEKE
+- id: FILL_THIS-90
+  pioId: swsh10-90
+  enumId: HISUIAN_OVERQWIL_90
+  name: Hisuian Overqwil
+  number: '90'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Hisuian Qwilfish
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: []
+    name: Tormenting Poison
+    text: Your opponent's Active Pokémon is now Poisoned. During Pokémon Checkup,
+      put 5 damage counters on that Pokémon instead of 1.
+  - cost: [D, C]
+    name: Pinning
+    damage: '50'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: AKIRA EGAWA
+- id: FILL_THIS-91
+  pioId: swsh10-91
+  enumId: HISUIAN_OVERQWIL_91
+  name: Hisuian Overqwil
+  number: '91'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Hisuian Qwilfish
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [D]
+    name: Dirty Press
+    damage: 30+
+    text: If you have at least 3 [D] Energy in play, this attack does 90 more damage.
+  - cost: [D, C]
+    name: Pierce
+    damage: '70'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Anesaki Dynamic
+- id: FILL_THIS-92
+  pioId: swsh10-92
+  enumId: HISUIAN_SNEASEL_92
+  name: Hisuian Sneasel
+  number: '92'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Weavile]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Scratch
+    damage: '10'
+  - cost: [D, C]
+    name: Claw Slash
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Mizue
+- id: FILL_THIS-93
+  pioId: swsh10-93
+  enumId: HISUIAN_SNEASLER_93
+  name: Hisuian Sneasler
+  number: '93'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Hisuian Sneasel
+  hp: 120
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Carry and Climb
+    text: As long as this Pokémon is on your Bench, your Active Pokémon's Retreat
+      Cost is [C][C] less.
+  moves:
+  - cost: [D, C]
+    name: Claw Slash
+    damage: '60'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: Kouki Saitou
+- id: FILL_THIS-94
+  pioId: swsh10-94
+  enumId: HISUIAN_SNEASLER_V_94
+  name: Hisuian Sneasler V
+  number: '94'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  moves:
+  - cost: []
+    name: Poison Claws
+    text: Your opponent's Active Pokémon is now Poisoned.
+  - cost: [D, C]
+    name: Dire Claw
+    damage: 80x
+    text: This attack does 80 damage for each Special Condition affecting your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-95
+  pioId: swsh10-95
+  enumId: POOCHYENA_95
+  name: Poochyena
+  number: '95'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Mightyena]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Gnaw
+    damage: '10'
+  - cost: [C, C]
+    name: Slight Intrusion
+    damage: '30'
+    text: This Pokémon also does 10 damage to itself.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: KIYOTAKA OSHIYAMA
+- id: FILL_THIS-96
+  pioId: swsh10-96
+  enumId: MIGHTYENA_96
+  name: Mightyena
+  number: '96'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Poochyena
+  hp: 110
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Hustle Bark
+    text: If your opponent has any Pokémon VMAX in play, this Pokémon's attacks cost
+      [C][C][C] less.
+  moves:
+  - cost: [C, C, C]
+    name: Wild Tackle
+    damage: '160'
+    text: This Pokémon also does 50 damage to itself.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: otumami
+- id: FILL_THIS-97
+  pioId: swsh10-97
+  enumId: ABSOL_97
+  name: Absol
+  number: '97'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Swirling Disaster
+    text: This attack does 10 damage to each of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  - cost: [D, C]
+    name: Claw Rend
+    damage: 50+
+    text: If your opponent's Active Pokémon already has any damage counters on it,
+      this attack does 70 more damage.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: GIDORA
+- id: FILL_THIS-98
+  pioId: swsh10-98
+  enumId: DARKRAI_V_98
+  name: Darkrai V
+  number: '98'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [D, C]
+    name: Wind of Darkness
+    damage: '50'
+  - cost: [D, D, C]
+    name: Dark Void
+    damage: '130'
+    text: Your opponent's Active Pokémon is now Asleep.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: takuyoa
+- id: FILL_THIS-99
+  pioId: swsh10-99
+  enumId: DARKRAI_VSTAR_99
+  name: Darkrai VSTAR
+  number: '99'
+  types: [D]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Darkrai V
+  hp: 270
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Star Abyss
+    text: During your turn, you may put up to 2 Item cards from your discard pile
+      into your hand. (You can't use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [C, C]
+    name: Dark Pulse
+    damage: 30+
+    text: This attack does 30 more damage for each [D] Energy attached to all of your
+      Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-100
+  pioId: swsh10-100
+  enumId: HISUIAN_SAMUROTT_100
+  name: Hisuian Samurott
+  number: '100'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Dewott
+  hp: 170
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Wily Stance
+    text: You must discard a card from your hand in order to use this Ability. Once
+      during your turn, you may draw 3 cards.
+  moves:
+  - cost: [D, C, C]
+    name: Dark Mastery
+    damage: 60+
+    text: This attack does 20 more damage for each Energy attached to all of your
+      Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: Kouki Saitou
+- id: FILL_THIS-101
+  pioId: swsh10-101
+  enumId: HISUIAN_SAMUROTT_V_101
+  name: Hisuian Samurott V
+  number: '101'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [D]
+    name: Basket Crash
+    text: Discard up to 2 Pokémon Tools from your opponent's Pokémon.
+  - cost: [D, D, D]
+    name: Shadow Slash
+    damage: '180'
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Shin Nagasawa
+- id: FILL_THIS-102
+  pioId: swsh10-102
+  enumId: HISUIAN_SAMUROTT_VSTAR_102
+  name: Hisuian Samurott VSTAR
+  number: '102'
+  types: [D]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Hisuian Samurott V
+  hp: 270
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Moon Cleave Star
+    text: During your turn, you may put 4 damage counters on 1 of your opponent's
+      Pokémon. (You can't use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [D, D]
+    name: Merciless Blade
+    damage: 110+
+    text: If your opponent's Active Pokémon already has any damage counters on it,
+      this attack does 110 more damage.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-103
+  pioId: swsh10-103
+  enumId: NICKIT_103
+  name: Nickit
+  number: '103'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Thievul]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Rear Kick
+    damage: '10'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Naoyo Kimura
+- id: FILL_THIS-104
+  pioId: swsh10-104
+  enumId: THIEVUL_104
+  name: Thievul
+  number: '104'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Nickit
+  hp: 100
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Baffling
+    text: If your opponent has 2 or fewer Prize cards remaining, whenever your opponent
+      plays a Supporter card from their hand, prevent all effects of that card done
+      to your Benched Pokémon V.
+  moves:
+  - cost: [D, D, C]
+    name: Sharp Fang
+    damage: '110'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: KIYOTAKA OSHIYAMA
+- id: FILL_THIS-105
+  pioId: swsh10-105
+  enumId: MAGNEMITE_105
+  name: Magnemite
+  number: '105'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Magneton]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Magnetic Catch
+    text: Shuffle up to 3 [M] Energy cards from your discard pile into your deck.
+  - cost: [M, C]
+    name: Rolling Attack
+    damage: '30'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Common
+  artist: Mitsuhiro Arita
+- id: FILL_THIS-106
+  pioId: swsh10-106
+  enumId: MAGNETON_106
+  name: Magneton
+  number: '106'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Magnemite
+  evolvesTo: [Magnezone]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [M, C]
+    name: Bounce Back
+    damage: '50'
+    text: Your opponent switches their Active Pokémon with 1 of their Benched Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Uncommon
+  artist: Saya Tsuruta
+- id: FILL_THIS-107
+  pioId: swsh10-107
+  enumId: MAGNEZONE_107
+  name: Magnezone
+  number: '107'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Magneton
+  hp: 150
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Giga Magnet
+    text: Once during your turn, you may look at the top 6 cards of your deck and
+      attach any number of [M] Energy cards you find there to your Pokémon in any
+      way you like. Shuffle the other cards back into your deck.
+  moves:
+  - cost: [M, C, C]
+    name: Power Beam
+    damage: '120'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  artist: GOSSAN
+- id: FILL_THIS-108
+  pioId: swsh10-108
+  enumId: REGISTEEL_108
+  name: Registeel
+  number: '108'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Regi Gate
+    text: Search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle
+      your deck.
+  - cost: [M, M, C]
+    name: Heavy Slam
+    damage: 220-
+    text: This attack does 50 less damage for each [C] in your opponent's Active Pokémon's
+      Retreat Cost.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare
+  artist: hatachu
+- id: FILL_THIS-109
+  pioId: swsh10-109
+  enumId: SHIELDON_109
+  name: Shieldon
+  number: '109'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Unidentified Fossil
+  evolvesTo: [Bastiodon]
+  hp: 100
+  retreatCost: 3
+  moves:
+  - cost: [M, C]
+    name: Hard Headbutt
+    damage: '30'
+    text: Flip a coin. If heads, during your opponent's next turn, prevent all damage
+      from and effects of attacks done to this Pokémon.
+  - cost: [M, M, C]
+    name: Confront
+    damage: '100'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Uncommon
+  artist: Yuka Morii
+- id: FILL_THIS-110
+  pioId: swsh10-110
+  enumId: BASTIODON_110
+  name: Bastiodon
+  number: '110'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Shieldon
+  hp: 160
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Primal Fortress
+    text: Your Pokémon take 30 less damage from attacks from your opponent's Pokémon
+      V (after applying Weakness and Resistance).
+  moves:
+  - cost: [M, M, C]
+    name: Iron Tackle
+    damage: '180'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  artist: Yuya Oka
+- id: FILL_THIS-111
+  pioId: swsh10-111
+  enumId: BRONZOR_111
+  name: Bronzor
+  number: '111'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Bronzong]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [M, C]
+    name: Metal Press
+    damage: '20'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Common
+  artist: Kouki Saitou
+- id: FILL_THIS-112
+  pioId: swsh10-112
+  enumId: BRONZONG_112
+  name: Bronzong
+  number: '112'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Bronzor
+  hp: 130
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Heatproof
+    text: Prevent all damage done to this Pokémon by attacks from your opponent's
+      [R] Pokémon.
+  moves:
+  - cost: [M, C, C]
+    name: Hammer In
+    damage: '100'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Uncommon
+  artist: Shinji Kanda
+- id: FILL_THIS-113
+  pioId: swsh10-113
+  enumId: ORIGIN_FORME_DIALGA_V_113
+  name: Origin Forme Dialga V
+  number: '113'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Metal Coating
+    text: Attach up to 2 [M] Energy cards from your discard pile to this Pokémon.
+  - cost: [M, M, M, C]
+    name: Temporal Rupture
+    damage: '180'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-114
+  pioId: swsh10-114
+  enumId: ORIGIN_FORME_DIALGA_VSTAR_114
+  name: Origin Forme Dialga VSTAR
+  number: '114'
+  types: [M]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Origin Forme Dialga V
+  hp: 280
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Metal Blast
+    damage: 40+
+    text: This attack does 40 more damage for each [M] Energy attached to this Pokémon.
+  - cost: [M, M, M, M, C]
+    name: Star Chronos
+    damage: '220'
+    text: Take another turn after this one. (Skip Pokémon Checkup.) (You can't use
+      more than 1 VSTAR Power in a game.)
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-115
+  pioId: swsh10-115
+  enumId: PAWNIARD_115
+  name: Pawniard
+  number: '115'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Bisharp]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [M]
+    name: Reckless Charge
+    damage: '30'
+    text: This Pokémon also does 10 damage to itself.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Common
+  artist: Tomokazu Komiya
+- id: FILL_THIS-116
+  pioId: swsh10-116
+  enumId: BISHARP_116
+  name: Bisharp
+  number: '116'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Pawniard
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [M]
+    name: Vengeful Cut
+    damage: 30+
+    text: This attack does 30 more damage for each damage counter on all of your Benched
+      Pawniard.
+  - cost: [M, C, C]
+    name: Slicing Blade
+    damage: '90'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Uncommon
+  artist: NC Empire
+- id: FILL_THIS-117
+  pioId: swsh10-117
+  enumId: GARCHOMP_V_117
+  name: Garchomp V
+  number: '117'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  moves:
+  - cost: [W, F, C]
+    name: Dragon Claw
+    damage: '120'
+  - cost: [W, F, F, C]
+    name: Sonic Strike
+    text: Discard 3 Energy from this Pokémon. This attack does 220 damage to 1 of
+      your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: N-DESIGN Inc.
+- id: FILL_THIS-118
+  pioId: swsh10-118
+  enumId: REGIDRAGO_118
+  name: Regidrago
+  number: '118'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Dragon's Hoard
+    text: Once during your turn, if this Pokémon is in the Active Spot, you may draw
+      cards until you have 4 cards in your hand. You can't use more than 1 Dragon's
+      Hoard Ability each turn.
+  moves:
+  - cost: [G, R, C]
+    name: Giant Fangs
+    damage: '160'
+  rarity: Rare
+  artist: DOM
+- id: FILL_THIS-119
+  pioId: swsh10-119
+  enumId: EEVEE_119
+  name: Eevee
+  number: '119'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Vaporeon, Jolteon, Flareon, Sylveon, Espeon, Umbreon, Leafeon, Glaceon]
+  hp: 50
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Resonant Evolution
+    text: Once during your turn, when you play a Pokémon from your hand to evolve
+      1 of your other Eevee, you may search your deck for a card that evolves from
+      this Pokémon and put it onto this Pokémon to evolve it. Then, shuffle your deck.
+  moves:
+  - cost: [C, C]
+    name: Tackle
+    damage: '20'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: sowsow
+- id: FILL_THIS-120
+  pioId: swsh10-120
+  enumId: HOOTHOOT_120
+  name: Hoothoot
+  number: '120'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Noctowl]
+  hp: 50
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Stand Sentry
+    text: Basic Energy attached to your Benched Pokémon can't be discarded by an effect
+      of your opponent's Item or Supporter cards.
+  moves:
+  - cost: [C, C]
+    name: Flap
+    damage: '20'
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Pani Kobayashi
+- id: FILL_THIS-121
+  pioId: swsh10-121
+  enumId: NOCTOWL_121
+  name: Noctowl
+  number: '121'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Hoothoot
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Silent Wing
+    damage: '50'
+    text: Your opponent reveals their hand.
+  - cost: [C, C, C]
+    name: Air Slash
+    damage: '120'
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Nisota Niso
+- id: FILL_THIS-122
+  pioId: swsh10-122
+  enumId: TEDDIURSA_122
+  name: Teddiursa
+  number: '122'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Ursaring]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Gather Food
+    text: Flip a coin. If heads, put an Item card from your discard pile into your
+      hand.
+  - cost: [C, C]
+    name: Dig Claws
+    damage: '20'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Nagomi Nijo
+- id: FILL_THIS-123
+  pioId: swsh10-123
+  enumId: URSARING_123
+  name: Ursaring
+  number: '123'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Teddiursa
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Continuous Slap
+    damage: 40x
+    text: Flip a coin until you get tails. This attack does 40 damage for each heads.
+  - cost: [C, C, C]
+    name: Strength
+    damage: '100'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: Teeziro
+- id: FILL_THIS-124
+  pioId: swsh10-124
+  enumId: URSALUNA_124
+  name: Ursaluna
+  number: '124'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Ursaring
+  hp: 180
+  retreatCost: 4
+  moves:
+  - cost: [C]
+    name: Peat Hunt
+    text: Put up to 2 cards from your discard pile into your hand.
+  - cost: [C, C, C]
+    name: Bulky Bump
+    damage: '200'
+    text: Discard 2 Energy from this Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: nagimiso
+- id: FILL_THIS-125
+  pioId: swsh10-125
+  enumId: STANTLER_125
+  name: Stantler
+  number: '125'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 100
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Guard Press
+    damage: '30'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Teeziro
+- id: FILL_THIS-126
+  pioId: swsh10-126
+  enumId: MILTANK_126
+  name: Miltank
+  number: '126'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Miracle Body
+    text: Prevent all damage done to this Pokémon by attacks from your opponent's
+      Pokémon V.
+  moves:
+  - cost: [C, C]
+    name: Rout
+    damage: 10+
+    text: This attack does 20 more damage for each of your opponent's Benched Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: saino misaki
+- id: FILL_THIS-127
+  pioId: swsh10-127
+  enumId: GLAMEOW_127
+  name: Glameow
+  number: '127'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Purugly]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Fake Out
+    damage: '20'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Naoyo Kimura
+- id: FILL_THIS-128
+  pioId: swsh10-128
+  enumId: PURUGLY_128
+  name: Purugly
+  number: '128'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Glameow
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Body Slam
+    damage: '30'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [C, C, C]
+    name: Slashing Claw
+    damage: '100'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: Mina Nakai
+- id: FILL_THIS-129
+  pioId: swsh10-129
+  enumId: CHATOT_129
+  name: Chatot
+  number: '129'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Collect
+    text: Draw a card.
+  - cost: [C]
+    name: Jabber On
+    damage: '30'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Shin Nagasawa
+- id: FILL_THIS-130
+  pioId: swsh10-130
+  enumId: REGIGIGAS_130
+  name: Regigigas
+  number: '130'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 150
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Ancient Wisdom
+    text: Once during your turn, if you have Regirock, Regice, Registeel, Regieleki,
+      and Regidrago in play, you may attach up to 3 Energy cards from your discard
+      pile to 1 of your Pokémon.
+  moves:
+  - cost: [C, C, C, C, C]
+    name: Gigaton Break
+    damage: 150+
+    text: If your opponent's Active Pokémon is a Pokémon VMAX, this attack does 150
+      more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: Yuya Oka
+- id: FILL_THIS-131
+  pioId: swsh10-131
+  enumId: RUFFLET_131
+  name: Rufflet
+  number: '131'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Braviary]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Claw
+    damage: '30'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Eri Yamaki
+- id: FILL_THIS-132
+  pioId: swsh10-132
+  enumId: HISUIAN_BRAVIARY_132
+  name: Hisuian Braviary
+  number: '132'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Rufflet
+  hp: 130
+  retreatCost: 1
+  moves:
+  - cost: []
+    name: Psywave
+    damage: 30x
+    text: This attack does 30 damage for each Energy attached to your opponent's Active
+      Pokémon.
+  - cost: [C, C, C]
+    name: Slashing Strike
+    damage: '120'
+    text: During your next turn, this Pokémon can't use Slashing Strike.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Shin Nagasawa
+- id: FILL_THIS-133
+  pioId: swsh10-133
+  enumId: ORANGURU_V_133
+  name: Oranguru V
+  number: '133'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Back Order
+    text: Once during your turn, if this Pokémon is in the Active Spot, you may search
+      your deck for up to 2 Pokémon Tool cards, reveal them, and put them into your
+      hand. Then, shuffle your deck.
+  moves:
+  - cost: [C, C, C]
+    name: Psychic
+    damage: 30+
+    text: This attack does 50 more damage for each Energy attached to your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Uta
+- id: FILL_THIS-134
+  pioId: swsh10-134
+  enumId: WYRDEER_V_134
+  name: Wyrdeer V
+  number: '134'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Frontier Road
+    text: Once during your turn, when this Pokémon moves from your Bench to the Active
+      Spot, you may move any amount of Energy from your other Pokémon to it.
+  moves:
+  - cost: [C, C, C]
+    name: Psyshield Bash
+    damage: 40x
+    text: This attack does 40 damage for each Energy attached to this Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+- id: FILL_THIS-135
+  pioId: swsh10-135
+  enumId: ADAMAN_135
+  name: Adaman
+  number: '135'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Rare Holo
+  text:
+  - You can use this card only if you discard 2 [M] Energy cards from your hand. Search
+    your deck for up to 2 cards and put them into your hand. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Souichirou Gunjima
+- id: FILL_THIS-136
+  pioId: swsh10-136
+  enumId: CANCELING_COLOGNE_136
+  name: Canceling Cologne
+  number: '136'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Until the end of your turn, your opponent's Active Pokémon has no Abilities. (This
+    includes Pokémon that come into play during that turn.)
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Studio Bora Inc.
+- id: FILL_THIS-137
+  pioId: swsh10-137
+  enumId: CHOY_137
+  name: Choy
+  number: '137'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Each player reveals their hand. Draw 3 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hitoshi Ariga
+- id: FILL_THIS-138
+  pioId: swsh10-138
+  enumId: CYLLENE_138
+  name: Cyllene
+  number: '138'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Flip 2 coins. Put a number of cards up to the number of heads from your discard
+    pile on top of your deck in any order.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: nagimiso
+- id: FILL_THIS-139
+  pioId: swsh10-139
+  enumId: DARK_PATCH_139
+  name: Dark Patch
+  number: '139'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Attach a basic [D] Energy card from your discard pile to 1 of your Benched [D]
+    Pokémon.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Ryo Ueda
+- id: FILL_THIS-140
+  pioId: swsh10-140
+  enumId: ENERGY_LOTO_140
+  name: Energy Loto
+  number: '140'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Look at the top 7 cards of your deck. You may reveal an Energy card you find there
+    and put it into your hand. Shuffle the other cards back into your deck.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: ORBITALLINK Inc.
+- id: FILL_THIS-141
+  pioId: swsh10-141
+  enumId: FEATHER_BALL_141
+  name: Feather Ball
+  number: '141'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Search your deck for a Pokémon that has no Retreat Cost, reveal it, and put it
+    into your hand. Then, shuffle your deck.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Studio Bora Inc.
+- id: FILL_THIS-142
+  pioId: swsh10-142
+  enumId: GAPEJAW_BOG_142
+  name: Gapejaw Bog
+  number: '142'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Uncommon
+  text:
+  - Whenever either player puts a Basic Pokémon from their hand onto their Bench,
+    put 2 damage counters on that Pokémon.
+  artist: Oswaldo KATO
+- id: FILL_THIS-143
+  pioId: swsh10-143
+  enumId: GARDENIA_S_VIGOR_143
+  name: Gardenia's Vigor
+  number: '143'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Draw 2 cards. If you drew any cards in this way, attach up to 2 [G] Energy cards
+    from your hand to 1 of your Benched Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yuu Nishida
+- id: FILL_THIS-144
+  pioId: swsh10-144
+  enumId: GRANT_144
+  name: Grant
+  number: '144'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - During this turn, your [F] Pokémon's attacks do 30 more damage to your opponent's
+    Active Pokémon (before applying Weakness and Resistance). During your turn, if
+    this Grant is in your discard pile, you may discard 2 cards, except any Grant,
+    from your hand. If you do, put this Grant into your hand. (This effect doesn't
+    use up your Supporter card for the turn.)
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hideki Ishikawa
+- id: FILL_THIS-145
+  pioId: swsh10-145
+  enumId: GUTSY_PICKAXE_145
+  name: Gutsy Pickaxe
+  number: '145'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Reveal the top card of your deck. If that card is a [F] Energy card, attach it
+    to 1 of your Benched Pokémon. If it is not a [F] Energy card, put it into your
+    hand.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Eske Yoshinob
+- id: FILL_THIS-146
+  pioId: swsh10-146
+  enumId: HISUIAN_HEAVY_BALL_146
+  name: Hisuian Heavy Ball
+  number: '146'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Look at your face-down Prize cards. You may reveal a Basic Pokémon you find there,
+    put it into your hand, and put this Hisuian Heavy Ball in its place as a face-down
+    Prize card. (If you don't reveal a Basic Pokémon, put this card in the discard
+    pile.) Then, shuffle your face-down Prize cards.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Studio Bora Inc.
+- id: FILL_THIS-147
+  pioId: swsh10-147
+  enumId: IRIDA_147
+  name: Irida
+  number: '147'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Rare Holo
+  text:
+  - Search your deck for a [W] Pokémon and an Item card, reveal them, and put them
+    into your hand. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: kirisAki
+- id: FILL_THIS-148
+  pioId: swsh10-148
+  enumId: JUBILIFE_VILLAGE_148
+  name: Jubilife Village
+  number: '148'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Uncommon
+  text:
+  - Once during each player's turn, that player may shuffle their hand into their
+    deck and draw 5 cards. If they do, their turn ends.
+  artist: Oswaldo KATO
+- id: FILL_THIS-149
+  pioId: swsh10-149
+  enumId: KAMADO_149
+  name: Kamado
+  number: '149'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Choose a card in your hand, and discard the other cards. If you do, draw 4 cards.
+    (If you have no other cards in your hand, you can't use this card.)
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hitoshi Ariga
+- id: FILL_THIS-150
+  pioId: swsh10-150
+  enumId: ROXANNE_150
+  name: Roxanne
+  number: '150'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - You can use this card only if your opponent has 3 or fewer Prize cards remaining.
+    Each player shuffles their hand into their deck. Then, you draw 6 cards, and your
+    opponent draws 2 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Megumi Mizutani
+- id: FILL_THIS-151
+  pioId: swsh10-151
+  enumId: SPICY_SEASONED_CURRY_151
+  name: Spicy Seasoned Curry
+  number: '151'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Your Active Pokémon is now Burned. Heal 40 damage from it.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: AYUMI ODASHIMA
+- id: FILL_THIS-152
+  pioId: swsh10-152
+  enumId: SUPEREFFECTIVE_GLASSES_152
+  name: Supereffective Glasses
+  number: '152'
+  superType: TRAINER
+  subTypes: [ITEM, ITEM, POKEMON_TOOL]
+  rarity: Uncommon
+  text:
+  - When applying Weakness to damage from the attacks of the Pokémon this card is
+    attached to done to your opponent's Active Pokémon, apply it as ×3.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
+    have a Pokémon Tool attached.'
+  artist: Ryo Ueda
+- id: FILL_THIS-153
+  pioId: swsh10-153
+  enumId: SWEET_HONEY_153
+  name: Sweet Honey
+  number: '153'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Choose 1 of your Pokémon, and then flip a coin until you get tails. For each heads,
+    heal 40 damage from that Pokémon.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: ORBITALLINK Inc.
+- id: FILL_THIS-154
+  pioId: swsh10-154
+  enumId: SWITCH_CART_154
+  name: Switch Cart
+  number: '154'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Switch your Active Basic Pokémon with 1 of your Benched Pokémon. If you do, heal
+    30 damage from the Pokémon you moved to your Bench.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Toyste Beach
+- id: FILL_THIS-155
+  pioId: swsh10-155
+  enumId: TEMPLE_OF_SINNOH_155
+  name: Temple of Sinnoh
+  number: '155'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Uncommon
+  text:
+  - All Special Energy attached to Pokémon (both yours and your opponent's) provide
+    [C] Energy and have no other effect.
+  artist: Oswaldo KATO
+- id: FILL_THIS-156
+  pioId: swsh10-156
+  enumId: TREKKING_SHOES_156
+  name: Trekking Shoes
+  number: '156'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Look at the top card of your deck. You may put that card into your hand. If you
+    don't, discard that card and draw a card.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Toyste Beach
+- id: FILL_THIS-157
+  pioId: swsh10-157
+  enumId: UNIDENTIFIED_FOSSIL_157
+  name: Unidentified Fossil
+  number: '157'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Play this card as if it were a 60-HP Basic [C] Pokémon. At any time during your
+    turn, you may discard this card from play. This card can't retreat.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: AYUMI ODASHIMA
+- id: FILL_THIS-158
+  pioId: swsh10-158
+  enumId: WAIT_AND_SEE_TURBO_158
+  name: Wait and See Turbo
+  number: '158'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - You can use this card only if you go second, and only during your first turn.
+    Search your deck for a basic Energy card and attach it to 1 of your Pokémon. Then,
+    shuffle your deck. Your turn ends.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: sadaji
+- id: FILL_THIS-159
+  pioId: swsh10-159
+  enumId: ZISU_159
+  name: Zisu
+  number: '159'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Draw cards until you have 1 more card in your hand than your opponent.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: kirisAki
+- id: FILL_THIS-160
+  pioId: swsh10-160
+  enumId: BEEDRILL_V_160
+  name: Beedrill V
+  number: '160'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Twineedle
+    damage: 40x
+    text: Flip 2 coins. This attack does 40 damage for each heads.
+  - cost: [G, G, C]
+    name: Swarming Sting
+    text: This attack does 50 damage to 1 of your opponent's Pokémon for each of your
+      Beedrill V in play. (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Ayaka Yoshida
+  variantOf: FILL_THIS-1
+  variantType: Full Art
+- id: FILL_THIS-161
+  pioId: swsh10-161
+  enumId: BEEDRILL_V_161
+  name: Beedrill V
+  number: '161'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Twineedle
+    damage: 40x
+    text: Flip 2 coins. This attack does 40 damage for each heads.
+  - cost: [G, G, C]
+    name: Swarming Sting
+    text: This attack does 50 damage to 1 of your opponent's Pokémon for each of your
+      Beedrill V in play. (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Narumi Sato
+  variantOf: FILL_THIS-1
+  variantType: Full Art
+- id: FILL_THIS-162
+  pioId: swsh10-162
+  enumId: HISUIAN_LILLIGANT_V_162
+  name: Hisuian Lilligant V
+  number: '162'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 2
+  moves:
+  - cost: []
+    name: Dance Gracefully
+    text: Draw cards until you have 6 cards in your hand.
+  - cost: [G, G, C]
+    name: Leaf Step
+    damage: '130'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-17
+  variantType: Full Art
+- id: FILL_THIS-163
+  pioId: swsh10-163
+  enumId: HISUIAN_LILLIGANT_V_163
+  name: Hisuian Lilligant V
+  number: '163'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 2
+  moves:
+  - cost: []
+    name: Dance Gracefully
+    text: Draw cards until you have 6 cards in your hand.
+  - cost: [G, G, C]
+    name: Leaf Step
+    damage: '130'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: kodama
+  variantOf: FILL_THIS-17
+  variantType: Full Art
+- id: FILL_THIS-164
+  pioId: swsh10-164
+  enumId: VIRIZION_V_164
+  name: Virizion V
+  number: '164'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Verdant Wind
+    text: Each of your Pokémon that has any [G] Energy attached to it can't be affected
+      by any Special Conditions. (Remove any Special Conditions affecting those Pokémon.)
+  moves:
+  - cost: [G, G, C]
+    name: Emerald Blade
+    damage: '200'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Saki Hayashiro
+- id: FILL_THIS-165
+  pioId: swsh10-165
+  enumId: HEATRAN_V_165
+  name: Heatran V
+  number: '165'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [R, C]
+    name: Heat Burn
+    damage: '30'
+    text: Your opponent's Active Pokémon is now Burned.
+  - cost: [R, R, C]
+    name: Magma Fall
+    damage: 90+
+    text: If you have a Stadium in play, this attack does 90 more damage.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Studio Bora Inc.
+  variantOf: FILL_THIS-25
+  variantType: Full Art
+- id: FILL_THIS-166
+  pioId: swsh10-166
+  enumId: STARMIE_V_166
+  name: Starmie V
+  number: '166'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  moves:
+  - cost: [C, C]
+    name: Swift
+    damage: '50'
+    text: This attack's damage isn't affected by Weakness or Resistance, or by any
+      effects on your opponent's Active Pokémon.
+  - cost: [W, W]
+    name: Energy Spiral
+    damage: 50x
+    text: This attack does 50 damage for each Energy attached to all of your opponent's
+      Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Eske Yoshinob
+  variantOf: FILL_THIS-30
+  variantType: Full Art
+- id: FILL_THIS-167
+  pioId: swsh10-167
+  enumId: ORIGIN_FORME_PALKIA_V_167
+  name: Origin Forme Palkia V
+  number: '167'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Rule the Region
+    text: Search your deck for a Stadium card, reveal it, and put it into your hand.
+      Then, shuffle your deck.
+  - cost: [W, W, C]
+    name: Hydro Break
+    damage: '200'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Oswaldo KATO
+  variantOf: FILL_THIS-39
+  variantType: Full Art
+- id: FILL_THIS-168
+  pioId: swsh10-168
+  enumId: LUXRAY_V_168
+  name: Luxray V
+  number: '168'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Fang Snipe
+    damage: '30'
+    text: Your opponent reveals their hand. Discard a Trainer card you find there.
+  - cost: [L, L, C]
+    name: Radiating Pulse
+    damage: '120'
+    text: Discard 2 Energy from this Pokémon. Your opponent's Active Pokémon is now
+      Paralyzed.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: MUGENUP
+  variantOf: FILL_THIS-50
+  variantType: Full Art
+- id: FILL_THIS-169
+  pioId: swsh10-169
+  enumId: HISUIAN_TYPHLOSION_V_169
+  name: Hisuian Typhlosion V
+  number: '169'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: []
+    name: Singe
+    text: Your opponent's Active Pokémon is now Burned.
+  - cost: [P, P, C]
+    name: Petrifying Flame
+    damage: '120'
+    text: Choose a random card from your opponent's hand. Your opponent reveals that
+      card and shuffles it into their deck.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-53
+  variantType: Full Art
+- id: FILL_THIS-170
+  pioId: swsh10-170
+  enumId: JIRACHI_V_170
+  name: Jirachi V
+  number: '170'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 180
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Wish Connector
+    text: When 1 of your Basic Pokémon V is Knocked Out by damage from an attack from
+      your opponent's Pokémon, you may move a basic Energy card from that Pokémon
+      to another of your Pokémon.
+  moves:
+  - cost: [P, C]
+    name: Hypnostrike
+    damage: '60'
+    text: Both Active Pokémon are now Asleep.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: N-DESIGN Inc.
+- id: FILL_THIS-171
+  pioId: swsh10-171
+  enumId: MACHAMP_V_171
+  name: Machamp V
+  number: '171'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [F, C]
+    name: Revenge Buster
+    damage: 50+
+    text: If your Benched Pokémon have any damage counters on them, this attack does
+      50 more damage.
+  - cost: [F, F, C]
+    name: Seismic Toss
+    damage: '140'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Ryo Ueda
+  variantOf: FILL_THIS-72
+  variantType: Full Art
+- id: FILL_THIS-172
+  pioId: swsh10-172
+  enumId: MACHAMP_V_172
+  name: Machamp V
+  number: '172'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [F, C]
+    name: Revenge Buster
+    damage: 50+
+    text: If your Benched Pokémon have any damage counters on them, this attack does
+      50 more damage.
+  - cost: [F, F, C]
+    name: Seismic Toss
+    damage: '140'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Shinya Komatsu
+  variantOf: FILL_THIS-72
+  variantType: Full Art
+- id: FILL_THIS-173
+  pioId: swsh10-173
+  enumId: HISUIAN_DECIDUEYE_V_173
+  name: Hisuian Decidueye V
+  number: '173'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Mountain Hunt
+    text: Search your deck for up to 2 cards and put them into your hand. Then, shuffle
+      your deck.
+  - cost: [F, C, C]
+    name: Close-Quarters Shooting
+    damage: '100'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-83
+  variantType: Full Art
+- id: FILL_THIS-174
+  pioId: swsh10-174
+  enumId: HISUIAN_SNEASLER_V_174
+  name: Hisuian Sneasler V
+  number: '174'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  moves:
+  - cost: []
+    name: Poison Claws
+    text: Your opponent's Active Pokémon is now Poisoned.
+  - cost: [D, C]
+    name: Dire Claw
+    damage: 80x
+    text: This attack does 80 damage for each Special Condition affecting your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-94
+  variantType: Full Art
+- id: FILL_THIS-175
+  pioId: swsh10-175
+  enumId: HISUIAN_SNEASLER_V_175
+  name: Hisuian Sneasler V
+  number: '175'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  moves:
+  - cost: []
+    name: Poison Claws
+    text: Your opponent's Active Pokémon is now Poisoned.
+  - cost: [D, C]
+    name: Dire Claw
+    damage: 80x
+    text: This attack does 80 damage for each Special Condition affecting your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: OKACHEKE
+  variantOf: FILL_THIS-94
+  variantType: Full Art
+- id: FILL_THIS-176
+  pioId: swsh10-176
+  enumId: HISUIAN_SAMUROTT_V_176
+  name: Hisuian Samurott V
+  number: '176'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [D]
+    name: Basket Crash
+    text: Discard up to 2 Pokémon Tools from your opponent's Pokémon.
+  - cost: [D, D, D]
+    name: Shadow Slash
+    damage: '180'
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-101
+  variantType: Full Art
+- id: FILL_THIS-177
+  pioId: swsh10-177
+  enumId: ORIGIN_FORME_DIALGA_V_177
+  name: Origin Forme Dialga V
+  number: '177'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Metal Coating
+    text: Attach up to 2 [M] Energy cards from your discard pile to this Pokémon.
+  - cost: [M, M, M, C]
+    name: Temporal Rupture
+    damage: '180'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Mitsuhiro Arita
+  variantOf: FILL_THIS-113
+  variantType: Full Art
+- id: FILL_THIS-178
+  pioId: swsh10-178
+  enumId: GARCHOMP_V_178
+  name: Garchomp V
+  number: '178'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  moves:
+  - cost: [W, F, C]
+    name: Dragon Claw
+    damage: '120'
+  - cost: [W, F, F, C]
+    name: Sonic Strike
+    text: Discard 3 Energy from this Pokémon. This attack does 220 damage to 1 of
+      your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: N-DESIGN Inc.
+  variantOf: FILL_THIS-117
+  variantType: Full Art
+- id: FILL_THIS-179
+  pioId: swsh10-179
+  enumId: ORANGURU_V_179
+  name: Oranguru V
+  number: '179'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Back Order
+    text: Once during your turn, if this Pokémon is in the Active Spot, you may search
+      your deck for up to 2 Pokémon Tool cards, reveal them, and put them into your
+      hand. Then, shuffle your deck.
+  moves:
+  - cost: [C, C, C]
+    name: Psychic
+    damage: 30+
+    text: This attack does 50 more damage for each Energy attached to your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Toyste Beach
+  variantOf: FILL_THIS-133
+  variantType: Full Art
+- id: FILL_THIS-180
+  pioId: swsh10-180
+  enumId: WYRDEER_V_180
+  name: Wyrdeer V
+  number: '180'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Frontier Road
+    text: Once during your turn, when this Pokémon moves from your Bench to the Active
+      Spot, you may move any amount of Energy from your other Pokémon to it.
+  moves:
+  - cost: [C, C, C]
+    name: Psyshield Bash
+    damage: 40x
+    text: This attack does 40 damage for each Energy attached to this Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+  variantOf: FILL_THIS-134
+  variantType: Full Art
+- id: FILL_THIS-181
+  pioId: swsh10-181
+  enumId: ADAMAN_181
+  name: Adaman
+  number: '181'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - You can use this card only if you discard 2 [M] Energy cards from your hand. Search
+    your deck for up to 2 cards and put them into your hand. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Souichirou Gunjima
+  variantOf: FILL_THIS-135
+  variantType: Full Art
+- id: FILL_THIS-182
+  pioId: swsh10-182
+  enumId: CHOY_182
+  name: Choy
+  number: '182'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Each player reveals their hand. Draw 3 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hitoshi Ariga
+  variantOf: FILL_THIS-137
+  variantType: Full Art
+- id: FILL_THIS-183
+  pioId: swsh10-183
+  enumId: CYLLENE_183
+  name: Cyllene
+  number: '183'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Flip 2 coins. Put a number of cards up to the number of heads from your discard
+    pile on top of your deck in any order.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: nagimiso
+  variantOf: FILL_THIS-138
+  variantType: Full Art
+- id: FILL_THIS-184
+  pioId: swsh10-184
+  enumId: GARDENIA_S_VIGOR_184
+  name: Gardenia's Vigor
+  number: '184'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 2 cards. If you drew any cards in this way, attach up to 2 [G] Energy cards
+    from your hand to 1 of your Benched Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: En Morikura
+  variantOf: FILL_THIS-143
+  variantType: Full Art
+- id: FILL_THIS-185
+  pioId: swsh10-185
+  enumId: GRANT_185
+  name: Grant
+  number: '185'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - During this turn, your [F] Pokémon's attacks do 30 more damage to your opponent's
+    Active Pokémon (before applying Weakness and Resistance). During your turn, if
+    this Grant is in your discard pile, you may discard 2 cards, except any Grant,
+    from your hand. If you do, put this Grant into your hand. (This effect doesn't
+    use up your Supporter card for the turn.)
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hideki Ishikawa
+  variantOf: FILL_THIS-144
+  variantType: Full Art
+- id: FILL_THIS-186
+  pioId: swsh10-186
+  enumId: IRIDA_186
+  name: Irida
+  number: '186'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Search your deck for a [W] Pokémon and an Item card, reveal them, and put them
+    into your hand. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: kirisAki
+  variantOf: FILL_THIS-147
+  variantType: Full Art
+- id: FILL_THIS-187
+  pioId: swsh10-187
+  enumId: KAMADO_187
+  name: Kamado
+  number: '187'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Choose a card in your hand, and discard the other cards. If you do, draw 4 cards.
+    (If you have no other cards in your hand, you can't use this card.)
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hitoshi Ariga
+  variantOf: FILL_THIS-149
+  variantType: Full Art
+- id: FILL_THIS-188
+  pioId: swsh10-188
+  enumId: ROXANNE_188
+  name: Roxanne
+  number: '188'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - You can use this card only if your opponent has 3 or fewer Prize cards remaining.
+    Each player shuffles their hand into their deck. Then, you draw 6 cards, and your
+    opponent draws 2 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Sanosuke Sakuma
+  variantOf: FILL_THIS-150
+  variantType: Full Art
+- id: FILL_THIS-189
+  pioId: swsh10-189
+  enumId: ZISU_189
+  name: Zisu
+  number: '189'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw cards until you have 1 more card in your hand than your opponent.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: kirisAki
+  variantOf: FILL_THIS-159
+  variantType: Full Art
+- id: FILL_THIS-190
+  pioId: swsh10-190
+  enumId: HISUIAN_LILLIGANT_VSTAR_190
+  name: Hisuian Lilligant VSTAR
+  number: '190'
+  types: [G]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Hisuian Lilligant V
+  hp: 260
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Star Perfume
+    text: During your turn, you may search your deck for up to 5 in any combination
+      of [G] Pokémon and [G] Energy cards, reveal them, and put them into your hand.
+      Then, shuffle your deck. (You can't use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [G, G, C]
+    name: Parallel Spin
+    damage: 130+
+    text: You may put an Energy attached to this Pokémon into your hand. If you do,
+      this attack does 100 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-18
+  variantType: Full Art
+- id: FILL_THIS-191
+  pioId: swsh10-191
+  enumId: HEATRAN_VMAX_191
+  name: Heatran VMAX
+  number: '191'
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Heatran V
+  hp: 330
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Magma Gain
+    text: Once during your turn, if you have a Stadium in play, you may heal 50 damage
+      from this Pokémon.
+  moves:
+  - cost: [R, R, C]
+    name: Max Heat Burst
+    damage: '180'
+    text: Your opponent's Active Pokémon is now Burned.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: N-DESIGN Inc.
+  variantOf: FILL_THIS-26
+  variantType: Full Art
+- id: FILL_THIS-192
+  pioId: swsh10-192
+  enumId: ORIGIN_FORME_PALKIA_VSTAR_192
+  name: Origin Forme Palkia VSTAR
+  number: '192'
+  types: [W]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Origin Forme Palkia V
+  hp: 280
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Star Portal
+    text: During your turn, you may attach up to 3 [W] Energy cards from your discard
+      pile to your [W] Pokémon in any way you like. (You can't use more than 1 VSTAR
+      Power in a game.)
+  moves:
+  - cost: [W, W]
+    name: Subspace Swell
+    damage: 60+
+    text: This attack does 20 more damage for each Benched Pokémon (both yours and
+      your opponent's).
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: aky CG Works
+  variantOf: FILL_THIS-40
+  variantType: Full Art
+- id: FILL_THIS-193
+  pioId: swsh10-193
+  enumId: HISUIAN_TYPHLOSION_VSTAR_193
+  name: Hisuian Typhlosion VSTAR
+  number: '193'
+  types: [P]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Hisuian Typhlosion V
+  hp: 260
+  retreatCost: 2
+  moves:
+  - cost: [P, P, C]
+    name: Hollow Flame
+    damage: '180'
+    text: Put 3 damage counters on your opponent's Benched Pokémon in any way you
+      like.
+  - cost: [P]
+    name: Shimmering Star
+    text: If your opponent's Active Pokémon has exactly 4 damage counters on it, that
+      Pokémon is Knocked Out. (You can't use more than 1 VSTAR Power in a game.)
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-54
+  variantType: Full Art
+- id: FILL_THIS-194
+  pioId: swsh10-194
+  enumId: MACHAMP_VMAX_194
+  name: Machamp VMAX
+  number: '194'
+  types: [F]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Machamp V
+  hp: 330
+  retreatCost: 3
+  moves:
+  - cost: [F, C]
+    name: Revenge Buster
+    damage: 80+
+    text: If your Benched Pokémon have any damage counters on them, this attack does
+      140 more damage.
+  - cost: [F, F, C]
+    name: G-Max Chi Strike
+    damage: '240'
+    text: During your next turn, this Pokémon can't use G-Max Chi Strike.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: N-DESIGN Inc.
+  variantOf: FILL_THIS-73
+  variantType: Full Art
+- id: FILL_THIS-195
+  pioId: swsh10-195
+  enumId: HISUIAN_DECIDUEYE_VSTAR_195
+  name: Hisuian Decidueye VSTAR
+  number: '195'
+  types: [F]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Hisuian Decidueye V
+  hp: 270
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Star of Fortune
+    text: During your turn, you may draw cards until you have 8 cards in your hand.
+      (You can't use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [F, C, C]
+    name: Somersault Feathers
+    damage: 160+
+    text: You may discard up to 3 Energy cards from your hand. This attack does 30
+      more damage for each card you discarded in this way.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-84
+  variantType: Full Art
+- id: FILL_THIS-196
+  pioId: swsh10-196
+  enumId: KLEAVOR_VSTAR_196
+  name: Kleavor VSTAR
+  number: '196'
+  types: [F]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Kleavor V
+  hp: 270
+  retreatCost: 2
+  moves:
+  - cost: [F, C]
+    name: Axe Break
+    damage: '120'
+    text: This attack also does 60 damage to 1 of your opponent's Benched Pokémon
+      V. (Don't apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [F]
+    name: Rampaging Star
+    damage: 30x
+    text: This attack does 30 damage for each Pokémon in your discard pile. (You can't
+      use more than 1 VSTAR Power in a game.)
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-197
+  pioId: swsh10-197
+  enumId: HISUIAN_SAMUROTT_VSTAR_197
+  name: Hisuian Samurott VSTAR
+  number: '197'
+  types: [D]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Hisuian Samurott V
+  hp: 270
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Moon Cleave Star
+    text: During your turn, you may put 4 damage counters on 1 of your opponent's
+      Pokémon. (You can't use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [D, D]
+    name: Merciless Blade
+    damage: 110+
+    text: If your opponent's Active Pokémon already has any damage counters on it,
+      this attack does 110 more damage.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-102
+  variantType: Full Art
+- id: FILL_THIS-198
+  pioId: swsh10-198
+  enumId: ORIGIN_FORME_DIALGA_VSTAR_198
+  name: Origin Forme Dialga VSTAR
+  number: '198'
+  types: [M]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Origin Forme Dialga V
+  hp: 280
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Metal Blast
+    damage: 40+
+    text: This attack does 40 more damage for each [M] Energy attached to this Pokémon.
+  - cost: [M, M, M, M, C]
+    name: Star Chronos
+    damage: '220'
+    text: Take another turn after this one. (Skip Pokémon Checkup.) (You can't use
+      more than 1 VSTAR Power in a game.)
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-114
+  variantType: Full Art
+- id: FILL_THIS-199
+  pioId: swsh10-199
+  enumId: ADAMAN_199
+  name: Adaman
+  number: '199'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - You can use this card only if you discard 2 [M] Energy cards from your hand. Search
+    your deck for up to 2 cards and put them into your hand. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Souichirou Gunjima
+  variantOf: FILL_THIS-135
+  variantType: Full Art
+- id: FILL_THIS-200
+  pioId: swsh10-200
+  enumId: CHOY_200
+  name: Choy
+  number: '200'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Each player reveals their hand. Draw 3 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hitoshi Ariga
+  variantOf: FILL_THIS-137
+  variantType: Full Art
+- id: FILL_THIS-201
+  pioId: swsh10-201
+  enumId: CYLLENE_201
+  name: Cyllene
+  number: '201'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Flip 2 coins. Put a number of cards up to the number of heads from your discard
+    pile on top of your deck in any order.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: nagimiso
+  variantOf: FILL_THIS-138
+  variantType: Full Art
+- id: FILL_THIS-202
+  pioId: swsh10-202
+  enumId: GARDENIA_S_VIGOR_202
+  name: Gardenia's Vigor
+  number: '202'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 2 cards. If you drew any cards in this way, attach up to 2 [G] Energy cards
+    from your hand to 1 of your Benched Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: En Morikura
+  variantOf: FILL_THIS-143
+  variantType: Full Art
+- id: FILL_THIS-203
+  pioId: swsh10-203
+  enumId: GRANT_203
+  name: Grant
+  number: '203'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - During this turn, your [F] Pokémon's attacks do 30 more damage to your opponent's
+    Active Pokémon (before applying Weakness and Resistance). During your turn, if
+    this Grant is in your discard pile, you may discard 2 cards, except any Grant,
+    from your hand. If you do, put this Grant into your hand. (This effect doesn't
+    use up your Supporter card for the turn.)
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hideki Ishikawa
+  variantOf: FILL_THIS-144
+  variantType: Full Art
+- id: FILL_THIS-204
+  pioId: swsh10-204
+  enumId: IRIDA_204
+  name: Irida
+  number: '204'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Search your deck for a [W] Pokémon and an Item card, reveal them, and put them
+    into your hand. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: kirisAki
+  variantOf: FILL_THIS-147
+  variantType: Full Art
+- id: FILL_THIS-205
+  pioId: swsh10-205
+  enumId: KAMADO_205
+  name: Kamado
+  number: '205'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Choose a card in your hand, and discard the other cards. If you do, draw 4 cards.
+    (If you have no other cards in your hand, you can't use this card.)
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hitoshi Ariga
+  variantOf: FILL_THIS-149
+  variantType: Full Art
+- id: FILL_THIS-206
+  pioId: swsh10-206
+  enumId: ROXANNE_206
+  name: Roxanne
+  number: '206'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - You can use this card only if your opponent has 3 or fewer Prize cards remaining.
+    Each player shuffles their hand into their deck. Then, you draw 6 cards, and your
+    opponent draws 2 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Sanosuke Sakuma
+  variantOf: FILL_THIS-150
+  variantType: Full Art
+- id: FILL_THIS-207
+  pioId: swsh10-207
+  enumId: ZISU_207
+  name: Zisu
+  number: '207'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw cards until you have 1 more card in your hand than your opponent.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: kirisAki
+  variantOf: FILL_THIS-159
+  variantType: Full Art
+- id: FILL_THIS-208
+  pioId: swsh10-208
+  enumId: ORIGIN_FORME_PALKIA_VSTAR_208
+  name: Origin Forme Palkia VSTAR
+  number: '208'
+  types: [W]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Origin Forme Palkia V
+  hp: 280
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Star Portal
+    text: During your turn, you may attach up to 3 [W] Energy cards from your discard
+      pile to your [W] Pokémon in any way you like. (You can't use more than 1 VSTAR
+      Power in a game.)
+  moves:
+  - cost: [W, W]
+    name: Subspace Swell
+    damage: 60+
+    text: This attack does 20 more damage for each Benched Pokémon (both yours and
+      your opponent's).
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Secret
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: aky CG Works
+  variantOf: FILL_THIS-40
+  variantType: Secret Art
+- id: FILL_THIS-209
+  pioId: swsh10-209
+  enumId: HISUIAN_SAMUROTT_VSTAR_209
+  name: Hisuian Samurott VSTAR
+  number: '209'
+  types: [D]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Hisuian Samurott V
+  hp: 270
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Moon Cleave Star
+    text: During your turn, you may put 4 damage counters on 1 of your opponent's
+      Pokémon. (You can't use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [D, D]
+    name: Merciless Blade
+    damage: 110+
+    text: If your opponent's Active Pokémon already has any damage counters on it,
+      this attack does 110 more damage.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Secret
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-102
+  variantType: Secret Art
+- id: FILL_THIS-210
+  pioId: swsh10-210
+  enumId: ORIGIN_FORME_DIALGA_VSTAR_210
+  name: Origin Forme Dialga VSTAR
+  number: '210'
+  types: [M]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Origin Forme Dialga V
+  hp: 280
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Metal Blast
+    damage: 40+
+    text: This attack does 40 more damage for each [M] Energy attached to this Pokémon.
+  - cost: [M, M, M, M, C]
+    name: Star Chronos
+    damage: '220'
+    text: Take another turn after this one. (Skip Pokémon Checkup.) (You can't use
+      more than 1 VSTAR Power in a game.)
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Secret
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-114
+  variantType: Secret Art
+- id: FILL_THIS-211
+  pioId: swsh10-211
+  enumId: CHOICE_BELT_211
+  name: Choice Belt
+  number: '211'
+  superType: TRAINER
+  subTypes: [ITEM, ITEM, POKEMON_TOOL]
+  rarity: Secret
+  text:
+  - The attacks of the Pokémon this card is attached to do 30 more damage to your
+    opponent's Active Pokémon V (before applying Weakness and Resistance).
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already
+    have a Pokémon Tool attached.'
+  artist: Studio Bora Inc.
+- id: FILL_THIS-212
+  pioId: swsh10-212
+  enumId: JUBILIFE_VILLAGE_212
+  name: Jubilife Village
+  number: '212'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Secret
+  text:
+  - Once during each player's turn, that player may shuffle their hand into their
+    deck and draw 5 cards. If they do, their turn ends.
+  artist: Oswaldo KATO
+  variantOf: FILL_THIS-148
+  variantType: Secret Art
+- id: FILL_THIS-213
+  pioId: swsh10-213
+  enumId: PATH_TO_THE_PEAK_213
+  name: Path to the Peak
+  number: '213'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Secret
+  text:
+  - Pokémon with a Rule Box in play (both yours and your opponent's) have no Abilities.
+    (Pokémon V, Pokémon-GX, etc. have Rule Boxes.)
+  artist: Oswaldo KATO
+- id: FILL_THIS-214
+  pioId: swsh10-214
+  enumId: TEMPLE_OF_SINNOH_214
+  name: Temple of Sinnoh
+  number: '214'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Secret
+  text:
+  - All Special Energy attached to Pokémon (both yours and your opponent's) provide
+    [C] Energy and have no other effect.
+  artist: Oswaldo KATO
+  variantOf: FILL_THIS-155
+  variantType: Secret Art
+- id: FILL_THIS-215
+  pioId: swsh10-215
+  enumId: TREKKING_SHOES_215
+  name: Trekking Shoes
+  number: '215'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Secret
+  text:
+  - Look at the top card of your deck. You may put that card into your hand. If you
+    don't, discard that card and draw a card.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Toyste Beach
+  variantOf: FILL_THIS-156
+  variantType: Secret Art
+- id: FILL_THIS-216
+  pioId: swsh10-216
+  enumId: DOUBLE_TURBO_ENERGY_216
+  name: Double Turbo Energy
+  number: '216'
+  superType: ENERGY
+  subTypes: [SPECIAL_ENERGY]
+  rarity: Secret
+  text:
+  - As long as this card is attached to a Pokémon, it provides [C][C] Energy. The
+    attacks of the Pokémon this card is attached to do 20 less damage to your opponent's
+    Pokémon (before applying Weakness and Resistance).

--- a/data/src/main/resources/cards/442-astral_radiance.yaml
+++ b/data/src/main/resources/cards/442-astral_radiance.yaml
@@ -1,3 +1,4 @@
+schema: E2
 id: '442'
 name: Astral Radiance
 enumId: ASTRAL_RADIANCE

--- a/data/src/main/resources/cards/442-astral_radiance.yaml
+++ b/data/src/main/resources/cards/442-astral_radiance.yaml
@@ -1168,7 +1168,7 @@ cards:
   number: '49'
   types: [W]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_V]
+  subTypes: [BASIC, POKEMON_V, FUSION_STRIKE]
   hp: 210
   retreatCost: 2
   moves:

--- a/data/src/main/resources/cards/443-lost_origins.yaml
+++ b/data/src/main/resources/cards/443-lost_origins.yaml
@@ -1,0 +1,4991 @@
+id: FILL_THIS
+name: swsh11
+enumId: FILL_THIS
+abbr: FILL_THIS
+pioId: swsh11
+cards:
+- id: FILL_THIS-1
+  pioId: swsh11-1
+  enumId: ODDISH_1
+  name: Oddish
+  number: '1'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Gloom]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [G, C]
+    name: Ram
+    damage: '30'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Miki Tanaka
+- id: FILL_THIS-2
+  pioId: swsh11-2
+  enumId: GLOOM_2
+  name: Gloom
+  number: '2'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Oddish
+  evolvesTo: [Vileplume, Bellossom]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [G, C]
+    name: Absorb
+    damage: '30'
+    text: Heal 30 damage from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Tomokazu Komiya
+- id: FILL_THIS-3
+  pioId: swsh11-3
+  enumId: VILEPLUME_3
+  name: Vileplume
+  number: '3'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Gloom
+  hp: 150
+  retreatCost: 2
+  moves:
+  - cost: [G, C]
+    name: Mega Drain
+    damage: '50'
+    text: Heal 30 damage from this Pokémon.
+  - cost: [G, C, C]
+    name: Allergy Storm
+    damage: '90'
+    text: Flip a coin. If heads, during your opponent's next turn, they can't play
+      any Supporter cards from their hand. If tails, during your opponent's next turn,
+      they can't play any Item cards from their hand.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  artist: Jiro Sasumo
+- id: FILL_THIS-4
+  pioId: swsh11-4
+  enumId: PARAS_4
+  name: Paras
+  number: '4'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Parasect]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [G, C]
+    name: Absorb
+    damage: '20'
+    text: Heal 10 damage from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Mizue
+- id: FILL_THIS-5
+  pioId: swsh11-5
+  enumId: PARASECT_5
+  name: Parasect
+  number: '5'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Paras
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Lethargy Spores
+    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
+      your turn, you may make both Active Pokémon Asleep and Poisoned.
+  moves:
+  - cost: [G, C]
+    name: X-Scissor
+    damage: 50+
+    text: Flip a coin. If heads, this attack does 50 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare
+  artist: Pani Kobayashi
+- id: FILL_THIS-6
+  pioId: swsh11-6
+  enumId: WURMPLE_6
+  name: Wurmple
+  number: '6'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Silcoon, Cascoon]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Sting
+    damage: '10'
+  - cost: [G, G, G]
+    name: Creepy-Crawly Congregation
+    text: Search your deck for any number of Wurmple, Silcoon, Beautifly, Cascoon,
+      and Dustox, reveal them, and put them into your hand. Then, shuffle your deck.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: ryoma uratsuka
+- id: FILL_THIS-7
+  pioId: swsh11-7
+  enumId: SILCOON_7
+  name: Silcoon
+  number: '7'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Wurmple
+  evolvesTo: [Beautifly]
+  hp: 80
+  retreatCost: 3
+  moves:
+  - cost: [G]
+    name: Entangling String
+    text: Flip a coin. If heads, during your opponent's next turn, the Defending Pokémon
+      can't attack.
+  - cost: [G, C]
+    name: Ram
+    damage: '30'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Kagemaru Himeno
+- id: FILL_THIS-8
+  pioId: swsh11-8
+  enumId: BEAUTIFLY_8
+  name: Beautifly
+  number: '8'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Silcoon
+  hp: 130
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Stoked Straw
+    text: Once during your turn, you may draw cards until you have 6 cards in your
+      hand.
+  moves:
+  - cost: [G, C]
+    name: Mega Drain
+    damage: '70'
+    text: Heal 30 damage from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  artist: Yuu Nishida
+- id: FILL_THIS-9
+  pioId: swsh11-9
+  enumId: CASCOON_9
+  name: Cascoon
+  number: '9'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Wurmple
+  evolvesTo: [Dustox]
+  hp: 80
+  retreatCost: 3
+  moves:
+  - cost: [G]
+    name: Harden
+    text: During your opponent's next turn, prevent all damage done to this Pokémon
+      by attacks if that damage is 60 or less.
+  - cost: [C, C]
+    name: Rolling Tackle
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: GOSSAN
+- id: FILL_THIS-10
+  pioId: swsh11-10
+  enumId: DUSTOX_10
+  name: Dustox
+  number: '10'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Cascoon
+  hp: 140
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Nadir Powder
+    text: Your opponent's Active Pokémon is now Confused and Poisoned. During Pokémon
+      Checkup, put 8 damage counters on that Pokémon instead of 1.
+  - cost: [G, C, C]
+    name: Cutting Wind
+    damage: '110'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare
+  artist: Mitsuhiro Arita
+- id: FILL_THIS-11
+  pioId: swsh11-11
+  enumId: SEEDOT_11
+  name: Seedot
+  number: '11'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Nuzleaf]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Absorb
+    damage: '10'
+    text: Heal 10 damage from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Yuka Morii
+- id: FILL_THIS-12
+  pioId: swsh11-12
+  enumId: NUZLEAF_12
+  name: Nuzleaf
+  number: '12'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Seedot
+  evolvesTo: [Shiftry]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [G]
+    name: Push Down
+    damage: '30'
+    text: You may have your opponent switch their Active Pokémon with 1 of their Benched
+      Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Mizue
+- id: FILL_THIS-13
+  pioId: swsh11-13
+  enumId: SHIFTRY_13
+  name: Shiftry
+  number: '13'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Nuzleaf
+  hp: 160
+  retreatCost: 2
+  moves:
+  - cost: [G]
+    name: Fan Tornado
+    damage: '50'
+    text: You may have your opponent switch their Active Pokémon with 1 of their Benched
+      Pokémon.
+  - cost: [G]
+    name: Tearing Gust
+    damage: '210'
+    text: Put this Pokémon and all attached cards in the Lost Zone.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  artist: kawayoo
+- id: FILL_THIS-14
+  pioId: swsh11-14
+  enumId: ROSELIA_14
+  name: Roselia
+  number: '14'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Roserade]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Soothing Scent
+    text: Your opponent's Active Pokémon is now Asleep.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Yukiko Baba
+- id: FILL_THIS-15
+  pioId: swsh11-15
+  enumId: ROSERADE_15
+  name: Roserade
+  number: '15'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Roselia
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Poisonous Whip
+    damage: '30'
+    text: Your opponent's Active Pokémon is now Poisoned.
+  - cost: [G, C]
+    name: Assassin's Rose
+    damage: '60'
+    text: If your opponent's Active Pokémon is affected by a Special Condition, this
+      attack also does 60 damage to 1 of your opponent's Benched Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: '0313'
+- id: FILL_THIS-16
+  pioId: swsh11-16
+  enumId: PHANTUMP_16
+  name: Phantump
+  number: '16'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Trevenant]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Hook
+    damage: '10'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: AKIRA EGAWA
+- id: FILL_THIS-17
+  pioId: swsh11-17
+  enumId: TREVENANT_17
+  name: Trevenant
+  number: '17'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Phantump
+  hp: 120
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Elder Tree Barrier
+    text: If this Pokémon is Knocked Out by damage from an attack from your opponent's
+      Pokémon V, your opponent can't take any Prize cards for it.
+  moves:
+  - cost: [G, G, C]
+    name: Giga Impact
+    damage: '150'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  artist: Yuya Oka
+- id: FILL_THIS-18
+  pioId: swsh11-18
+  enumId: BLIPBUG_18
+  name: Blipbug
+  number: '18'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Dottler]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [G, C]
+    name: Gnaw
+    damage: '30'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Asako Ito
+- id: FILL_THIS-19
+  pioId: swsh11-19
+  enumId: DOTTLER_19
+  name: Dottler
+  number: '19'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Blipbug
+  evolvesTo: [Orbeetle]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [G, C]
+    name: Barrier Attack
+    damage: '30'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Kyoko Umemoto
+- id: FILL_THIS-20
+  pioId: swsh11-20
+  enumId: ORBEETLE_20
+  name: Orbeetle
+  number: '20'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Dottler
+  hp: 110
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Jamming Attachment
+    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
+      your turn, you may attach up to 3 Energy cards from your opponent's discard
+      pile to your opponent's Pokémon in any way you like.
+  moves:
+  - cost: [C, C]
+    name: Mysterious Wave
+    damage: 30+
+    text: This attack does 50 more damage for each Energy attached to your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  artist: yuu
+- id: FILL_THIS-21
+  pioId: swsh11-21
+  enumId: SLUGMA_21
+  name: Slugma
+  number: '21'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Magcargo]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [R]
+    name: Draw In
+    text: Attach a [R] Energy card from your discard pile to this Pokémon.
+  - cost: [R, R, C]
+    name: Combustion
+    damage: '50'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: Scav
+- id: FILL_THIS-22
+  pioId: swsh11-22
+  enumId: MAGCARGO_22
+  name: Magcargo
+  number: '22'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Slugma
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [R]
+    name: Flare
+    damage: '30'
+  - cost: [R, R, C]
+    name: Lost Volcano
+    damage: '220'
+    text: Put all Energy attached to this Pokémon in the Lost Zone.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare
+  artist: Pani Kobayashi
+- id: FILL_THIS-23
+  pioId: swsh11-23
+  enumId: TORKOAL_23
+  name: Torkoal
+  number: '23'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [R, C]
+    name: Stampede
+    damage: '30'
+  - cost: [R, C, C, C]
+    name: Flamethrower
+    damage: '130'
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Uncommon
+  artist: Naoyo Kimura
+- id: FILL_THIS-24
+  pioId: swsh11-24
+  enumId: LITWICK_24
+  name: Litwick
+  number: '24'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Lampent]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Kindling Panic
+    text: Discard the top card of your opponent's deck.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: Yuka Morii
+- id: FILL_THIS-25
+  pioId: swsh11-25
+  enumId: LAMPENT_25
+  name: Lampent
+  number: '25'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Litwick
+  evolvesTo: [Chandelure]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Flickering Glow
+    damage: '20'
+    text: Flip a coin. If heads, discard an Energy from your opponent's Active Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Uncommon
+  artist: kurumitsu
+- id: FILL_THIS-26
+  pioId: swsh11-26
+  enumId: CHANDELURE_26
+  name: Chandelure
+  number: '26'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Lampent
+  hp: 150
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Mountain Roasting
+    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
+      your turn, you may discard the top 3 cards of your opponent's deck.
+  moves:
+  - cost: [R, C]
+    name: Heat Blast
+    damage: '90'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  artist: sui
+- id: FILL_THIS-27
+  pioId: swsh11-27
+  enumId: DELPHOX_V_27
+  name: Delphox V
+  number: '27'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [R]
+    name: Eerie Glow
+    text: Your opponent's Active Pokémon is now Burned and Confused.
+  - cost: [R, R, C]
+    name: Magical Fire
+    damage: '120'
+    text: Put 2 Energy attached to this Pokémon in the Lost Zone. This attack also
+      does 120 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness
+      and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-28
+  pioId: swsh11-28
+  enumId: LITLEO_28
+  name: Litleo
+  number: '28'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Pyroar]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [R]
+    name: Singe
+    text: Your opponent's Active Pokémon is now Burned.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: Sekio
+- id: FILL_THIS-29
+  pioId: swsh11-29
+  enumId: PYROAR_29
+  name: Pyroar
+  number: '29'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Litleo
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Scorching Aura
+    text: During Pokémon Checkup, put 4 damage counters on your opponent's Burned
+      Pokémon instead of 2.
+  moves:
+  - cost: [R, C, C]
+    name: Fire Fang
+    damage: '90'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Burned.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  artist: Misa Tsutsui
+- id: FILL_THIS-30
+  pioId: swsh11-30
+  enumId: POLIWAG_30
+  name: Poliwag
+  number: '30'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Poliwhirl]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Splashing Dodge
+    damage: '10'
+    text: Flip a coin. If heads, during your opponent's next turn, prevent all damage
+      from and effects of attacks done to this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Miki Tanaka
+- id: FILL_THIS-31
+  pioId: swsh11-31
+  enumId: POLIWHIRL_31
+  name: Poliwhirl
+  number: '31'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Poliwag
+  evolvesTo: [Poliwrath, Politoed]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Light Punch
+    damage: '30'
+  - cost: [W, C, C]
+    name: Double Smash
+    damage: 50x
+    text: Flip 2 coins. This attack does 50 damage for each heads.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: Scav
+- id: FILL_THIS-32
+  pioId: swsh11-32
+  enumId: POLITOED_32
+  name: Politoed
+  number: '32'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Poliwhirl
+  hp: 140
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Lordly Songleader
+    damage: 10+ damage. If Poliwag is on your Bench, this attack does 60 more damage.
+      If Poliwhirl is on your Bench, this attack does 90 more
+    text: If Poliwrath is on your Bench, this attack does 120 more damage.
+  - cost: [W, C, C]
+    name: Hydro Splash
+    damage: '100'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare
+  artist: ryoma uratsuka
+- id: FILL_THIS-33
+  pioId: swsh11-33
+  enumId: SEEL_33
+  name: Seel
+  number: '33'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Dewgong]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Headbutt
+    damage: '10'
+  - cost: [W, C]
+    name: Rain Splash
+    damage: '20'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: GIDORA
+- id: FILL_THIS-34
+  pioId: swsh11-34
+  enumId: DEWGONG_34
+  name: Dewgong
+  number: '34'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Seel
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Swim Freely
+    damage: '10'
+    text: Flip a coin. If heads, during your opponent's next turn, prevent all damage
+      from and effects of attacks done to this Pokémon.
+  - cost: [C, C]
+    name: Floe Return
+    damage: 40x
+    text: Shuffle any amount of [W] Energy from your Pokémon into your deck. This
+      attack does 40 damage for each card you shuffled into your deck in this way.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare
+  artist: chibi
+- id: FILL_THIS-35
+  pioId: swsh11-35
+  enumId: HORSEA_35
+  name: Horsea
+  number: '35'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Seadra]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Reverse Thrust
+    damage: '10'
+    text: Switch this Pokémon with 1 of your Benched Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Tika Matsuno
+- id: FILL_THIS-36
+  pioId: swsh11-36
+  enumId: SEADRA_36
+  name: Seadra
+  number: '36'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Horsea
+  evolvesTo: [Kingdra]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Swim Freely
+    damage: '10'
+    text: Flip a coin. If heads, during your opponent's next turn, prevent all damage
+      from and effects of attacks done to this Pokémon.
+  - cost: [W]
+    name: Hydro Jet
+    text: This attack does 20 damage to 1 of your opponent's Pokémon for each [W]
+      Energy attached to this Pokémon. (Don't apply Weakness and Resistance for Benched
+      Pokémon.)
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: sui
+- id: FILL_THIS-37
+  pioId: swsh11-37
+  enumId: KINGDRA_37
+  name: Kingdra
+  number: '37'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Seadra
+  hp: 150
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Seething Currents
+    text: Once during your turn, you may have either player shuffle their hand and
+      put it on the bottom of their deck. If that player put any cards on the bottom
+      of their deck in this way, they draw 4 cards.
+  moves:
+  - cost: [W, C]
+    name: Hydro Splash
+    damage: '130'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  artist: AKIRA EGAWA
+- id: FILL_THIS-38
+  pioId: swsh11-38
+  enumId: LUVDISC_38
+  name: Luvdisc
+  number: '38'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Matching Look
+    text: Each player reveals the top 2 cards of their deck, then draws those cards.
+  - cost: [C, C]
+    name: Tackle
+    damage: '30'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Sekio
+- id: FILL_THIS-39
+  pioId: swsh11-39
+  enumId: SHELLOS_39
+  name: Shellos
+  number: '39'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Gastrodon]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Rain Splash
+    damage: '10'
+  - cost: [C, C, C]
+    name: Surf
+    damage: '30'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Saya Tsuruta
+- id: FILL_THIS-40
+  pioId: swsh11-40
+  enumId: FINNEON_40
+  name: Finneon
+  number: '40'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Lumineon]
+  hp: 50
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Oceanic Accompaniment
+    text: As often as you like during your turn, you may attach a [W] Energy card
+      from your hand to 1 of your Pokémon that has the Swim Freely attack.
+  moves:
+  - cost: [W]
+    name: Water Gun
+    damage: '10'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Taira Akitsu
+- id: FILL_THIS-41
+  pioId: swsh11-41
+  enumId: LUMINEON_41
+  name: Lumineon
+  number: '41'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Finneon
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Swim Freely
+    damage: '10'
+    text: Flip a coin. If heads, during your opponent's next turn, prevent all damage
+      from and effects of attacks done to this Pokémon.
+  - cost: [W, W, C]
+    name: Waterfall
+    damage: '120'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: zig
+- id: FILL_THIS-42
+  pioId: swsh11-42
+  enumId: SNOVER_42
+  name: Snover
+  number: '42'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Abomasnow]
+  hp: 80
+  retreatCost: 3
+  moves:
+  - cost: [W]
+    name: Corkscrew Punch
+    damage: '10'
+  - cost: [W, W, C]
+    name: Icicle Missile
+    damage: '60'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: Mitsuhiro Arita
+- id: FILL_THIS-43
+  pioId: swsh11-43
+  enumId: ABOMASNOW_43
+  name: Abomasnow
+  number: '43'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Snover
+  hp: 140
+  retreatCost: 4
+  moves:
+  - cost: [W, C]
+    name: Icicle Punch
+    damage: '50'
+  - cost: [W, W, C]
+    name: Double-Edge
+    damage: '160'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Uncommon
+  artist: kodama
+- id: FILL_THIS-44
+  pioId: swsh11-44
+  enumId: HISUIAN_BASCULIN_44
+  name: Hisuian Basculin
+  number: '44'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Surprise Attack
+    damage: '40'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Oswaldo KATO
+- id: FILL_THIS-45
+  pioId: swsh11-45
+  enumId: HISUIAN_BASCULEGION_45
+  name: Hisuian Basculegion
+  number: '45'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Hisuian Basculin
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Upstream Spirits
+    damage: 20x
+    text: This attack does 20 damage for each basic Energy card in your discard pile.
+      Then, shuffle those cards into your deck.
+  - cost: [W]
+    name: Water Shot
+    damage: '70'
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  artist: AKIRA EGAWA
+- id: FILL_THIS-46
+  pioId: swsh11-46
+  enumId: DUCKLETT_46
+  name: Ducklett
+  number: '46'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Swanna]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Rain Splash
+    damage: '20'
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Yuka Morii
+- id: FILL_THIS-47
+  pioId: swsh11-47
+  enumId: SWANNA_47
+  name: Swanna
+  number: '47'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Ducklett
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Water Pulse
+    damage: '20'
+    text: Your opponent's Active Pokémon is now Asleep.
+  - cost: [W, W, C]
+    name: Air Slash
+    damage: '130'
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Sekio
+- id: FILL_THIS-48
+  pioId: swsh11-48
+  enumId: KYUREM_V_48
+  name: Kyurem V
+  number: '48'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [W]
+    name: Rapid Freeze
+    text: Attach any number of [W] Energy cards from your hand to your Pokémon in
+      any way you like.
+  - cost: [W, W, W]
+    name: Frost Smash
+    damage: '140'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: takuyoa
+- id: FILL_THIS-49
+  pioId: swsh11-49
+  enumId: KYUREM_VMAX_49
+  name: Kyurem VMAX
+  number: '49'
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Kyurem V
+  hp: 330
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Glaciated World
+    text: Once during your turn, you may discard the top card of your deck. If that
+      card is a [W] Energy card, attach it to 1 of your Pokémon.
+  moves:
+  - cost: [W, W, W]
+    name: Max Frost
+    damage: 120+
+    text: You may discard any amount of [W] Energy from this Pokémon. This attack
+      does 50 more damage for each card you discarded in this way.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: N-DESIGN Inc.
+- id: FILL_THIS-50
+  pioId: swsh11-50
+  enumId: CRAMORANT_50
+  name: Cramorant
+  number: '50'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Lost Provisions
+    text: If you have 4 or more cards in the Lost Zone, ignore all Energy in this
+      Pokémon's attack costs.
+  moves:
+  - cost: [W, W, C]
+    name: Spit Innocently
+    damage: '110'
+    text: This attack's damage isn't affected by Weakness.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare
+  artist: Midori Harada
+- id: FILL_THIS-51
+  pioId: swsh11-51
+  enumId: GLASTRIER_51
+  name: Glastrier
+  number: '51'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [W, C]
+    name: Freeze Down
+    damage: '40'
+    text: If the Defending Pokémon is a Basic Pokémon, it can't attack during your
+      opponent's next turn.
+  - cost: [W, W, C]
+    name: Wild Tackle
+    damage: '130'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  artist: Jiro Sasumo
+- id: FILL_THIS-52
+  pioId: swsh11-52
+  enumId: PIKACHU_52
+  name: Pikachu
+  number: '52'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raichu]
+  hp: 60
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Pika Dash
+    text: If this Pokémon has any Energy attached, it has no Retreat Cost.
+  moves:
+  - cost: [L, C, C]
+    name: Whimsy Tackle
+    damage: '50'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: kurumitsu
+- id: FILL_THIS-53
+  pioId: swsh11-53
+  enumId: RAICHU_53
+  name: Raichu
+  number: '53'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Pikachu
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Thunder Shock
+    damage: '30'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [L, C, C]
+    name: Ace Spark
+    damage: 100+
+    text: If you have used your VSTAR Power, this attack does 120 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: GIDORA
+- id: FILL_THIS-54
+  pioId: swsh11-54
+  enumId: ELECTRIKE_54
+  name: Electrike
+  number: '54'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Manectric]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Zap Kick
+    damage: '10'
+  - cost: [C, C]
+    name: Thunder Fang
+    damage: '20'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: otumami
+- id: FILL_THIS-55
+  pioId: swsh11-55
+  enumId: MANECTRIC_55
+  name: Manectric
+  number: '55'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Electrike
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Bite
+    damage: '50'
+  - cost: [L, C, C]
+    name: Assault Laser
+    damage: 80+
+    text: If your opponent's Active Pokémon has a Pokémon Tool attached, this attack
+      does 80 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: GIDORA
+- id: FILL_THIS-56
+  pioId: swsh11-56
+  enumId: MAGNEZONE_V_56
+  name: Magnezone V
+  number: '56'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [L, C]
+    name: Magnetic Tension
+    text: Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. This
+      attack does 40 damage to the new Active Pokémon.
+  - cost: [L, C, C]
+    name: Splitting Beam
+    damage: '90'
+    text: This attack also does 30 damage to 2 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: N-DESIGN Inc.
+- id: FILL_THIS-57
+  pioId: swsh11-57
+  enumId: MAGNEZONE_VSTAR_57
+  name: Magnezone VSTAR
+  number: '57'
+  types: [L]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Magnezone V
+  hp: 270
+  retreatCost: 2
+  moves:
+  - cost: [L, C, C]
+    name: Magnetic Grip
+    damage: '180'
+    text: Search your deck for up to 2 Item cards, reveal them, and put them into
+      your hand. Then, shuffle your deck.
+  - cost: [L, L]
+    name: Electro Star
+    text: This attack does 90 damage to 2 of your opponent's Benched Pokémon. (Don't
+      apply Weakness and Resistance for Benched Pokémon.) (You can't use more than
+      1 VSTAR Power in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: PLANETA Mochizuki
+- id: FILL_THIS-58
+  pioId: swsh11-58
+  enumId: ROTOM_V_58
+  name: Rotom V
+  number: '58'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Instant Charge
+    text: Once during your turn, you may draw 3 cards. If you use this Ability, your
+      turn ends.
+  moves:
+  - cost: [L, L]
+    name: Scrap Short
+    damage: 40+
+    text: Put any number of Pokémon Tool cards from your discard pile in the Lost
+      Zone. This attack does 40 more damage for each card you put in the Lost Zone
+      in this way.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-59
+  pioId: swsh11-59
+  enumId: TYNAMO_59
+  name: Tynamo
+  number: '59'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Eelektrik]
+  hp: 30
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Call Sign
+    text: Search your deck for a [L] Pokémon, reveal it, and put it into your hand.
+      Then, shuffle your deck.
+  - cost: [L]
+    name: Tiny Charge
+    damage: '10'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Yukiko Baba
+- id: FILL_THIS-60
+  pioId: swsh11-60
+  enumId: EELEKTRIK_60
+  name: Eelektrik
+  number: '60'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Tynamo
+  evolvesTo: [Eelektross]
+  hp: 80
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Ad Hoc Shock
+    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
+      your turn, you may flip a coin. If heads, your opponent's Active Pokémon is
+      now Paralyzed.
+  moves:
+  - cost: [L]
+    name: Static Shock
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: Uta
+- id: FILL_THIS-61
+  pioId: swsh11-61
+  enumId: EELEKTROSS_61
+  name: Eelektross
+  number: '61'
+  types: [L]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Eelektrik
+  hp: 160
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Coil
+    damage: '10'
+    text: During your next turn, this Pokémon's attacks do 120 more damage to your
+      opponent's Active Pokémon (before applying Weakness and Resistance).
+  - cost: [L, C]
+    name: Extreme Current
+    damage: '160'
+    text: Discard 2 Energy from this Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Shin Nagasawa
+- id: FILL_THIS-62
+  pioId: swsh11-62
+  enumId: CLEFAIRY_62
+  name: Clefairy
+  number: '62'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Clefable]
+  hp: 60
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Moon-Watching Party
+    text: Once during your turn, if this Pokémon is in the Active Spot, for each of
+      your Benched Clefairy, you may search your deck for a [P] Energy card and attach
+      it to that Clefairy. Then, shuffle your deck.
+  moves:
+  - cost: [C, C, C]
+    name: Wonder Storm
+    damage: 20x
+    text: This attack does 20 damage for each [P] Energy attached to all of your Pokémon.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: Kouki Saitou
+- id: FILL_THIS-63
+  pioId: swsh11-63
+  enumId: CLEFABLE_63
+  name: Clefable
+  number: '63'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Clefairy
+  hp: 100
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Spirit Charm
+    text: All of your Pokémon take 30 less damage from attacks from your opponent's
+      [N] Pokémon (after applying Weakness and Resistance). You can't apply more than
+      1 Spirit Charm Ability at a time.
+  moves:
+  - cost: [P, C, C]
+    name: Moon Impact
+    damage: '90'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare
+  artist: Sekio
+- id: FILL_THIS-64
+  pioId: swsh11-64
+  enumId: GASTLY_64
+  name: Gastly
+  number: '64'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Haunter]
+  hp: 40
+  moves:
+  - cost: [P]
+    name: Furtive Drop
+    text: Put 1 damage counter on your opponent's Active Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Tika Matsuno
+- id: FILL_THIS-65
+  pioId: swsh11-65
+  enumId: HAUNTER_65
+  name: Haunter
+  number: '65'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Gastly
+  evolvesTo: [Gengar]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Cursed Drop
+    text: Put 3 damage counters on your opponent's Pokémon in any way you like.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Kouki Saitou
+- id: FILL_THIS-66
+  pioId: swsh11-66
+  enumId: GENGAR_66
+  name: Gengar
+  number: '66'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Haunter
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Netherworld Gate
+    text: Once during your turn, if this Pokémon is in your discard pile, you may
+      put it onto your Bench. If you do, put 3 damage counters on this Pokémon.
+  moves:
+  - cost: [P]
+    name: Screaming Circle
+    text: Put 2 damage counters on your opponent's Active Pokémon for each of your
+      opponent's Benched Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: Narumi Sato
+- id: FILL_THIS-67
+  pioId: swsh11-67
+  enumId: MR_MIME_67
+  name: Mr. Mime
+  number: '67'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Pound
+    damage: '20'
+  - cost: [P, C, C]
+    name: Tricky Slap
+    damage: '90'
+    text: You and your opponent play Rock-Paper-Scissors until someone wins. If you
+      win, during your opponent's next turn, prevent all damage from and effects of
+      attacks done to this Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Souichirou Gunjima
+- id: FILL_THIS-68
+  pioId: swsh11-68
+  enumId: JYNX_68
+  name: Jynx
+  number: '68'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Alluring Dance
+    text: Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The
+      new Active Pokémon is now Confused.
+  - cost: [P, C, C]
+    name: Super Psy Bolt
+    damage: '80'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Nagomi Nijo
+- id: FILL_THIS-69
+  pioId: swsh11-69
+  enumId: RADIANT_GARDEVOIR_69
+  name: Radiant Gardevoir
+  number: '69'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Loving Veil
+    text: All of your Pokémon take 20 less damage from attacks from your opponent's
+      Pokémon V (after applying Weakness and Resistance).
+  moves:
+  - cost: [P, C, C]
+    name: Psychic
+    damage: 70+
+    text: This attack does 20 more damage for each Energy attached to your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare
+  text:
+  - 'Radiant Pokémon Rule: You cant have more than 1 Radiant Pokémon in your deck.'
+  artist: Ryuta Fuse
+- id: FILL_THIS-70
+  pioId: swsh11-70
+  enumId: SABLEYE_70
+  name: Sableye
+  number: '70'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Scratch
+    damage: '20'
+  - cost: [P]
+    name: Lost Mine
+    text: You can use this attack only if you have 10 or more cards in the Lost Zone.
+      Put 12 damage counters on your opponent's Pokémon in any way you like.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: Shibuzoh.
+- id: FILL_THIS-71
+  pioId: swsh11-71
+  enumId: MAWILE_71
+  name: Mawile
+  number: '71'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Tempting Trap
+    text: During your opponent's next turn, the Defending Pokémon can't retreat. During
+      your next turn, the Defending Pokémon takes 90 more damage from attacks (after
+      applying Weakness and Resistance).
+  - cost: [P, C, C]
+    name: Bite
+    damage: '90'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Common
+  artist: kurumitsu
+- id: FILL_THIS-72
+  pioId: swsh11-72
+  enumId: SHUPPET_72
+  name: Shuppet
+  number: '72'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Banette]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [P, P]
+    name: Tongue Slap
+    damage: '30'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Kouki Saitou
+- id: FILL_THIS-73
+  pioId: swsh11-73
+  enumId: BANETTE_73
+  name: Banette
+  number: '73'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Shuppet
+  hp: 100
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Puppet Offering
+    text: Once during your turn, you may put a Supporter card from your discard pile
+      into your hand. If you do, put this Pokémon in the Lost Zone. (Discard all attached
+      cards.)
+  moves:
+  - cost: [P, P]
+    name: Spooky Shot
+    damage: '50'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Kagemaru Himeno
+- id: FILL_THIS-74
+  pioId: swsh11-74
+  enumId: CRESSELIA_74
+  name: Cresselia
+  number: '74'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Moonglow Reverse
+    text: Move 2 damage counters from each of your Pokémon to 1 of your opponent's
+      Pokémon.
+  - cost: [P, P, C]
+    name: Lunar Blast
+    damage: '110'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: saino misaki
+- id: FILL_THIS-75
+  pioId: swsh11-75
+  enumId: HISUIAN_ZORUA_75
+  name: Hisuian Zorua
+  number: '75'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Zoroark]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Collect
+    text: Draw a card.
+  - cost: [P]
+    name: Mumble
+    damage: '10'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Akira Komayama
+- id: FILL_THIS-76
+  pioId: swsh11-76
+  enumId: HISUIAN_ZOROARK_76
+  name: Hisuian Zoroark
+  number: '76'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Hisuian Zorua
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Doom Curse
+    text: At the end of your opponent's next turn, the Defending Pokémon will be Knocked
+      Out.
+  - cost: [P]
+    name: Call Back
+    text: Put a card from your discard pile into your hand.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: Kouki Saitou
+- id: FILL_THIS-77
+  pioId: swsh11-77
+  enumId: INKAY_77
+  name: Inkay
+  number: '77'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Malamar]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Fickle Attack
+    damage: '30'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: miki kudo
+- id: FILL_THIS-78
+  pioId: swsh11-78
+  enumId: MALAMAR_78
+  name: Malamar
+  number: '78'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Inkay
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [P]
+    name: Synchro Kinesis
+    damage: 30+
+    text: Each player reveals their hand. If a card in your opponent's hand has the
+      same name as a card in your hand, this attack does 90 more damage.
+  - cost: [P, C, C]
+    name: Psychic Sphere
+    damage: '80'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Tomokazu Komiya
+- id: FILL_THIS-79
+  pioId: swsh11-79
+  enumId: COMFEY_79
+  name: Comfey
+  number: '79'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Flower Selecting
+    text: Once during your turn, if this Pokémon is in the Active Spot, you may look
+      at the top 2 cards of your deck and put 1 of them into your hand. Put the other
+      card in the Lost Zone.
+  moves:
+  - cost: [P, C]
+    name: Spinning Attack
+    damage: '30'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare
+  artist: Aya Kusube
+- id: FILL_THIS-80
+  pioId: swsh11-80
+  enumId: MIMIKYU_80
+  name: Mimikyu
+  number: '80'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Perplex
+    text: Your opponent's Active Pokémon is now Confused.
+  - cost: [P, C]
+    name: Worst Gift
+    damage: 10x
+    text: This attack does 10 damage for each damage counter on all of your opponent's
+      Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Ligton
+- id: FILL_THIS-81
+  pioId: swsh11-81
+  enumId: SPECTRIER_81
+  name: Spectrier
+  number: '81'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Night Footsteps
+    text: Choose 2 of your opponent's Pokémon and put 2 damage counters on each of
+      them.
+  - cost: [P, P, C]
+    name: Phantom Strike
+    damage: '120'
+    text: During your next turn, this Pokémon can't use Phantom Strike.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: Narumi Sato
+- id: FILL_THIS-82
+  pioId: swsh11-82
+  enumId: ENAMORUS_V_82
+  name: Enamorus V
+  number: '82'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Guardian of Love
+    text: Prevent all effects of your opponent's Pokémon's Abilities done to each
+      of your Pokémon that has any [P] Energy attached, except any Enamorus V.
+  moves:
+  - cost: [P, C, C]
+    name: Blossom Tail
+    damage: '100'
+    text: Attach up to 2 basic Energy cards from your discard pile to your Benched
+      Pokémon in any way you like.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-83
+  pioId: swsh11-83
+  enumId: HISUIAN_GROWLITHE_83
+  name: Hisuian Growlithe
+  number: '83'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Arcanine]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Singe
+    text: Your opponent's Active Pokémon is now Burned.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Kouki Saitou
+- id: FILL_THIS-84
+  pioId: swsh11-84
+  enumId: HISUIAN_ARCANINE_84
+  name: Hisuian Arcanine
+  number: '84'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Hisuian Growlithe
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Very Vulnerable
+    damage: 10+
+    text: If you have no cards in your hand, this attack does 150 more damage.
+  - cost: [F, C, C]
+    name: Sharp Fang
+    damage: '100'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: Oswaldo KATO
+- id: FILL_THIS-85
+  pioId: swsh11-85
+  enumId: POLIWRATH_85
+  name: Poliwrath
+  number: '85'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Poliwhirl
+  hp: 160
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Split Spiral Punch
+    damage: '60'
+    text: Your opponent's Active Pokémon is now Confused.
+  - cost: [W, C, C]
+    name: Splash Loop
+    damage: '160'
+    text: Put 2 Energy attached to this Pokémon into your hand.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare
+  artist: Teeziro
+- id: FILL_THIS-86
+  pioId: swsh11-86
+  enumId: MACHOP_86
+  name: Machop
+  number: '86'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Machoke]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Punch
+    damage: '20'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Common
+  artist: Yuka Morii
+- id: FILL_THIS-87
+  pioId: swsh11-87
+  enumId: MACHOKE_87
+  name: Machoke
+  number: '87'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Machop
+  evolvesTo: [Machamp]
+  hp: 100
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Strength
+    damage: '30'
+  - cost: [F, F]
+    name: Seismic Toss
+    damage: '50'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Uncommon
+  artist: Mitsuhiro Arita
+- id: FILL_THIS-88
+  pioId: swsh11-88
+  enumId: MACHAMP_88
+  name: Machamp
+  number: '88'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Machoke
+  hp: 150
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Crisis Muscles
+    text: If your opponent has 3 or fewer Prize cards remaining, this Pokémon gets
+      +150 HP.
+  moves:
+  - cost: [F, F]
+    name: Strong-Arm Lariat
+    damage: 100+ damage. You may do 100 more
+    text: If you do, during your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare Holo
+  artist: Nisota Niso
+- id: FILL_THIS-89
+  pioId: swsh11-89
+  enumId: RHYHORN_89
+  name: Rhyhorn
+  number: '89'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Rhydon]
+  hp: 100
+  retreatCost: 3
+  moves:
+  - cost: [F, C, C]
+    name: Take Down
+    damage: '70'
+    text: This Pokémon also does 20 damage to itself.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Scav
+- id: FILL_THIS-90
+  pioId: swsh11-90
+  enumId: RHYDON_90
+  name: Rhydon
+  number: '90'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Rhyhorn
+  evolvesTo: [Rhyperior]
+  hp: 120
+  retreatCost: 3
+  moves:
+  - cost: [F]
+    name: Horn Drill
+    damage: '30'
+  - cost: [F, C, C, C]
+    name: Take Down
+    damage: '120'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: HYOGONOSUKE
+- id: FILL_THIS-91
+  pioId: swsh11-91
+  enumId: RHYPERIOR_91
+  name: Rhyperior
+  number: '91'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Rhydon
+  hp: 190
+  retreatCost: 4
+  moves:
+  - cost: [F]
+    name: Geo Cannon
+    damage: 50+
+    text: Discard the top card of your deck. If that card is an Energy card, this
+      attack does 100 more damage, and attach that card to this Pokémon.
+  - cost: [F, C, C, C]
+    name: Rocky Tackle
+    damage: '180'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: GOSSAN
+- id: FILL_THIS-92
+  pioId: swsh11-92
+  enumId: AERODACTYL_V_92
+  name: Aerodactyl V
+  number: '92'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [F, C]
+    name: Bite
+    damage: '40'
+  - cost: [F, C, C]
+    name: Rock Crush
+    damage: '120'
+    text: Discard an Energy from your opponent's Active Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: N-DESIGN Inc.
+- id: FILL_THIS-93
+  pioId: swsh11-93
+  enumId: AERODACTYL_VSTAR_93
+  name: Aerodactyl VSTAR
+  number: '93'
+  types: [F]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Aerodactyl V
+  hp: 260
+  retreatCost: 2
+  moves:
+  - cost: [F, C, C]
+    name: Lost Dive
+    damage: '240'
+    text: Put the top 3 cards of your deck in the Lost Zone.
+  - cost: [C]
+    name: Ancient Star
+    text: Until this Pokémon leaves play, it gains an Ability that has the effect
+      "Your opponent's Pokémon V in play, except any Aerodactyl VSTAR, have no Abilities."
+      (You can't use more than 1 VSTAR Power in a game.)
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-94
+  pioId: swsh11-94
+  enumId: SUDOWOODO_94
+  name: Sudowoodo
+  number: '94'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Joust
+    damage: '20'
+    text: Before doing damage, discard all Pokémon Tools from your opponent's Active
+      Pokémon.
+  - cost: [F, C]
+    name: Impound
+    damage: '50'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: AKIRA EGAWA
+- id: FILL_THIS-95
+  pioId: swsh11-95
+  enumId: GLIGAR_95
+  name: Gligar
+  number: '95'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Gliscor]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Cyclone Pincers
+    damage: 10x
+    text: Flip 4 coins. This attack does 10 damage for each heads.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Miki Tanaka
+- id: FILL_THIS-96
+  pioId: swsh11-96
+  enumId: GLISCOR_96
+  name: Gliscor
+  number: '96'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Gligar
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [F, F]
+    name: Hurricane Shock
+    damage: 50x
+    text: Flip 4 coins. This attack does 50 damage for each heads. If at least 2 of
+      them are heads, your opponent's Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: Shiburingaru
+- id: FILL_THIS-97
+  pioId: swsh11-97
+  enumId: MAKUHITA_97
+  name: Makuhita
+  number: '97'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Hariyama]
+  hp: 80
+  retreatCost: 3
+  moves:
+  - cost: [F, C]
+    name: Fake Out
+    damage: '20'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Common
+  artist: Shigenori Negishi
+- id: FILL_THIS-98
+  pioId: swsh11-98
+  enumId: HARIYAMA_98
+  name: Hariyama
+  number: '98'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Makuhita
+  hp: 140
+  retreatCost: 3
+  moves:
+  - cost: [F, C]
+    name: Shove
+    damage: '40'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [F, C, C]
+    name: Muscular Slap
+    damage: '100'
+    text: This attack's damage isn't affected by Resistance.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Uncommon
+  artist: Scav
+- id: FILL_THIS-99
+  pioId: swsh11-99
+  enumId: MEDITITE_99
+  name: Meditite
+  number: '99'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Medicham]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Focus Fist
+    damage: '30'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Common
+  artist: '0313'
+- id: FILL_THIS-100
+  pioId: swsh11-100
+  enumId: MEDICHAM_100
+  name: Medicham
+  number: '100'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Meditite
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Battle Step
+    damage: '50'
+    text: Search your deck for up to 2 [F] Energy cards and attach them to your Benched
+      Pokémon in any way you like. Then, shuffle your deck.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Uncommon
+  artist: Kouki Saitou
+- id: FILL_THIS-101
+  pioId: swsh11-101
+  enumId: RELICANTH_101
+  name: Relicanth
+  number: '101'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Into the Deep
+    text: Put up to 2 basic Energy cards from your discard pile into your hand.
+  - cost: [C, C, C]
+    name: Tackle
+    damage: '80'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: ryoma uratsuka
+- id: FILL_THIS-102
+  pioId: swsh11-102
+  enumId: GASTRODON_102
+  name: Gastrodon
+  number: '102'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Shellos
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Recover
+    text: Discard an Energy from this Pokémon and heal all damage from it.
+  - cost: [F, F, C]
+    name: Earthquake
+    damage: '170'
+    text: This attack also does 20 damage to each of your Benched Pokémon. (Don't
+      apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: Sanosuke Sakuma
+- id: FILL_THIS-103
+  pioId: swsh11-103
+  enumId: MIENFOO_103
+  name: Mienfoo
+  number: '103'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Mienshao]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Chop
+    damage: '10'
+  - cost: [F, C]
+    name: Spiral Kick
+    damage: '30'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Common
+  artist: yuu
+- id: FILL_THIS-104
+  pioId: swsh11-104
+  enumId: MIENSHAO_104
+  name: Mienshao
+  number: '104'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Mienfoo
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Pound
+    damage: '30'
+  - cost: [F, C]
+    name: Double Smash
+    damage: 70x
+    text: Flip 2 coins. This attack does 70 damage for each heads.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Uncommon
+  artist: Shibuzoh.
+- id: FILL_THIS-105
+  pioId: swsh11-105
+  enumId: LANDORUS_105
+  name: Landorus
+  number: '105'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Slap Push
+    damage: '20'
+  - cost: [F, F, C]
+    name: Smashing Edge
+    damage: '130'
+    text: Discard 2 Energy from this Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: KEIICHIRO ITO
+- id: FILL_THIS-106
+  pioId: swsh11-106
+  enumId: BINACLE_106
+  name: Binacle
+  number: '106'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Barbaracle]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Mud-Slap
+    damage: '10'
+  - cost: [C, C]
+    name: Slash
+    damage: '20'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Scav
+- id: FILL_THIS-107
+  pioId: swsh11-107
+  enumId: BARBARACLE_107
+  name: Barbaracle
+  number: '107'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Binacle
+  hp: 130
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Lost Block
+    text: Your opponent puts any Prize cards they would take in the Lost Zone instead
+      of into their hand.
+  moves:
+  - cost: [F, C, C]
+    name: Dynamic Chop
+    damage: '100'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: KEIICHIRO ITO
+- id: FILL_THIS-108
+  pioId: swsh11-108
+  enumId: CARBINK_108
+  name: Carbink
+  number: '108'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Lucky Find
+    text: Search your deck for up to 2 Item cards, reveal them, and put them into
+      your hand. Then, shuffle your deck.
+  - cost: [F, C, C]
+    name: Power Gem
+    damage: '80'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: Tika Matsuno
+- id: FILL_THIS-109
+  pioId: swsh11-109
+  enumId: ROCKRUFF_109
+  name: Rockruff
+  number: '109'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Lycanroc]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Double Draw
+    text: Draw 2 cards.
+  - cost: [F, C, C]
+    name: Rear Kick
+    damage: '30'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Miki Tanaka
+- id: FILL_THIS-110
+  pioId: swsh11-110
+  enumId: FALINKS_110
+  name: Falinks
+  number: '110'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 100
+  retreatCost: 1
+  moves:
+  - cost: [F]
+    name: Fighting Headbutt
+    damage: 10+
+    text: This attack's damage isn't affected by Weakness. If your opponent's Active
+      Pokémon is a Pokémon V, this attack does 50 more damage.
+  - cost: [F, C, C]
+    name: Jet Headbutt
+    damage: '80'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Common
+  artist: sowsow
+- id: FILL_THIS-111
+  pioId: swsh11-111
+  enumId: STONJOURNER_111
+  name: Stonjourner
+  number: '111'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 140
+  retreatCost: 4
+  moves:
+  - cost: [C]
+    name: Power Stone
+    text: Attach up to 2 [F] Energy cards from your hand to your Pokémon in any way
+      you like.
+  - cost: [F, C, C, C]
+    name: Lost Shot
+    damage: '120'
+    text: Put the top card of your opponent's deck in the Lost Zone.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: HYOGONOSUKE
+- id: FILL_THIS-112
+  pioId: swsh11-112
+  enumId: SPINARAK_112
+  name: Spinarak
+  number: '112'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Ariados]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Poison Sting
+    damage: '10'
+    text: Your opponent's Active Pokémon is now Poisoned.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Atsuko Nishida
+- id: FILL_THIS-113
+  pioId: swsh11-113
+  enumId: ARIADOS_113
+  name: Ariados
+  number: '113'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Spinarak
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: String Bind
+    damage: 10+
+    text: This attack does 30 more damage for each [C] in your opponent's Active Pokémon's
+      Retreat Cost.
+  - cost: [D, C, C]
+    name: Venomous Fang
+    damage: '80'
+    text: Your opponent's Active Pokémon is now Poisoned.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Shinji Kanda
+- id: FILL_THIS-114
+  pioId: swsh11-114
+  enumId: MURKROW_114
+  name: Murkrow
+  number: '114'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Honchkrow]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Peck
+    damage: '10'
+  - cost: [D, C]
+    name: Wing Attack
+    damage: '30'
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: Yuka Morii
+- id: FILL_THIS-115
+  pioId: swsh11-115
+  enumId: HONCHKROW_115
+  name: Honchkrow
+  number: '115'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Murkrow
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Peck
+    damage: '20'
+  - cost: [D, D, C]
+    name: Night Cyclone
+    damage: '160'
+    text: Move all Energy from this Pokémon to your Benched Pokémon in any way you
+      like.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare
+  artist: Shiburingaru
+- id: FILL_THIS-116
+  pioId: swsh11-116
+  enumId: SEVIPER_116
+  name: Seviper
+  number: '116'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [D, D]
+    name: Sucker Punch and Turn
+    damage: '60'
+    text: Switch this Pokémon with 1 of your Benched [D] Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: Tomokazu Komiya
+- id: FILL_THIS-117
+  pioId: swsh11-117
+  enumId: SPIRITOMB_117
+  name: Spiritomb
+  number: '117'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Cursed Message
+    text: If this Pokémon is Knocked Out by damage from an attack from your opponent's
+      Pokémon, search your deck for a card and put it into your hand. Then, shuffle
+      your deck.
+  moves:
+  - cost: [D, D]
+    name: Chain of Spirits
+    damage: 10+
+    text: This attack does 60 more damage for each Spiritomb in your discard pile.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: sui
+- id: FILL_THIS-118
+  pioId: swsh11-118
+  enumId: DRAPION_V_118
+  name: Drapion V
+  number: '118'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Wild Style
+    text: This Pokémon's attacks cost [C] less for each of your opponent's Single
+      Strike, Rapid Strike, and Fusion Strike Pokémon in play.
+  moves:
+  - cost: [C, C, C, C]
+    name: Dynamic Tail
+    damage: '190'
+    text: This attack also does 60 damage to 1 of your Pokémon. (Don't apply Weakness
+      and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: N-DESIGN Inc.
+- id: FILL_THIS-119
+  pioId: swsh11-119
+  enumId: DRAPION_VSTAR_119
+  name: Drapion VSTAR
+  number: '119'
+  types: [D]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Drapion V
+  hp: 270
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Hazard Star
+    text: During your turn, you may make your opponent's Active Pokémon Paralyzed
+      and Poisoned. During Pokémon Checkup, put 3 damage counters on that Pokémon
+      instead of 1. (You can't use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [D, D, C]
+    name: Big Bang Arm
+    damage: 250-
+    text: This attack does 10 less damage for each damage counter on this Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: PLANETA Mochizuki
+- id: FILL_THIS-120
+  pioId: swsh11-120
+  enumId: DARKRAI_120
+  name: Darkrai
+  number: '120'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [D, C]
+    name: Nightmare
+    damage: '30'
+    text: Your opponent's Active Pokémon is now Asleep.
+  - cost: [D, D, C]
+    name: Pitch-Black Blade
+    damage: '130'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: Shin Nagasawa
+- id: FILL_THIS-121
+  pioId: swsh11-121
+  enumId: INKAY_121
+  name: Inkay
+  number: '121'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Malamar]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Call for Family
+    text: Search your deck for up to 2 Basic Pokémon and put them onto your Bench.
+      Then, shuffle your deck.
+  - cost: [D, C]
+    name: Tackle
+    damage: '20'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Shibuzoh.
+- id: FILL_THIS-122
+  pioId: swsh11-122
+  enumId: HOOPA_122
+  name: Hoopa
+  number: '122'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [D]
+    name: Hand of Djinn
+    text: Search your deck for a [D] Energy card and attach it to 1 of your Pokémon.
+      Then, shuffle your deck.
+  - cost: [D, D, C]
+    name: Tyrannical Hole
+    damage: '100'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare
+  artist: Sanosuke Sakuma
+- id: FILL_THIS-123
+  pioId: swsh11-123
+  enumId: RADIANT_HISUIAN_SNEASLER_123
+  name: Radiant Hisuian Sneasler
+  number: '123'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Poison Peak
+    text: During Pokémon Checkup, put 2 more damage counters on your opponent's Poisoned
+      Pokémon.
+  moves:
+  - cost: [D, C, C]
+    name: Poison Jab
+    damage: '90'
+    text: Your opponent's Active Pokémon is now Poisoned.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  text:
+  - 'Radiant Pokémon Rule: You cant have more than 1 Radiant Pokémon in your deck.'
+  artist: Akira Komayama
+- id: FILL_THIS-124
+  pioId: swsh11-124
+  enumId: RADIANT_STEELIX_124
+  name: Radiant Steelix
+  number: '124'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 170
+  retreatCost: 4
+  moves:
+  - cost: [C]
+    name: Energy Stream
+    damage: '20'
+    text: Attach up to 2 [M] Energy cards from your discard pile to this Pokémon.
+  - cost: [M, M, C]
+    name: Destructive Finish
+    damage: 60+
+    text: Discard cards from the top of your deck until only 1 card remains. This
+      attack does 30 more damage for each Energy card you discarded in this way.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare
+  text:
+  - 'Radiant Pokémon Rule: You cant have more than 1 Radiant Pokémon in your deck.'
+  artist: Sanosuke Sakuma
+- id: FILL_THIS-125
+  pioId: swsh11-125
+  enumId: BRONZOR_125
+  name: Bronzor
+  number: '125'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Bronzong]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Spinning Attack
+    damage: '10'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Common
+  artist: Tomokazu Komiya
+- id: FILL_THIS-126
+  pioId: swsh11-126
+  enumId: BRONZONG_126
+  name: Bronzong
+  number: '126'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Bronzor
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [C, C]
+    name: Ram
+    damage: '30'
+  - cost: [M, C, C]
+    name: Gravitational Drop
+    damage: 40+
+    text: This attack does 40 more damage for each [C] in your opponent's Active Pokémon's
+      Retreat Cost.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Uncommon
+  artist: AKIRA EGAWA
+- id: FILL_THIS-127
+  pioId: swsh11-127
+  enumId: GALARIAN_STUNFISK_127
+  name: Galarian Stunfisk
+  number: '127'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 100
+  retreatCost: 3
+  moves:
+  - cost: [M]
+    name: Field Trap
+    damage: '20'
+    text: If your opponent has a Stadium in play, discard it. If you discarded a Stadium
+      in this way, discard 2 Energy from your opponent's Active Pokémon.
+  - cost: [M, C]
+    name: Tackle
+    damage: '50'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Uncommon
+  artist: Shigenori Negishi
+- id: FILL_THIS-128
+  pioId: swsh11-128
+  enumId: MAGEARNA_128
+  name: Magearna
+  number: '128'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [M]
+    name: Gear Cutter
+    damage: '20'
+  - cost: [M, C, C]
+    name: Windup Beam
+    damage: 60+
+    text: If this Pokémon has a Pokémon Tool attached, this attack does 60 more damage,
+      and your opponent's Active Pokémon is now Confused.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare
+  artist: Rianti Hidayat
+- id: FILL_THIS-129
+  pioId: swsh11-129
+  enumId: GALARIAN_PERRSERKER_V_129
+  name: Galarian Perrserker V
+  number: '129'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Feelin' Fine
+    text: Draw 3 cards.
+  - cost: [M, C]
+    name: Treasure Rush
+    damage: 20x
+    text: This attack does 20 damage for each card in your hand.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: PLANETA Yamashita
+- id: FILL_THIS-130
+  pioId: swsh11-130
+  enumId: GIRATINA_V_130
+  name: Giratina V
+  number: '130'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Abyss Seeking
+    text: Look at the top 4 cards of your deck and put 2 of them into your hand. Put
+      the other cards in the Lost Zone.
+  - cost: [G, P, C]
+    name: Shred
+    damage: '160'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon.
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-131
+  pioId: swsh11-131
+  enumId: GIRATINA_VSTAR_131
+  name: Giratina VSTAR
+  number: '131'
+  types: [N]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Giratina V
+  hp: 280
+  retreatCost: 2
+  moves:
+  - cost: [G, P, C]
+    name: Lost Impact
+    damage: '280'
+    text: Put 2 Energy attached to your Pokémon in the Lost Zone.
+  - cost: [G, P]
+    name: Star Requiem
+    text: You can use this attack only if you have 10 or more cards in the Lost Zone.
+      Your opponent's Active Pokémon is Knocked Out. (You can't use more than 1 VSTAR
+      Power in a game.)
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-132
+  pioId: swsh11-132
+  enumId: GOOMY_132
+  name: Goomy
+  number: '132'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Sliggoo]
+  hp: 60
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Tackle
+    damage: '10'
+  - cost: [W, M]
+    name: Melt
+    damage: '30'
+  rarity: Common
+  artist: Oswaldo KATO
+- id: FILL_THIS-133
+  pioId: swsh11-133
+  enumId: HISUIAN_SLIGGOO_133
+  name: Hisuian Sliggoo
+  number: '133'
+  types: [N]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Goomy
+  evolvesTo: [Goodra]
+  hp: 90
+  retreatCost: 3
+  moves:
+  - cost: [W]
+    name: Rigidify
+    text: During your opponent's next turn, this Pokémon takes 50 less damage from
+      attacks (after applying Weakness and Resistance).
+  - cost: [W, M]
+    name: Gentle Slap
+    damage: '40'
+  rarity: Uncommon
+  artist: Kouki Saitou
+- id: FILL_THIS-134
+  pioId: swsh11-134
+  enumId: HISUIAN_GOODRA_134
+  name: Hisuian Goodra
+  number: '134'
+  types: [N]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Hisuian Sliggoo
+  hp: 160
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Metal Lodging
+    text: Prevent all damage done to each of your Basic Pokémon that has any [M] Energy
+      attached by attacks from your opponent's Pokémon V.
+  moves:
+  - cost: [W, M, C]
+    name: Heavy Impact
+    damage: '140'
+  rarity: Rare Holo
+  artist: Akira Komayama
+- id: FILL_THIS-135
+  pioId: swsh11-135
+  enumId: HISUIAN_GOODRA_V_135
+  name: Hisuian Goodra V
+  number: '135'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [W, M]
+    name: Slip-'n'-Trip
+    damage: '60'
+    text: Your opponent switches their Active Pokémon with 1 of their Benched Pokémon.
+  - cost: [W, M, C]
+    name: Rolling Shell
+    damage: '140'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-136
+  pioId: swsh11-136
+  enumId: HISUIAN_GOODRA_VSTAR_136
+  name: Hisuian Goodra VSTAR
+  number: '136'
+  types: [N]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Hisuian Goodra V
+  hp: 270
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Moisture Star
+    text: During your turn, you may heal all damage from this Pokémon. (You can't
+      use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [W, M, C]
+    name: Rolling Iron
+    damage: '200'
+    text: During your opponent's next turn, this Pokémon takes 80 less damage from
+      attacks (after applying Weakness and Resistance).
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: 5ban Graphics
+- id: FILL_THIS-137
+  pioId: swsh11-137
+  enumId: PIDGEOT_V_137
+  name: Pidgeot V
+  number: '137'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Vanishing Wings
+    text: Once during your turn, if this Pokémon is on your Bench, you may shuffle
+      it and all attached cards into your deck.
+  moves:
+  - cost: [C, C, C]
+    name: Flight Surf
+    damage: 80+
+    text: If you have a Stadium in play, this attack does 80 more damage.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Saki Hayashiro
+- id: FILL_THIS-138
+  pioId: swsh11-138
+  enumId: LICKITUNG_138
+  name: Lickitung
+  number: '138'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Lickilicky]
+  hp: 110
+  retreatCost: 4
+  moves:
+  - cost: [C, C]
+    name: Drool
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: KIYOTAKA OSHIYAMA
+- id: FILL_THIS-139
+  pioId: swsh11-139
+  enumId: LICKILICKY_139
+  name: Lickilicky
+  number: '139'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Lickitung
+  hp: 140
+  retreatCost: 4
+  moves:
+  - cost: [C, C]
+    name: Tongue Slap
+    damage: '50'
+  - cost: [C, C, C, C]
+    name: Heavy Impact
+    damage: '130'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: Shibuzoh.
+- id: FILL_THIS-140
+  pioId: swsh11-140
+  enumId: PORYGON_140
+  name: Porygon
+  number: '140'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Porygon2]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Branch Calculation
+    text: Look at the top 4 cards of either player's deck and put them back in any
+      order.
+  - cost: [C]
+    name: Beam
+    damage: '10'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: kurumitsu
+- id: FILL_THIS-141
+  pioId: swsh11-141
+  enumId: PORYGON2_141
+  name: Porygon2
+  number: '141'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Porygon
+  evolvesTo: [Porygon-Z]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Garbage Attack
+    damage: 20x
+    text: This attack does 20 damage for each Pokémon Tool card in the Lost Zone (both
+      yours and your opponent's).
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: OKACHEKE
+- id: FILL_THIS-142
+  pioId: swsh11-142
+  enumId: PORYGON_Z_142
+  name: Porygon-Z
+  number: '142'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Porygon2
+  hp: 150
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Downgrading Beam
+    text: Devolve 1 of your opponent's evolved Pokémon by removing any number of Evolution
+      cards from it. Your opponent shuffles those cards into their deck.
+  - cost: [C, C, C]
+    name: Power Beam
+    damage: '130'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Shibuzoh.
+- id: FILL_THIS-143
+  pioId: swsh11-143
+  enumId: SNORLAX_143
+  name: Snorlax
+  number: '143'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 150
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Unfazed Fat
+    text: Prevent all effects of attacks from your opponent's Pokémon done to this
+      Pokémon. (Damage is not an effect.)
+  moves:
+  - cost: [C, C, C]
+    name: Thumping Snore
+    damage: '180'
+    text: This Pokémon is now Asleep. During Pokémon Checkup, flip 2 coins instead
+      of 1. If either of them is tails, this Pokémon is still Asleep.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: '0313'
+- id: FILL_THIS-144
+  pioId: swsh11-144
+  enumId: AIPOM_144
+  name: Aipom
+  number: '144'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Ambipom]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Mischievous Tail
+    text: Look at the top card of your opponent's deck. You may have your opponent
+      shuffle their deck.
+  - cost: [C]
+    name: Scratch
+    damage: '10'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Kouki Saitou
+- id: FILL_THIS-145
+  pioId: swsh11-145
+  enumId: AMBIPOM_145
+  name: Ambipom
+  number: '145'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Aipom
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: All-You-Can-Grab
+    text: Flip a coin until you get tails. Search your deck for a number of cards
+      up to the number of heads and put them into your hand. Then, shuffle your deck.
+  - cost: [C, C]
+    name: Knock Off
+    damage: '50'
+    text: Discard a random card from your opponent's hand.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: Atsushi Furusawa
+- id: FILL_THIS-146
+  pioId: swsh11-146
+  enumId: HISUIAN_ZOROARK_V_146
+  name: Hisuian Zoroark V
+  number: '146'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Void Return
+    damage: '30'
+    text: You may switch this Pokémon with 1 of your Benched Pokémon.
+  - cost: [C, C, C]
+    name: Shadow Cyclone
+    damage: '130'
+    text: Move an Energy from this Pokémon to 1 of your Benched Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: aky CG Works
+- id: FILL_THIS-147
+  pioId: swsh11-147
+  enumId: HISUIAN_ZOROARK_VSTAR_147
+  name: Hisuian Zoroark VSTAR
+  number: '147'
+  types: [C]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Hisuian Zoroark V
+  hp: 270
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Phantom Star
+    text: During your turn, you may discard your hand and draw 7 cards. (You can't
+      use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [C, C]
+    name: Ticking Curse
+    damage: 50x
+    text: This attack does 50 damage for each of your Pokémon that has any damage
+      counters on it.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: aky CG Works
+- id: FILL_THIS-148
+  pioId: swsh11-148
+  enumId: BOUFFALANT_148
+  name: Bouffalant
+  number: '148'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [C, C, C]
+    name: Lost Headbutt
+    damage: '50'
+    text: Put an Energy attached to your opponent's Active Pokémon in the Lost Zone.
+  - cost: [C, C, C, C]
+    name: Superpowered Horns
+    damage: '120'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: Nisota Niso
+- id: FILL_THIS-149
+  pioId: swsh11-149
+  enumId: KOMALA_149
+  name: Komala
+  number: '149'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 100
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: All Just a Dream
+    text: If this Pokémon is Asleep and is Knocked Out by damage from an attack from
+      your opponent's Pokémon, your opponent can't take any Prize cards for it.
+  moves:
+  - cost: [C, C]
+    name: Collapse
+    damage: '60'
+    text: This Pokémon is now Asleep.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: HYOGONOSUKE
+- id: FILL_THIS-150
+  pioId: swsh11-150
+  enumId: SKWOVET_150
+  name: Skwovet
+  number: '150'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Greedent]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Gnaw
+    damage: '20'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Miki Tanaka
+- id: FILL_THIS-151
+  pioId: swsh11-151
+  enumId: GREEDENT_151
+  name: Greedent
+  number: '151'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Skwovet
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Collect
+    text: Draw 2 cards.
+  - cost: [C, C]
+    name: Spill Out
+    damage: 60+
+    text: Discard your hand. If you discarded 5 or more cards in this way, this attack
+      does 150 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare
+  artist: sui
+- id: FILL_THIS-152
+  pioId: swsh11-152
+  enumId: ARC_PHONE_152
+  name: Arc Phone
+  number: '152'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Look at the top card of your deck. You may switch that card with 1 of your face-down
+    Prize cards. (The cards stay face down.)
+  - 'Item rule: You may play any number of Item cards during your turn.'
+- id: FILL_THIS-153
+  pioId: swsh11-153
+  enumId: AREZU_153
+  name: Arezu
+  number: '153'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Search your deck for up to 3 Evolution Pokémon that don't have a Rule Box, reveal
+    them, and put them into your hand. Then, shuffle your deck. (Pokémon V, Pokémon-GX,
+    etc. have Rule Boxes.)
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+- id: FILL_THIS-154
+  pioId: swsh11-154
+  enumId: BOX_OF_DISASTER_154
+  name: Box of Disaster
+  number: '154'
+  superType: TRAINER
+  subTypes: [ITEM, ITEM, POKEMON_TOOL]
+  rarity: Uncommon
+  text:
+  - If the Pokémon V this card is attached to has full HP and is Knocked Out by damage
+    from an attack from your opponent's Pokémon, put 8 damage counters on the Attacking
+    Pokémon.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn''t already
+    have a Pokémon Tool attached.'
+- id: FILL_THIS-155
+  pioId: swsh11-155
+  enumId: COLRESS_S_EXPERIMENT_155
+  name: Colress's Experiment
+  number: '155'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Look at the top 5 cards of your deck and put 3 of them into your hand. Put the
+    other cards in the Lost Zone.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+- id: FILL_THIS-156
+  pioId: swsh11-156
+  enumId: DAMAGE_PUMP_156
+  name: Damage Pump
+  number: '156'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Move up to 2 damage counters from 1 of your Pokémon to your other Pokémon in any
+    way you like.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+- id: FILL_THIS-157
+  pioId: swsh11-157
+  enumId: FANTINA_157
+  name: Fantina
+  number: '157'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - You can use this card only if you have 10 or more cards in the Lost Zone. During
+    your opponent's next turn, all of your Pokémon take 120 less damage from attacks
+    from your opponent's Pokémon V (after applying Weakness and Resistance). (This
+    includes Pokémon that come into play during that turn.)
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+- id: FILL_THIS-158
+  pioId: swsh11-158
+  enumId: ISCAN_158
+  name: Iscan
+  number: '158'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Draw 2 cards. If your Active Pokémon has "Hisuian" in its name, draw 2 more cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+- id: FILL_THIS-159
+  pioId: swsh11-159
+  enumId: LADY_159
+  name: Lady
+  number: '159'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Search your deck for up to 4 basic Energy cards, reveal them, and put them into
+    your hand. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+- id: FILL_THIS-160
+  pioId: swsh11-160
+  enumId: LAKE_ACUITY_160
+  name: Lake Acuity
+  number: '160'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Uncommon
+  text:
+  - All Pokémon that have any Water or [F] Energy attached (both yours and your opponent's)
+    take 20 less damage from attacks from the opponent's Pokémon (after applying Weakness
+    and Resistance).
+- id: FILL_THIS-161
+  pioId: swsh11-161
+  enumId: LOST_CITY_161
+  name: Lost City
+  number: '161'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Uncommon
+  text:
+  - Whenever a Pokémon (either yours or your opponent's) is Knocked Out, put that
+    Pokémon in the Lost Zone instead of the discard pile. (Discard all attached cards.)
+- id: FILL_THIS-162
+  pioId: swsh11-162
+  enumId: LOST_VACUUM_162
+  name: Lost Vacuum
+  number: '162'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - You can use this card only if you put another card from your hand in the Lost
+    Zone. Choose a Pokémon Tool attached to any Pokémon, or any Stadium in play, and
+    put it in the Lost Zone.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+- id: FILL_THIS-163
+  pioId: swsh11-163
+  enumId: MIRAGE_GATE_163
+  name: Mirage Gate
+  number: '163'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - You can use this card only if you have 7 or more cards in the Lost Zone. Search
+    your deck for up to 2 basic Energy cards of different types and attach them to
+    your Pokémon in any way you like. Then, shuffle your deck.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+- id: FILL_THIS-164
+  pioId: swsh11-164
+  enumId: MISS_FORTUNE_SISTERS_164
+  name: Miss Fortune Sisters
+  number: '164'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Look at the top 5 cards of your opponent's deck and discard any number of Item
+    cards you find there. Your opponent shuffles the other cards back into their deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+- id: FILL_THIS-165
+  pioId: swsh11-165
+  enumId: PANIC_MASK_165
+  name: Panic Mask
+  number: '165'
+  superType: TRAINER
+  subTypes: [ITEM, ITEM, POKEMON_TOOL]
+  rarity: Uncommon
+  text:
+  - Prevent all damage done to the Pokémon this card is attached to by attacks from
+    your opponent's Pokémon that have 40 HP or less remaining.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn''t already
+    have a Pokémon Tool attached.'
+- id: FILL_THIS-166
+  pioId: swsh11-166
+  enumId: RILEY_166
+  name: Riley
+  number: '166'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Reveal the top 5 cards of your deck and have your opponent choose 2 of them. Discard
+    the chosen cards and put the remaining cards into your hand.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+- id: FILL_THIS-167
+  pioId: swsh11-167
+  enumId: THORTON_167
+  name: Thorton
+  number: '167'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Choose a Basic Pokémon in your discard pile and switch it with 1 of your Basic
+    Pokémon in play. Any attached cards, damage counters, Special Conditions, turns
+    in play, and any other effects remain on the new Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+- id: FILL_THIS-168
+  pioId: swsh11-168
+  enumId: TOOL_BOX_168
+  name: Tool Box
+  number: '168'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Look at the top 7 cards of your deck. You may reveal any number of Pokémon Tool
+    cards you find there and put them into your hand. Shuffle the other cards back
+    into your deck.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+- id: FILL_THIS-169
+  pioId: swsh11-169
+  enumId: VOLO_169
+  name: Volo
+  number: '169'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Rare Holo
+  text:
+  - Discard 1 of your Benched Pokémon V and all attached cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+- id: FILL_THIS-170
+  pioId: swsh11-170
+  enumId: WINDUP_ARM_170
+  name: Windup Arm
+  number: '170'
+  superType: TRAINER
+  subTypes: [ITEM, ITEM, POKEMON_TOOL]
+  rarity: Uncommon
+  text:
+  - The Pokémon this card is attached to can attack even if it's Asleep or Paralyzed.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn''t already
+    have a Pokémon Tool attached.'
+- id: FILL_THIS-171
+  pioId: swsh11-171
+  enumId: GIFT_ENERGY_171
+  name: Gift Energy
+  number: '171'
+  superType: ENERGY
+  subTypes: [SPECIAL_ENERGY]
+  rarity: Uncommon
+  text:
+  - As long as this card is attached to a Pokémon, it provides [C] Energy. If the
+    Pokémon this card is attached to is Knocked Out by damage from an attack from
+    your opponent's Pokémon, draw cards until you have 7 cards in your hand.
+- id: FILL_THIS-172
+  pioId: swsh11-172
+  enumId: HISUIAN_ELECTRODE_V_172
+  name: Hisuian Electrode V
+  number: '172'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Tantrum Blast
+    damage: 100x
+    text: This attack does 100 damage for each Special Condition affecting this Pokémon.
+  - cost: [G, C]
+    name: Solar Shot
+    damage: '120'
+    text: Discard all Energy from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+- id: FILL_THIS-173
+  pioId: swsh11-173
+  enumId: DELPHOX_V_173
+  name: Delphox V
+  number: '173'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [R]
+    name: Eerie Glow
+    text: Your opponent's Active Pokémon is now Burned and Confused.
+  - cost: [R, R, C]
+    name: Magical Fire
+    damage: '120'
+    text: Put 2 Energy attached to this Pokémon in the Lost Zone. This attack also
+      does 120 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness
+      and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-27
+  variantType: Full Art
+- id: FILL_THIS-174
+  pioId: swsh11-174
+  enumId: KYUREM_V_174
+  name: Kyurem V
+  number: '174'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [W]
+    name: Rapid Freeze
+    text: Attach any number of [W] Energy cards from your hand to your Pokémon in
+      any way you like.
+  - cost: [W, W, W]
+    name: Frost Smash
+    damage: '140'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-48
+  variantType: Full Art
+- id: FILL_THIS-175
+  pioId: swsh11-175
+  enumId: MAGNEZONE_V_175
+  name: Magnezone V
+  number: '175'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [L, C]
+    name: Magnetic Tension
+    text: Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. This
+      attack does 40 damage to the new Active Pokémon.
+  - cost: [L, C, C]
+    name: Splitting Beam
+    damage: '90'
+    text: This attack also does 30 damage to 2 of your opponent's Benched Pokémon.
+      (Don't apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-56
+  variantType: Full Art
+- id: FILL_THIS-176
+  pioId: swsh11-176
+  enumId: ROTOM_V_176
+  name: Rotom V
+  number: '176'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Instant Charge
+    text: Once during your turn, you may draw 3 cards. If you use this Ability, your
+      turn ends.
+  moves:
+  - cost: [L, L]
+    name: Scrap Short
+    damage: 40+
+    text: Put any number of Pokémon Tool cards from your discard pile in the Lost
+      Zone. This attack does 40 more damage for each card you put in the Lost Zone
+      in this way.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-58
+  variantType: Full Art
+- id: FILL_THIS-177
+  pioId: swsh11-177
+  enumId: ROTOM_V_177
+  name: Rotom V
+  number: '177'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 190
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Instant Charge
+    text: Once during your turn, you may draw 3 cards. If you use this Ability, your
+      turn ends.
+  moves:
+  - cost: [L, L]
+    name: Scrap Short
+    damage: 40+
+    text: Put any number of Pokémon Tool cards from your discard pile in the Lost
+      Zone. This attack does 40 more damage for each card you put in the Lost Zone
+      in this way.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-58
+  variantType: Full Art
+- id: FILL_THIS-178
+  pioId: swsh11-178
+  enumId: ENAMORUS_V_178
+  name: Enamorus V
+  number: '178'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Guardian of Love
+    text: Prevent all effects of your opponent's Pokémon's Abilities done to each
+      of your Pokémon that has any [P] Energy attached, except any Enamorus V.
+  moves:
+  - cost: [P, C, C]
+    name: Blossom Tail
+    damage: '100'
+    text: Attach up to 2 basic Energy cards from your discard pile to your Benched
+      Pokémon in any way you like.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-82
+  variantType: Full Art
+- id: FILL_THIS-179
+  pioId: swsh11-179
+  enumId: AERODACTYL_V_179
+  name: Aerodactyl V
+  number: '179'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [F, C]
+    name: Bite
+    damage: '40'
+  - cost: [F, C, C]
+    name: Rock Crush
+    damage: '120'
+    text: Discard an Energy from your opponent's Active Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-92
+  variantType: Full Art
+- id: FILL_THIS-180
+  pioId: swsh11-180
+  enumId: AERODACTYL_V_180
+  name: Aerodactyl V
+  number: '180'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [F, C]
+    name: Bite
+    damage: '40'
+  - cost: [F, C, C]
+    name: Rock Crush
+    damage: '120'
+    text: Discard an Energy from your opponent's Active Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-92
+  variantType: Full Art
+- id: FILL_THIS-181
+  pioId: swsh11-181
+  enumId: GALLADE_V_181
+  name: Gallade V
+  number: '181'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [F, C]
+    name: Rising Sword
+    damage: 20+
+    text: This attack does 50 more damage for each Prize card you have taken.
+  - cost: [F, F, C]
+    name: Buster Swing
+    damage: '130'
+    text: This attack's damage isn't affected by Resistance.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+- id: FILL_THIS-182
+  pioId: swsh11-182
+  enumId: DRAPION_V_182
+  name: Drapion V
+  number: '182'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Wild Style
+    text: This Pokémon's attacks cost [C] less for each of your opponent's Single
+      Strike, Rapid Strike, and Fusion Strike Pokémon in play.
+  moves:
+  - cost: [C, C, C, C]
+    name: Dynamic Tail
+    damage: '190'
+    text: This attack also does 60 damage to 1 of your Pokémon. (Don't apply Weakness
+      and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-118
+  variantType: Full Art
+- id: FILL_THIS-183
+  pioId: swsh11-183
+  enumId: GALARIAN_PERRSERKER_V_183
+  name: Galarian Perrserker V
+  number: '183'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Feelin' Fine
+    text: Draw 3 cards.
+  - cost: [M, C]
+    name: Treasure Rush
+    damage: 20x
+    text: This attack does 20 damage for each card in your hand.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-129
+  variantType: Full Art
+- id: FILL_THIS-184
+  pioId: swsh11-184
+  enumId: GALARIAN_PERRSERKER_V_184
+  name: Galarian Perrserker V
+  number: '184'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Feelin' Fine
+    text: Draw 3 cards.
+  - cost: [M, C]
+    name: Treasure Rush
+    damage: 20x
+    text: This attack does 20 damage for each card in your hand.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-129
+  variantType: Full Art
+- id: FILL_THIS-185
+  pioId: swsh11-185
+  enumId: GIRATINA_V_185
+  name: Giratina V
+  number: '185'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Abyss Seeking
+    text: Look at the top 4 cards of your deck and put 2 of them into your hand. Put
+      the other cards in the Lost Zone.
+  - cost: [G, P, C]
+    name: Shred
+    damage: '160'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon.
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-130
+  variantType: Full Art
+- id: FILL_THIS-186
+  pioId: swsh11-186
+  enumId: GIRATINA_V_186
+  name: Giratina V
+  number: '186'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Abyss Seeking
+    text: Look at the top 4 cards of your deck and put 2 of them into your hand. Put
+      the other cards in the Lost Zone.
+  - cost: [G, P, C]
+    name: Shred
+    damage: '160'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon.
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-130
+  variantType: Full Art
+- id: FILL_THIS-187
+  pioId: swsh11-187
+  enumId: HISUIAN_GOODRA_V_187
+  name: Hisuian Goodra V
+  number: '187'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [W, M]
+    name: Slip-'n'-Trip
+    damage: '60'
+    text: Your opponent switches their Active Pokémon with 1 of their Benched Pokémon.
+  - cost: [W, M, C]
+    name: Rolling Shell
+    damage: '140'
+    text: During your opponent's next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-135
+  variantType: Full Art
+- id: FILL_THIS-188
+  pioId: swsh11-188
+  enumId: PIDGEOT_V_188
+  name: Pidgeot V
+  number: '188'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Vanishing Wings
+    text: Once during your turn, if this Pokémon is on your Bench, you may shuffle
+      it and all attached cards into your deck.
+  moves:
+  - cost: [C, C, C]
+    name: Flight Surf
+    damage: 80+
+    text: If you have a Stadium in play, this attack does 80 more damage.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  variantOf: FILL_THIS-137
+  variantType: Full Art
+- id: FILL_THIS-189
+  pioId: swsh11-189
+  enumId: AREZU_189
+  name: Arezu
+  number: '189'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Search your deck for up to 3 Evolution Pokémon that don't have a Rule Box, reveal
+    them, and put them into your hand. Then, shuffle your deck. (Pokémon V, Pokémon-GX,
+    etc. have Rule Boxes.)
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-153
+  variantType: Full Art
+- id: FILL_THIS-190
+  pioId: swsh11-190
+  enumId: COLRESS_S_EXPERIMENT_190
+  name: Colress's Experiment
+  number: '190'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Look at the top 5 cards of your deck and put 3 of them into your hand. Put the
+    other cards in the Lost Zone.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-155
+  variantType: Full Art
+- id: FILL_THIS-191
+  pioId: swsh11-191
+  enumId: FANTINA_191
+  name: Fantina
+  number: '191'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - You can use this card only if you have 10 or more cards in the Lost Zone. During
+    your opponent's next turn, all of your Pokémon take 120 less damage from attacks
+    from your opponent's Pokémon V (after applying Weakness and Resistance). (This
+    includes Pokémon that come into play during that turn.)
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-157
+  variantType: Full Art
+- id: FILL_THIS-192
+  pioId: swsh11-192
+  enumId: ISCAN_192
+  name: Iscan
+  number: '192'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 2 cards. If your Active Pokémon has "Hisuian" in its name, draw 2 more cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-158
+  variantType: Full Art
+- id: FILL_THIS-193
+  pioId: swsh11-193
+  enumId: LADY_193
+  name: Lady
+  number: '193'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Search your deck for up to 4 basic Energy cards, reveal them, and put them into
+    your hand. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-159
+  variantType: Full Art
+- id: FILL_THIS-194
+  pioId: swsh11-194
+  enumId: MISS_FORTUNE_SISTERS_194
+  name: Miss Fortune Sisters
+  number: '194'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Look at the top 5 cards of your opponent's deck and discard any number of Item
+    cards you find there. Your opponent shuffles the other cards back into their deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-164
+  variantType: Full Art
+- id: FILL_THIS-195
+  pioId: swsh11-195
+  enumId: THORTON_195
+  name: Thorton
+  number: '195'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Choose a Basic Pokémon in your discard pile and switch it with 1 of your Basic
+    Pokémon in play. Any attached cards, damage counters, Special Conditions, turns
+    in play, and any other effects remain on the new Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-167
+  variantType: Full Art
+- id: FILL_THIS-196
+  pioId: swsh11-196
+  enumId: VOLO_196
+  name: Volo
+  number: '196'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Discard 1 of your Benched Pokémon V and all attached cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-169
+  variantType: Full Art
+- id: FILL_THIS-197
+  pioId: swsh11-197
+  enumId: KYUREM_VMAX_197
+  name: Kyurem VMAX
+  number: '197'
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Kyurem V
+  hp: 330
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Glaciated World
+    text: Once during your turn, you may discard the top card of your deck. If that
+      card is a [W] Energy card, attach it to 1 of your Pokémon.
+  moves:
+  - cost: [W, W, W]
+    name: Max Frost
+    damage: 120+
+    text: You may discard any amount of [W] Energy from this Pokémon. This attack
+      does 50 more damage for each card you discarded in this way.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  variantOf: FILL_THIS-49
+  variantType: Full Art
+- id: FILL_THIS-198
+  pioId: swsh11-198
+  enumId: MAGNEZONE_VSTAR_198
+  name: Magnezone VSTAR
+  number: '198'
+  types: [L]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Magnezone V
+  hp: 270
+  retreatCost: 2
+  moves:
+  - cost: [L, C, C]
+    name: Magnetic Grip
+    damage: '180'
+    text: Search your deck for up to 2 Item cards, reveal them, and put them into
+      your hand. Then, shuffle your deck.
+  - cost: [L, L]
+    name: Electro Star
+    text: This attack does 90 damage to 2 of your opponent's Benched Pokémon. (Don't
+      apply Weakness and Resistance for Benched Pokémon.) (You can't use more than
+      1 VSTAR Power in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  variantOf: FILL_THIS-57
+  variantType: Full Art
+- id: FILL_THIS-199
+  pioId: swsh11-199
+  enumId: AERODACTYL_VSTAR_199
+  name: Aerodactyl VSTAR
+  number: '199'
+  types: [F]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Aerodactyl V
+  hp: 260
+  retreatCost: 2
+  moves:
+  - cost: [F, C, C]
+    name: Lost Dive
+    damage: '240'
+    text: Put the top 3 cards of your deck in the Lost Zone.
+  - cost: [C]
+    name: Ancient Star
+    text: Until this Pokémon leaves play, it gains an Ability that has the effect
+      "Your opponent's Pokémon V in play, except any Aerodactyl VSTAR, have no Abilities."
+      (You can't use more than 1 VSTAR Power in a game.)
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  variantOf: FILL_THIS-93
+  variantType: Full Art
+- id: FILL_THIS-200
+  pioId: swsh11-200
+  enumId: DRAPION_VSTAR_200
+  name: Drapion VSTAR
+  number: '200'
+  types: [D]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Drapion V
+  hp: 270
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Hazard Star
+    text: During your turn, you may make your opponent's Active Pokémon Paralyzed
+      and Poisoned. During Pokémon Checkup, put 3 damage counters on that Pokémon
+      instead of 1. (You can't use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [D, D, C]
+    name: Big Bang Arm
+    damage: 250-
+    text: This attack does 10 less damage for each damage counter on this Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  variantOf: FILL_THIS-119
+  variantType: Full Art
+- id: FILL_THIS-201
+  pioId: swsh11-201
+  enumId: GIRATINA_VSTAR_201
+  name: Giratina VSTAR
+  number: '201'
+  types: [N]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Giratina V
+  hp: 280
+  retreatCost: 2
+  moves:
+  - cost: [G, P, C]
+    name: Lost Impact
+    damage: '280'
+    text: Put 2 Energy attached to your Pokémon in the Lost Zone.
+  - cost: [G, P]
+    name: Star Requiem
+    text: You can use this attack only if you have 10 or more cards in the Lost Zone.
+      Your opponent's Active Pokémon is Knocked Out. (You can't use more than 1 VSTAR
+      Power in a game.)
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  variantOf: FILL_THIS-131
+  variantType: Full Art
+- id: FILL_THIS-202
+  pioId: swsh11-202
+  enumId: HISUIAN_GOODRA_VSTAR_202
+  name: Hisuian Goodra VSTAR
+  number: '202'
+  types: [N]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Hisuian Goodra V
+  hp: 270
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Moisture Star
+    text: During your turn, you may heal all damage from this Pokémon. (You can't
+      use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [W, M, C]
+    name: Rolling Iron
+    damage: '200'
+    text: During your opponent's next turn, this Pokémon takes 80 less damage from
+      attacks (after applying Weakness and Resistance).
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  variantOf: FILL_THIS-136
+  variantType: Full Art
+- id: FILL_THIS-203
+  pioId: swsh11-203
+  enumId: HISUIAN_ZOROARK_VSTAR_203
+  name: Hisuian Zoroark VSTAR
+  number: '203'
+  types: [C]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Hisuian Zoroark V
+  hp: 270
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Phantom Star
+    text: During your turn, you may discard your hand and draw 7 cards. (You can't
+      use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [C, C]
+    name: Ticking Curse
+    damage: 50x
+    text: This attack does 50 damage for each of your Pokémon that has any damage
+      counters on it.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  variantOf: FILL_THIS-147
+  variantType: Full Art
+- id: FILL_THIS-204
+  pioId: swsh11-204
+  enumId: AREZU_204
+  name: Arezu
+  number: '204'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Search your deck for up to 3 Evolution Pokémon that don't have a Rule Box, reveal
+    them, and put them into your hand. Then, shuffle your deck. (Pokémon V, Pokémon-GX,
+    etc. have Rule Boxes.)
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-153
+  variantType: Full Art
+- id: FILL_THIS-205
+  pioId: swsh11-205
+  enumId: COLRESS_S_EXPERIMENT_205
+  name: Colress's Experiment
+  number: '205'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Look at the top 5 cards of your deck and put 3 of them into your hand. Put the
+    other cards in the Lost Zone.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-155
+  variantType: Full Art
+- id: FILL_THIS-206
+  pioId: swsh11-206
+  enumId: FANTINA_206
+  name: Fantina
+  number: '206'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - You can use this card only if you have 10 or more cards in the Lost Zone. During
+    your opponent's next turn, all of your Pokémon take 120 less damage from attacks
+    from your opponent's Pokémon V (after applying Weakness and Resistance). (This
+    includes Pokémon that come into play during that turn.)
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-157
+  variantType: Full Art
+- id: FILL_THIS-207
+  pioId: swsh11-207
+  enumId: ISCAN_207
+  name: Iscan
+  number: '207'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 2 cards. If your Active Pokémon has "Hisuian" in its name, draw 2 more cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-158
+  variantType: Full Art
+- id: FILL_THIS-208
+  pioId: swsh11-208
+  enumId: LADY_208
+  name: Lady
+  number: '208'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Search your deck for up to 4 basic Energy cards, reveal them, and put them into
+    your hand. Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-159
+  variantType: Full Art
+- id: FILL_THIS-209
+  pioId: swsh11-209
+  enumId: MISS_FORTUNE_SISTERS_209
+  name: Miss Fortune Sisters
+  number: '209'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Look at the top 5 cards of your opponent's deck and discard any number of Item
+    cards you find there. Your opponent shuffles the other cards back into their deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-164
+  variantType: Full Art
+- id: FILL_THIS-210
+  pioId: swsh11-210
+  enumId: THORTON_210
+  name: Thorton
+  number: '210'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Choose a Basic Pokémon in your discard pile and switch it with 1 of your Basic
+    Pokémon in play. Any attached cards, damage counters, Special Conditions, turns
+    in play, and any other effects remain on the new Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-167
+  variantType: Full Art
+- id: FILL_THIS-211
+  pioId: swsh11-211
+  enumId: VOLO_211
+  name: Volo
+  number: '211'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Discard 1 of your Benched Pokémon V and all attached cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  variantOf: FILL_THIS-169
+  variantType: Full Art
+- id: FILL_THIS-212
+  pioId: swsh11-212
+  enumId: GIRATINA_VSTAR_212
+  name: Giratina VSTAR
+  number: '212'
+  types: [N]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Giratina V
+  hp: 280
+  retreatCost: 2
+  moves:
+  - cost: [G, P, C]
+    name: Lost Impact
+    damage: '280'
+    text: Put 2 Energy attached to your Pokémon in the Lost Zone.
+  - cost: [G, P]
+    name: Star Requiem
+    text: You can use this attack only if you have 10 or more cards in the Lost Zone.
+      Your opponent's Active Pokémon is Knocked Out. (You can't use more than 1 VSTAR
+      Power in a game.)
+  rarity: Secret
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  variantOf: FILL_THIS-131
+  variantType: Secret Art
+- id: FILL_THIS-213
+  pioId: swsh11-213
+  enumId: HISUIAN_ZOROARK_VSTAR_213
+  name: Hisuian Zoroark VSTAR
+  number: '213'
+  types: [C]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Hisuian Zoroark V
+  hp: 270
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Phantom Star
+    text: During your turn, you may discard your hand and draw 7 cards. (You can't
+      use more than 1 VSTAR Power in a game.)
+  moves:
+  - cost: [C, C]
+    name: Ticking Curse
+    damage: 50x
+    text: This attack does 50 damage for each of your Pokémon that has any damage
+      counters on it.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Secret
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  variantOf: FILL_THIS-147
+  variantType: Secret Art
+- id: FILL_THIS-214
+  pioId: swsh11-214
+  enumId: BOX_OF_DISASTER_214
+  name: Box of Disaster
+  number: '214'
+  superType: TRAINER
+  subTypes: [ITEM, ITEM, POKEMON_TOOL]
+  rarity: Secret
+  text:
+  - If the Pokémon V this card is attached to has full HP and is Knocked Out by damage
+    from an attack from your opponent's Pokémon, put 8 damage counters on the Attacking
+    Pokémon.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn''t already
+    have a Pokémon Tool attached.'
+  variantOf: FILL_THIS-154
+  variantType: Secret Art
+- id: FILL_THIS-215
+  pioId: swsh11-215
+  enumId: COLLAPSED_STADIUM_215
+  name: Collapsed Stadium
+  number: '215'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Secret
+  text:
+  - Each player can't have more than 4 Benched Pokémon. If a player has 5 or more
+    Benched Pokémon, they discard Benched Pokémon until they have 4 Pokémon on the
+    Bench. The player who played this card discards first. If more than one effect
+    changes the number of Benched Pokémon allowed, use the smaller number.
+- id: FILL_THIS-216
+  pioId: swsh11-216
+  enumId: DARK_PATCH_216
+  name: Dark Patch
+  number: '216'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Secret
+  text:
+  - Attach a basic [D] Energy card from your discard pile to 1 of your Benched [D]
+    Pokémon.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+- id: FILL_THIS-217
+  pioId: swsh11-217
+  enumId: LOST_VACUUM_217
+  name: Lost Vacuum
+  number: '217'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Secret
+  text:
+  - You can use this card only if you put another card from your hand in the Lost
+    Zone. Choose a Pokémon Tool attached to any Pokémon, or any Stadium in play, and
+    put it in the Lost Zone.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  variantOf: FILL_THIS-162
+  variantType: Secret Art

--- a/data/src/main/resources/cards/443-lost_origins.yaml
+++ b/data/src/main/resources/cards/443-lost_origins.yaml
@@ -1,10 +1,10 @@
-id: FILL_THIS
+id: '443'
 name: swsh11
-enumId: FILL_THIS
-abbr: FILL_THIS
+enumId: LOST_ORIGINS
+abbr: LOR
 pioId: swsh11
 cards:
-- id: FILL_THIS-1
+- id: 443-1
   pioId: swsh11-1
   enumId: ODDISH_1
   name: Oddish
@@ -24,7 +24,7 @@ cards:
     value: x2
   rarity: Common
   artist: Miki Tanaka
-- id: FILL_THIS-2
+- id: 443-2
   pioId: swsh11-2
   enumId: GLOOM_2
   name: Gloom
@@ -46,7 +46,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Tomokazu Komiya
-- id: FILL_THIS-3
+- id: 443-3
   pioId: swsh11-3
   enumId: VILEPLUME_3
   name: Vileplume
@@ -73,7 +73,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Jiro Sasumo
-- id: FILL_THIS-4
+- id: 443-4
   pioId: swsh11-4
   enumId: PARAS_4
   name: Paras
@@ -94,7 +94,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mizue
-- id: FILL_THIS-5
+- id: 443-5
   pioId: swsh11-5
   enumId: PARASECT_5
   name: Parasect
@@ -120,7 +120,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Pani Kobayashi
-- id: FILL_THIS-6
+- id: 443-6
   pioId: swsh11-6
   enumId: WURMPLE_6
   name: Wurmple
@@ -144,7 +144,7 @@ cards:
     value: x2
   rarity: Common
   artist: ryoma uratsuka
-- id: FILL_THIS-7
+- id: 443-7
   pioId: swsh11-7
   enumId: SILCOON_7
   name: Silcoon
@@ -169,7 +169,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Kagemaru Himeno
-- id: FILL_THIS-8
+- id: 443-8
   pioId: swsh11-8
   enumId: BEAUTIFLY_8
   name: Beautifly
@@ -195,7 +195,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Yuu Nishida
-- id: FILL_THIS-9
+- id: 443-9
   pioId: swsh11-9
   enumId: CASCOON_9
   name: Cascoon
@@ -220,7 +220,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: GOSSAN
-- id: FILL_THIS-10
+- id: 443-10
   pioId: swsh11-10
   enumId: DUSTOX_10
   name: Dustox
@@ -244,7 +244,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Mitsuhiro Arita
-- id: FILL_THIS-11
+- id: 443-11
   pioId: swsh11-11
   enumId: SEEDOT_11
   name: Seedot
@@ -265,7 +265,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yuka Morii
-- id: FILL_THIS-12
+- id: 443-12
   pioId: swsh11-12
   enumId: NUZLEAF_12
   name: Nuzleaf
@@ -288,7 +288,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Mizue
-- id: FILL_THIS-13
+- id: 443-13
   pioId: swsh11-13
   enumId: SHIFTRY_13
   name: Shiftry
@@ -314,7 +314,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: kawayoo
-- id: FILL_THIS-14
+- id: 443-14
   pioId: swsh11-14
   enumId: ROSELIA_14
   name: Roselia
@@ -334,7 +334,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yukiko Baba
-- id: FILL_THIS-15
+- id: 443-15
   pioId: swsh11-15
   enumId: ROSERADE_15
   name: Roserade
@@ -361,7 +361,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: '0313'
-- id: FILL_THIS-16
+- id: 443-16
   pioId: swsh11-16
   enumId: PHANTUMP_16
   name: Phantump
@@ -381,7 +381,7 @@ cards:
     value: x2
   rarity: Common
   artist: AKIRA EGAWA
-- id: FILL_THIS-17
+- id: 443-17
   pioId: swsh11-17
   enumId: TREVENANT_17
   name: Trevenant
@@ -407,7 +407,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Yuya Oka
-- id: FILL_THIS-18
+- id: 443-18
   pioId: swsh11-18
   enumId: BLIPBUG_18
   name: Blipbug
@@ -427,7 +427,7 @@ cards:
     value: x2
   rarity: Common
   artist: Asako Ito
-- id: FILL_THIS-19
+- id: 443-19
   pioId: swsh11-19
   enumId: DOTTLER_19
   name: Dottler
@@ -450,7 +450,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Kyoko Umemoto
-- id: FILL_THIS-20
+- id: 443-20
   pioId: swsh11-20
   enumId: ORBEETLE_20
   name: Orbeetle
@@ -478,7 +478,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: yuu
-- id: FILL_THIS-21
+- id: 443-21
   pioId: swsh11-21
   enumId: SLUGMA_21
   name: Slugma
@@ -501,7 +501,7 @@ cards:
     value: x2
   rarity: Common
   artist: Scav
-- id: FILL_THIS-22
+- id: 443-22
   pioId: swsh11-22
   enumId: MAGCARGO_22
   name: Magcargo
@@ -525,7 +525,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Pani Kobayashi
-- id: FILL_THIS-23
+- id: 443-23
   pioId: swsh11-23
   enumId: TORKOAL_23
   name: Torkoal
@@ -548,7 +548,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Naoyo Kimura
-- id: FILL_THIS-24
+- id: 443-24
   pioId: swsh11-24
   enumId: LITWICK_24
   name: Litwick
@@ -568,7 +568,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yuka Morii
-- id: FILL_THIS-25
+- id: 443-25
   pioId: swsh11-25
   enumId: LAMPENT_25
   name: Lampent
@@ -590,7 +590,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: kurumitsu
-- id: FILL_THIS-26
+- id: 443-26
   pioId: swsh11-26
   enumId: CHANDELURE_26
   name: Chandelure
@@ -615,7 +615,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: sui
-- id: FILL_THIS-27
+- id: 443-27
   pioId: swsh11-27
   enumId: DELPHOX_V_27
   name: Delphox V
@@ -642,7 +642,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-28
+- id: 443-28
   pioId: swsh11-28
   enumId: LITLEO_28
   name: Litleo
@@ -662,7 +662,7 @@ cards:
     value: x2
   rarity: Common
   artist: Sekio
-- id: FILL_THIS-29
+- id: 443-29
   pioId: swsh11-29
   enumId: PYROAR_29
   name: Pyroar
@@ -688,7 +688,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Misa Tsutsui
-- id: FILL_THIS-30
+- id: 443-30
   pioId: swsh11-30
   enumId: POLIWAG_30
   name: Poliwag
@@ -710,7 +710,7 @@ cards:
     value: x2
   rarity: Common
   artist: Miki Tanaka
-- id: FILL_THIS-31
+- id: 443-31
   pioId: swsh11-31
   enumId: POLIWHIRL_31
   name: Poliwhirl
@@ -735,7 +735,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Scav
-- id: FILL_THIS-32
+- id: 443-32
   pioId: swsh11-32
   enumId: POLITOED_32
   name: Politoed
@@ -760,7 +760,7 @@ cards:
     value: x2
   rarity: Rare
   artist: ryoma uratsuka
-- id: FILL_THIS-33
+- id: 443-33
   pioId: swsh11-33
   enumId: SEEL_33
   name: Seel
@@ -783,7 +783,7 @@ cards:
     value: x2
   rarity: Common
   artist: GIDORA
-- id: FILL_THIS-34
+- id: 443-34
   pioId: swsh11-34
   enumId: DEWGONG_34
   name: Dewgong
@@ -810,7 +810,7 @@ cards:
     value: x2
   rarity: Rare
   artist: chibi
-- id: FILL_THIS-35
+- id: 443-35
   pioId: swsh11-35
   enumId: HORSEA_35
   name: Horsea
@@ -831,7 +831,7 @@ cards:
     value: x2
   rarity: Common
   artist: Tika Matsuno
-- id: FILL_THIS-36
+- id: 443-36
   pioId: swsh11-36
   enumId: SEADRA_36
   name: Seadra
@@ -859,7 +859,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: sui
-- id: FILL_THIS-37
+- id: 443-37
   pioId: swsh11-37
   enumId: KINGDRA_37
   name: Kingdra
@@ -885,7 +885,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: AKIRA EGAWA
-- id: FILL_THIS-38
+- id: 443-38
   pioId: swsh11-38
   enumId: LUVDISC_38
   name: Luvdisc
@@ -907,7 +907,7 @@ cards:
     value: x2
   rarity: Common
   artist: Sekio
-- id: FILL_THIS-39
+- id: 443-39
   pioId: swsh11-39
   enumId: SHELLOS_39
   name: Shellos
@@ -930,7 +930,7 @@ cards:
     value: x2
   rarity: Common
   artist: Saya Tsuruta
-- id: FILL_THIS-40
+- id: 443-40
   pioId: swsh11-40
   enumId: FINNEON_40
   name: Finneon
@@ -955,7 +955,7 @@ cards:
     value: x2
   rarity: Common
   artist: Taira Akitsu
-- id: FILL_THIS-41
+- id: 443-41
   pioId: swsh11-41
   enumId: LUMINEON_41
   name: Lumineon
@@ -980,7 +980,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: zig
-- id: FILL_THIS-42
+- id: 443-42
   pioId: swsh11-42
   enumId: SNOVER_42
   name: Snover
@@ -1003,7 +1003,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mitsuhiro Arita
-- id: FILL_THIS-43
+- id: 443-43
   pioId: swsh11-43
   enumId: ABOMASNOW_43
   name: Abomasnow
@@ -1027,7 +1027,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: kodama
-- id: FILL_THIS-44
+- id: 443-44
   pioId: swsh11-44
   enumId: HISUIAN_BASCULIN_44
   name: Hisuian Basculin
@@ -1047,7 +1047,7 @@ cards:
     value: x2
   rarity: Common
   artist: Oswaldo KATO
-- id: FILL_THIS-45
+- id: 443-45
   pioId: swsh11-45
   enumId: HISUIAN_BASCULEGION_45
   name: Hisuian Basculegion
@@ -1073,7 +1073,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: AKIRA EGAWA
-- id: FILL_THIS-46
+- id: 443-46
   pioId: swsh11-46
   enumId: DUCKLETT_46
   name: Ducklett
@@ -1096,7 +1096,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Yuka Morii
-- id: FILL_THIS-47
+- id: 443-47
   pioId: swsh11-47
   enumId: SWANNA_47
   name: Swanna
@@ -1124,7 +1124,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Sekio
-- id: FILL_THIS-48
+- id: 443-48
   pioId: swsh11-48
   enumId: KYUREM_V_48
   name: Kyurem V
@@ -1149,7 +1149,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: takuyoa
-- id: FILL_THIS-49
+- id: 443-49
   pioId: swsh11-49
   enumId: KYUREM_VMAX_49
   name: Kyurem VMAX
@@ -1179,7 +1179,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: N-DESIGN Inc.
-- id: FILL_THIS-50
+- id: 443-50
   pioId: swsh11-50
   enumId: CRAMORANT_50
   name: Cramorant
@@ -1204,7 +1204,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Midori Harada
-- id: FILL_THIS-51
+- id: 443-51
   pioId: swsh11-51
   enumId: GLASTRIER_51
   name: Glastrier
@@ -1229,7 +1229,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Jiro Sasumo
-- id: FILL_THIS-52
+- id: 443-52
   pioId: swsh11-52
   enumId: PIKACHU_52
   name: Pikachu
@@ -1254,7 +1254,7 @@ cards:
     value: x2
   rarity: Common
   artist: kurumitsu
-- id: FILL_THIS-53
+- id: 443-53
   pioId: swsh11-53
   enumId: RAICHU_53
   name: Raichu
@@ -1279,7 +1279,7 @@ cards:
     value: x2
   rarity: Rare
   artist: GIDORA
-- id: FILL_THIS-54
+- id: 443-54
   pioId: swsh11-54
   enumId: ELECTRIKE_54
   name: Electrike
@@ -1303,7 +1303,7 @@ cards:
     value: x2
   rarity: Common
   artist: otumami
-- id: FILL_THIS-55
+- id: 443-55
   pioId: swsh11-55
   enumId: MANECTRIC_55
   name: Manectric
@@ -1328,7 +1328,7 @@ cards:
     value: x2
   rarity: Rare
   artist: GIDORA
-- id: FILL_THIS-56
+- id: 443-56
   pioId: swsh11-56
   enumId: MAGNEZONE_V_56
   name: Magnezone V
@@ -1355,7 +1355,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: N-DESIGN Inc.
-- id: FILL_THIS-57
+- id: 443-57
   pioId: swsh11-57
   enumId: MAGNEZONE_VSTAR_57
   name: Magnezone VSTAR
@@ -1385,7 +1385,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: PLANETA Mochizuki
-- id: FILL_THIS-58
+- id: 443-58
   pioId: swsh11-58
   enumId: ROTOM_V_58
   name: Rotom V
@@ -1414,7 +1414,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-59
+- id: 443-59
   pioId: swsh11-59
   enumId: TYNAMO_59
   name: Tynamo
@@ -1438,7 +1438,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yukiko Baba
-- id: FILL_THIS-60
+- id: 443-60
   pioId: swsh11-60
   enumId: EELEKTRIK_60
   name: Eelektrik
@@ -1465,7 +1465,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Uta
-- id: FILL_THIS-61
+- id: 443-61
   pioId: swsh11-61
   enumId: EELEKTROSS_61
   name: Eelektross
@@ -1491,7 +1491,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Shin Nagasawa
-- id: FILL_THIS-62
+- id: 443-62
   pioId: swsh11-62
   enumId: CLEFAIRY_62
   name: Clefairy
@@ -1518,7 +1518,7 @@ cards:
     value: x2
   rarity: Common
   artist: Kouki Saitou
-- id: FILL_THIS-63
+- id: 443-63
   pioId: swsh11-63
   enumId: CLEFABLE_63
   name: Clefable
@@ -1544,7 +1544,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Sekio
-- id: FILL_THIS-64
+- id: 443-64
   pioId: swsh11-64
   enumId: GASTLY_64
   name: Gastly
@@ -1566,7 +1566,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Tika Matsuno
-- id: FILL_THIS-65
+- id: 443-65
   pioId: swsh11-65
   enumId: HAUNTER_65
   name: Haunter
@@ -1590,7 +1590,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Kouki Saitou
-- id: FILL_THIS-66
+- id: 443-66
   pioId: swsh11-66
   enumId: GENGAR_66
   name: Gengar
@@ -1619,7 +1619,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Narumi Sato
-- id: FILL_THIS-67
+- id: 443-67
   pioId: swsh11-67
   enumId: MR_MIME_67
   name: Mr. Mime
@@ -1647,7 +1647,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Souichirou Gunjima
-- id: FILL_THIS-68
+- id: 443-68
   pioId: swsh11-68
   enumId: JYNX_68
   name: Jynx
@@ -1673,7 +1673,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Nagomi Nijo
-- id: FILL_THIS-69
+- id: 443-69
   pioId: swsh11-69
   enumId: RADIANT_GARDEVOIR_69
   name: Radiant Gardevoir
@@ -1701,7 +1701,7 @@ cards:
   text:
   - 'Radiant Pokémon Rule: You cant have more than 1 Radiant Pokémon in your deck.'
   artist: Ryuta Fuse
-- id: FILL_THIS-70
+- id: 443-70
   pioId: swsh11-70
   enumId: SABLEYE_70
   name: Sableye
@@ -1727,7 +1727,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Shibuzoh.
-- id: FILL_THIS-71
+- id: 443-71
   pioId: swsh11-71
   enumId: MAWILE_71
   name: Mawile
@@ -1751,7 +1751,7 @@ cards:
     value: x2
   rarity: Common
   artist: kurumitsu
-- id: FILL_THIS-72
+- id: 443-72
   pioId: swsh11-72
   enumId: SHUPPET_72
   name: Shuppet
@@ -1774,7 +1774,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Kouki Saitou
-- id: FILL_THIS-73
+- id: 443-73
   pioId: swsh11-73
   enumId: BANETTE_73
   name: Banette
@@ -1803,7 +1803,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Kagemaru Himeno
-- id: FILL_THIS-74
+- id: 443-74
   pioId: swsh11-74
   enumId: CRESSELIA_74
   name: Cresselia
@@ -1829,7 +1829,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: saino misaki
-- id: FILL_THIS-75
+- id: 443-75
   pioId: swsh11-75
   enumId: HISUIAN_ZORUA_75
   name: Hisuian Zorua
@@ -1855,7 +1855,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Akira Komayama
-- id: FILL_THIS-76
+- id: 443-76
   pioId: swsh11-76
   enumId: HISUIAN_ZOROARK_76
   name: Hisuian Zoroark
@@ -1882,7 +1882,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Kouki Saitou
-- id: FILL_THIS-77
+- id: 443-77
   pioId: swsh11-77
   enumId: INKAY_77
   name: Inkay
@@ -1906,7 +1906,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: miki kudo
-- id: FILL_THIS-78
+- id: 443-78
   pioId: swsh11-78
   enumId: MALAMAR_78
   name: Malamar
@@ -1934,7 +1934,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Tomokazu Komiya
-- id: FILL_THIS-79
+- id: 443-79
   pioId: swsh11-79
   enumId: COMFEY_79
   name: Comfey
@@ -1959,7 +1959,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Aya Kusube
-- id: FILL_THIS-80
+- id: 443-80
   pioId: swsh11-80
   enumId: MIMIKYU_80
   name: Mimikyu
@@ -1986,7 +1986,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Ligton
-- id: FILL_THIS-81
+- id: 443-81
   pioId: swsh11-81
   enumId: SPECTRIER_81
   name: Spectrier
@@ -2013,7 +2013,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Narumi Sato
-- id: FILL_THIS-82
+- id: 443-82
   pioId: swsh11-82
   enumId: ENAMORUS_V_82
   name: Enamorus V
@@ -2041,7 +2041,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-83
+- id: 443-83
   pioId: swsh11-83
   enumId: HISUIAN_GROWLITHE_83
   name: Hisuian Growlithe
@@ -2061,7 +2061,7 @@ cards:
     value: x2
   rarity: Common
   artist: Kouki Saitou
-- id: FILL_THIS-84
+- id: 443-84
   pioId: swsh11-84
   enumId: HISUIAN_ARCANINE_84
   name: Hisuian Arcanine
@@ -2085,7 +2085,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Oswaldo KATO
-- id: FILL_THIS-85
+- id: 443-85
   pioId: swsh11-85
   enumId: POLIWRATH_85
   name: Poliwrath
@@ -2110,7 +2110,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Teeziro
-- id: FILL_THIS-86
+- id: 443-86
   pioId: swsh11-86
   enumId: MACHOP_86
   name: Machop
@@ -2130,7 +2130,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yuka Morii
-- id: FILL_THIS-87
+- id: 443-87
   pioId: swsh11-87
   enumId: MACHOKE_87
   name: Machoke
@@ -2154,7 +2154,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Mitsuhiro Arita
-- id: FILL_THIS-88
+- id: 443-88
   pioId: swsh11-88
   enumId: MACHAMP_88
   name: Machamp
@@ -2180,7 +2180,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Nisota Niso
-- id: FILL_THIS-89
+- id: 443-89
   pioId: swsh11-89
   enumId: RHYHORN_89
   name: Rhyhorn
@@ -2201,7 +2201,7 @@ cards:
     value: x2
   rarity: Common
   artist: Scav
-- id: FILL_THIS-90
+- id: 443-90
   pioId: swsh11-90
   enumId: RHYDON_90
   name: Rhydon
@@ -2226,7 +2226,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: HYOGONOSUKE
-- id: FILL_THIS-91
+- id: 443-91
   pioId: swsh11-91
   enumId: RHYPERIOR_91
   name: Rhyperior
@@ -2252,7 +2252,7 @@ cards:
     value: x2
   rarity: Rare
   artist: GOSSAN
-- id: FILL_THIS-92
+- id: 443-92
   pioId: swsh11-92
   enumId: AERODACTYL_V_92
   name: Aerodactyl V
@@ -2277,7 +2277,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: N-DESIGN Inc.
-- id: FILL_THIS-93
+- id: 443-93
   pioId: swsh11-93
   enumId: AERODACTYL_VSTAR_93
   name: Aerodactyl VSTAR
@@ -2306,7 +2306,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-94
+- id: 443-94
   pioId: swsh11-94
   enumId: SUDOWOODO_94
   name: Sudowoodo
@@ -2331,7 +2331,7 @@ cards:
     value: x2
   rarity: Common
   artist: AKIRA EGAWA
-- id: FILL_THIS-95
+- id: 443-95
   pioId: swsh11-95
   enumId: GLIGAR_95
   name: Gligar
@@ -2352,7 +2352,7 @@ cards:
     value: x2
   rarity: Common
   artist: Miki Tanaka
-- id: FILL_THIS-96
+- id: 443-96
   pioId: swsh11-96
   enumId: GLISCOR_96
   name: Gliscor
@@ -2374,7 +2374,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Shiburingaru
-- id: FILL_THIS-97
+- id: 443-97
   pioId: swsh11-97
   enumId: MAKUHITA_97
   name: Makuhita
@@ -2395,7 +2395,7 @@ cards:
     value: x2
   rarity: Common
   artist: Shigenori Negishi
-- id: FILL_THIS-98
+- id: 443-98
   pioId: swsh11-98
   enumId: HARIYAMA_98
   name: Hariyama
@@ -2420,7 +2420,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Scav
-- id: FILL_THIS-99
+- id: 443-99
   pioId: swsh11-99
   enumId: MEDITITE_99
   name: Meditite
@@ -2441,7 +2441,7 @@ cards:
     value: x2
   rarity: Common
   artist: '0313'
-- id: FILL_THIS-100
+- id: 443-100
   pioId: swsh11-100
   enumId: MEDICHAM_100
   name: Medicham
@@ -2463,7 +2463,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Kouki Saitou
-- id: FILL_THIS-101
+- id: 443-101
   pioId: swsh11-101
   enumId: RELICANTH_101
   name: Relicanth
@@ -2485,7 +2485,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: ryoma uratsuka
-- id: FILL_THIS-102
+- id: 443-102
   pioId: swsh11-102
   enumId: GASTRODON_102
   name: Gastrodon
@@ -2510,7 +2510,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Sanosuke Sakuma
-- id: FILL_THIS-103
+- id: 443-103
   pioId: swsh11-103
   enumId: MIENFOO_103
   name: Mienfoo
@@ -2533,7 +2533,7 @@ cards:
     value: x2
   rarity: Common
   artist: yuu
-- id: FILL_THIS-104
+- id: 443-104
   pioId: swsh11-104
   enumId: MIENSHAO_104
   name: Mienshao
@@ -2557,7 +2557,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Shibuzoh.
-- id: FILL_THIS-105
+- id: 443-105
   pioId: swsh11-105
   enumId: LANDORUS_105
   name: Landorus
@@ -2580,7 +2580,7 @@ cards:
     value: x2
   rarity: Rare
   artist: KEIICHIRO ITO
-- id: FILL_THIS-106
+- id: 443-106
   pioId: swsh11-106
   enumId: BINACLE_106
   name: Binacle
@@ -2603,7 +2603,7 @@ cards:
     value: x2
   rarity: Common
   artist: Scav
-- id: FILL_THIS-107
+- id: 443-107
   pioId: swsh11-107
   enumId: BARBARACLE_107
   name: Barbaracle
@@ -2628,7 +2628,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: KEIICHIRO ITO
-- id: FILL_THIS-108
+- id: 443-108
   pioId: swsh11-108
   enumId: CARBINK_108
   name: Carbink
@@ -2651,7 +2651,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Tika Matsuno
-- id: FILL_THIS-109
+- id: 443-109
   pioId: swsh11-109
   enumId: ROCKRUFF_109
   name: Rockruff
@@ -2674,7 +2674,7 @@ cards:
     value: x2
   rarity: Common
   artist: Miki Tanaka
-- id: FILL_THIS-110
+- id: 443-110
   pioId: swsh11-110
   enumId: FALINKS_110
   name: Falinks
@@ -2698,7 +2698,7 @@ cards:
     value: x2
   rarity: Common
   artist: sowsow
-- id: FILL_THIS-111
+- id: 443-111
   pioId: swsh11-111
   enumId: STONJOURNER_111
   name: Stonjourner
@@ -2722,7 +2722,7 @@ cards:
     value: x2
   rarity: Rare
   artist: HYOGONOSUKE
-- id: FILL_THIS-112
+- id: 443-112
   pioId: swsh11-112
   enumId: SPINARAK_112
   name: Spinarak
@@ -2743,7 +2743,7 @@ cards:
     value: x2
   rarity: Common
   artist: Atsuko Nishida
-- id: FILL_THIS-113
+- id: 443-113
   pioId: swsh11-113
   enumId: ARIADOS_113
   name: Ariados
@@ -2769,7 +2769,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Shinji Kanda
-- id: FILL_THIS-114
+- id: 443-114
   pioId: swsh11-114
   enumId: MURKROW_114
   name: Murkrow
@@ -2795,7 +2795,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Yuka Morii
-- id: FILL_THIS-115
+- id: 443-115
   pioId: swsh11-115
   enumId: HONCHKROW_115
   name: Honchkrow
@@ -2823,7 +2823,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Shiburingaru
-- id: FILL_THIS-116
+- id: 443-116
   pioId: swsh11-116
   enumId: SEVIPER_116
   name: Seviper
@@ -2843,7 +2843,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Tomokazu Komiya
-- id: FILL_THIS-117
+- id: 443-117
   pioId: swsh11-117
   enumId: SPIRITOMB_117
   name: Spiritomb
@@ -2869,7 +2869,7 @@ cards:
     value: x2
   rarity: Rare
   artist: sui
-- id: FILL_THIS-118
+- id: 443-118
   pioId: swsh11-118
   enumId: DRAPION_V_118
   name: Drapion V
@@ -2897,7 +2897,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: N-DESIGN Inc.
-- id: FILL_THIS-119
+- id: 443-119
   pioId: swsh11-119
   enumId: DRAPION_VSTAR_119
   name: Drapion VSTAR
@@ -2927,7 +2927,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: PLANETA Mochizuki
-- id: FILL_THIS-120
+- id: 443-120
   pioId: swsh11-120
   enumId: DARKRAI_120
   name: Darkrai
@@ -2951,7 +2951,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Shin Nagasawa
-- id: FILL_THIS-121
+- id: 443-121
   pioId: swsh11-121
   enumId: INKAY_121
   name: Inkay
@@ -2975,7 +2975,7 @@ cards:
     value: x2
   rarity: Common
   artist: Shibuzoh.
-- id: FILL_THIS-122
+- id: 443-122
   pioId: swsh11-122
   enumId: HOOPA_122
   name: Hoopa
@@ -2998,7 +2998,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Sanosuke Sakuma
-- id: FILL_THIS-123
+- id: 443-123
   pioId: swsh11-123
   enumId: RADIANT_HISUIAN_SNEASLER_123
   name: Radiant Hisuian Sneasler
@@ -3025,7 +3025,7 @@ cards:
   text:
   - 'Radiant Pokémon Rule: You cant have more than 1 Radiant Pokémon in your deck.'
   artist: Akira Komayama
-- id: FILL_THIS-124
+- id: 443-124
   pioId: swsh11-124
   enumId: RADIANT_STEELIX_124
   name: Radiant Steelix
@@ -3055,7 +3055,7 @@ cards:
   text:
   - 'Radiant Pokémon Rule: You cant have more than 1 Radiant Pokémon in your deck.'
   artist: Sanosuke Sakuma
-- id: FILL_THIS-125
+- id: 443-125
   pioId: swsh11-125
   enumId: BRONZOR_125
   name: Bronzor
@@ -3078,7 +3078,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Tomokazu Komiya
-- id: FILL_THIS-126
+- id: 443-126
   pioId: swsh11-126
   enumId: BRONZONG_126
   name: Bronzong
@@ -3106,7 +3106,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: AKIRA EGAWA
-- id: FILL_THIS-127
+- id: 443-127
   pioId: swsh11-127
   enumId: GALARIAN_STUNFISK_127
   name: Galarian Stunfisk
@@ -3133,7 +3133,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Shigenori Negishi
-- id: FILL_THIS-128
+- id: 443-128
   pioId: swsh11-128
   enumId: MAGEARNA_128
   name: Magearna
@@ -3160,7 +3160,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Rianti Hidayat
-- id: FILL_THIS-129
+- id: 443-129
   pioId: swsh11-129
   enumId: GALARIAN_PERRSERKER_V_129
   name: Galarian Perrserker V
@@ -3188,7 +3188,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Yamashita
-- id: FILL_THIS-130
+- id: 443-130
   pioId: swsh11-130
   enumId: GIRATINA_V_130
   name: Giratina V
@@ -3212,7 +3212,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-131
+- id: 443-131
   pioId: swsh11-131
   enumId: GIRATINA_VSTAR_131
   name: Giratina VSTAR
@@ -3238,7 +3238,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-132
+- id: 443-132
   pioId: swsh11-132
   enumId: GOOMY_132
   name: Goomy
@@ -3258,7 +3258,7 @@ cards:
     damage: '30'
   rarity: Common
   artist: Oswaldo KATO
-- id: FILL_THIS-133
+- id: 443-133
   pioId: swsh11-133
   enumId: HISUIAN_SLIGGOO_133
   name: Hisuian Sliggoo
@@ -3280,7 +3280,7 @@ cards:
     damage: '40'
   rarity: Uncommon
   artist: Kouki Saitou
-- id: FILL_THIS-134
+- id: 443-134
   pioId: swsh11-134
   enumId: HISUIAN_GOODRA_134
   name: Hisuian Goodra
@@ -3302,7 +3302,7 @@ cards:
     damage: '140'
   rarity: Rare Holo
   artist: Akira Komayama
-- id: FILL_THIS-135
+- id: 443-135
   pioId: swsh11-135
   enumId: HISUIAN_GOODRA_V_135
   name: Hisuian Goodra V
@@ -3326,7 +3326,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-136
+- id: 443-136
   pioId: swsh11-136
   enumId: HISUIAN_GOODRA_VSTAR_136
   name: Hisuian Goodra VSTAR
@@ -3353,7 +3353,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: FILL_THIS-137
+- id: 443-137
   pioId: swsh11-137
   enumId: PIDGEOT_V_137
   name: Pidgeot V
@@ -3383,7 +3383,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Saki Hayashiro
-- id: FILL_THIS-138
+- id: 443-138
   pioId: swsh11-138
   enumId: LICKITUNG_138
   name: Lickitung
@@ -3403,7 +3403,7 @@ cards:
     value: x2
   rarity: Common
   artist: KIYOTAKA OSHIYAMA
-- id: FILL_THIS-139
+- id: 443-139
   pioId: swsh11-139
   enumId: LICKILICKY_139
   name: Lickilicky
@@ -3426,7 +3426,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Shibuzoh.
-- id: FILL_THIS-140
+- id: 443-140
   pioId: swsh11-140
   enumId: PORYGON_140
   name: Porygon
@@ -3450,7 +3450,7 @@ cards:
     value: x2
   rarity: Common
   artist: kurumitsu
-- id: FILL_THIS-141
+- id: 443-141
   pioId: swsh11-141
   enumId: PORYGON2_141
   name: Porygon2
@@ -3473,7 +3473,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: OKACHEKE
-- id: FILL_THIS-142
+- id: 443-142
   pioId: swsh11-142
   enumId: PORYGON_Z_142
   name: Porygon-Z
@@ -3497,7 +3497,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Shibuzoh.
-- id: FILL_THIS-143
+- id: 443-143
   pioId: swsh11-143
   enumId: SNORLAX_143
   name: Snorlax
@@ -3523,7 +3523,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: '0313'
-- id: FILL_THIS-144
+- id: 443-144
   pioId: swsh11-144
   enumId: AIPOM_144
   name: Aipom
@@ -3547,7 +3547,7 @@ cards:
     value: x2
   rarity: Common
   artist: Kouki Saitou
-- id: FILL_THIS-145
+- id: 443-145
   pioId: swsh11-145
   enumId: AMBIPOM_145
   name: Ambipom
@@ -3572,7 +3572,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Atsushi Furusawa
-- id: FILL_THIS-146
+- id: 443-146
   pioId: swsh11-146
   enumId: HISUIAN_ZOROARK_V_146
   name: Hisuian Zoroark V
@@ -3598,7 +3598,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: aky CG Works
-- id: FILL_THIS-147
+- id: 443-147
   pioId: swsh11-147
   enumId: HISUIAN_ZOROARK_VSTAR_147
   name: Hisuian Zoroark VSTAR
@@ -3628,7 +3628,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: aky CG Works
-- id: FILL_THIS-148
+- id: 443-148
   pioId: swsh11-148
   enumId: BOUFFALANT_148
   name: Bouffalant
@@ -3651,7 +3651,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Nisota Niso
-- id: FILL_THIS-149
+- id: 443-149
   pioId: swsh11-149
   enumId: KOMALA_149
   name: Komala
@@ -3676,7 +3676,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: HYOGONOSUKE
-- id: FILL_THIS-150
+- id: 443-150
   pioId: swsh11-150
   enumId: SKWOVET_150
   name: Skwovet
@@ -3696,7 +3696,7 @@ cards:
     value: x2
   rarity: Common
   artist: Miki Tanaka
-- id: FILL_THIS-151
+- id: 443-151
   pioId: swsh11-151
   enumId: GREEDENT_151
   name: Greedent
@@ -3721,7 +3721,7 @@ cards:
     value: x2
   rarity: Rare
   artist: sui
-- id: FILL_THIS-152
+- id: 443-152
   pioId: swsh11-152
   enumId: ARC_PHONE_152
   name: Arc Phone
@@ -3733,7 +3733,7 @@ cards:
   - Look at the top card of your deck. You may switch that card with 1 of your face-down
     Prize cards. (The cards stay face down.)
   - 'Item rule: You may play any number of Item cards during your turn.'
-- id: FILL_THIS-153
+- id: 443-153
   pioId: swsh11-153
   enumId: AREZU_153
   name: Arezu
@@ -3746,7 +3746,7 @@ cards:
     them, and put them into your hand. Then, shuffle your deck. (Pokémon V, Pokémon-GX,
     etc. have Rule Boxes.)
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: FILL_THIS-154
+- id: 443-154
   pioId: swsh11-154
   enumId: BOX_OF_DISASTER_154
   name: Box of Disaster
@@ -3761,7 +3761,7 @@ cards:
   - 'Item rule: You may play any number of Item cards during your turn.'
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn''t already
     have a Pokémon Tool attached.'
-- id: FILL_THIS-155
+- id: 443-155
   pioId: swsh11-155
   enumId: COLRESS_S_EXPERIMENT_155
   name: Colress's Experiment
@@ -3773,7 +3773,7 @@ cards:
   - Look at the top 5 cards of your deck and put 3 of them into your hand. Put the
     other cards in the Lost Zone.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: FILL_THIS-156
+- id: 443-156
   pioId: swsh11-156
   enumId: DAMAGE_PUMP_156
   name: Damage Pump
@@ -3785,7 +3785,7 @@ cards:
   - Move up to 2 damage counters from 1 of your Pokémon to your other Pokémon in any
     way you like.
   - 'Item rule: You may play any number of Item cards during your turn.'
-- id: FILL_THIS-157
+- id: 443-157
   pioId: swsh11-157
   enumId: FANTINA_157
   name: Fantina
@@ -3799,7 +3799,7 @@ cards:
     from your opponent's Pokémon V (after applying Weakness and Resistance). (This
     includes Pokémon that come into play during that turn.)
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: FILL_THIS-158
+- id: 443-158
   pioId: swsh11-158
   enumId: ISCAN_158
   name: Iscan
@@ -3810,7 +3810,7 @@ cards:
   text:
   - Draw 2 cards. If your Active Pokémon has "Hisuian" in its name, draw 2 more cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: FILL_THIS-159
+- id: 443-159
   pioId: swsh11-159
   enumId: LADY_159
   name: Lady
@@ -3822,7 +3822,7 @@ cards:
   - Search your deck for up to 4 basic Energy cards, reveal them, and put them into
     your hand. Then, shuffle your deck.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: FILL_THIS-160
+- id: 443-160
   pioId: swsh11-160
   enumId: LAKE_ACUITY_160
   name: Lake Acuity
@@ -3834,7 +3834,7 @@ cards:
   - All Pokémon that have any Water or [F] Energy attached (both yours and your opponent's)
     take 20 less damage from attacks from the opponent's Pokémon (after applying Weakness
     and Resistance).
-- id: FILL_THIS-161
+- id: 443-161
   pioId: swsh11-161
   enumId: LOST_CITY_161
   name: Lost City
@@ -3845,7 +3845,7 @@ cards:
   text:
   - Whenever a Pokémon (either yours or your opponent's) is Knocked Out, put that
     Pokémon in the Lost Zone instead of the discard pile. (Discard all attached cards.)
-- id: FILL_THIS-162
+- id: 443-162
   pioId: swsh11-162
   enumId: LOST_VACUUM_162
   name: Lost Vacuum
@@ -3858,7 +3858,7 @@ cards:
     Zone. Choose a Pokémon Tool attached to any Pokémon, or any Stadium in play, and
     put it in the Lost Zone.
   - 'Item rule: You may play any number of Item cards during your turn.'
-- id: FILL_THIS-163
+- id: 443-163
   pioId: swsh11-163
   enumId: MIRAGE_GATE_163
   name: Mirage Gate
@@ -3871,7 +3871,7 @@ cards:
     your deck for up to 2 basic Energy cards of different types and attach them to
     your Pokémon in any way you like. Then, shuffle your deck.
   - 'Item rule: You may play any number of Item cards during your turn.'
-- id: FILL_THIS-164
+- id: 443-164
   pioId: swsh11-164
   enumId: MISS_FORTUNE_SISTERS_164
   name: Miss Fortune Sisters
@@ -3883,7 +3883,7 @@ cards:
   - Look at the top 5 cards of your opponent's deck and discard any number of Item
     cards you find there. Your opponent shuffles the other cards back into their deck.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: FILL_THIS-165
+- id: 443-165
   pioId: swsh11-165
   enumId: PANIC_MASK_165
   name: Panic Mask
@@ -3897,7 +3897,7 @@ cards:
   - 'Item rule: You may play any number of Item cards during your turn.'
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn''t already
     have a Pokémon Tool attached.'
-- id: FILL_THIS-166
+- id: 443-166
   pioId: swsh11-166
   enumId: RILEY_166
   name: Riley
@@ -3909,7 +3909,7 @@ cards:
   - Reveal the top 5 cards of your deck and have your opponent choose 2 of them. Discard
     the chosen cards and put the remaining cards into your hand.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: FILL_THIS-167
+- id: 443-167
   pioId: swsh11-167
   enumId: THORTON_167
   name: Thorton
@@ -3922,7 +3922,7 @@ cards:
     Pokémon in play. Any attached cards, damage counters, Special Conditions, turns
     in play, and any other effects remain on the new Pokémon.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: FILL_THIS-168
+- id: 443-168
   pioId: swsh11-168
   enumId: TOOL_BOX_168
   name: Tool Box
@@ -3935,7 +3935,7 @@ cards:
     cards you find there and put them into your hand. Shuffle the other cards back
     into your deck.
   - 'Item rule: You may play any number of Item cards during your turn.'
-- id: FILL_THIS-169
+- id: 443-169
   pioId: swsh11-169
   enumId: VOLO_169
   name: Volo
@@ -3946,7 +3946,7 @@ cards:
   text:
   - Discard 1 of your Benched Pokémon V and all attached cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: FILL_THIS-170
+- id: 443-170
   pioId: swsh11-170
   enumId: WINDUP_ARM_170
   name: Windup Arm
@@ -3959,7 +3959,7 @@ cards:
   - 'Item rule: You may play any number of Item cards during your turn.'
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn''t already
     have a Pokémon Tool attached.'
-- id: FILL_THIS-171
+- id: 443-171
   pioId: swsh11-171
   enumId: GIFT_ENERGY_171
   name: Gift Energy
@@ -3971,7 +3971,7 @@ cards:
   - As long as this card is attached to a Pokémon, it provides [C] Energy. If the
     Pokémon this card is attached to is Knocked Out by damage from an attack from
     your opponent's Pokémon, draw cards until you have 7 cards in your hand.
-- id: FILL_THIS-172
+- id: 443-172
   pioId: swsh11-172
   enumId: HISUIAN_ELECTRODE_V_172
   name: Hisuian Electrode V
@@ -3996,7 +3996,7 @@ cards:
   rarity: Ultra Rare
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
-- id: FILL_THIS-173
+- id: 443-173
   pioId: swsh11-173
   enumId: DELPHOX_V_173
   name: Delphox V
@@ -4024,7 +4024,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-27
   variantType: Full Art
-- id: FILL_THIS-174
+- id: 443-174
   pioId: swsh11-174
   enumId: KYUREM_V_174
   name: Kyurem V
@@ -4050,7 +4050,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-48
   variantType: Full Art
-- id: FILL_THIS-175
+- id: 443-175
   pioId: swsh11-175
   enumId: MAGNEZONE_V_175
   name: Magnezone V
@@ -4078,7 +4078,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-56
   variantType: Full Art
-- id: FILL_THIS-176
+- id: 443-176
   pioId: swsh11-176
   enumId: ROTOM_V_176
   name: Rotom V
@@ -4108,7 +4108,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-58
   variantType: Full Art
-- id: FILL_THIS-177
+- id: 443-177
   pioId: swsh11-177
   enumId: ROTOM_V_177
   name: Rotom V
@@ -4138,7 +4138,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-58
   variantType: Full Art
-- id: FILL_THIS-178
+- id: 443-178
   pioId: swsh11-178
   enumId: ENAMORUS_V_178
   name: Enamorus V
@@ -4167,7 +4167,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-82
   variantType: Full Art
-- id: FILL_THIS-179
+- id: 443-179
   pioId: swsh11-179
   enumId: AERODACTYL_V_179
   name: Aerodactyl V
@@ -4193,7 +4193,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-92
   variantType: Full Art
-- id: FILL_THIS-180
+- id: 443-180
   pioId: swsh11-180
   enumId: AERODACTYL_V_180
   name: Aerodactyl V
@@ -4219,7 +4219,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-92
   variantType: Full Art
-- id: FILL_THIS-181
+- id: 443-181
   pioId: swsh11-181
   enumId: GALLADE_V_181
   name: Gallade V
@@ -4244,7 +4244,7 @@ cards:
   rarity: Ultra Rare
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
-- id: FILL_THIS-182
+- id: 443-182
   pioId: swsh11-182
   enumId: DRAPION_V_182
   name: Drapion V
@@ -4273,7 +4273,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-118
   variantType: Full Art
-- id: FILL_THIS-183
+- id: 443-183
   pioId: swsh11-183
   enumId: GALARIAN_PERRSERKER_V_183
   name: Galarian Perrserker V
@@ -4302,7 +4302,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-129
   variantType: Full Art
-- id: FILL_THIS-184
+- id: 443-184
   pioId: swsh11-184
   enumId: GALARIAN_PERRSERKER_V_184
   name: Galarian Perrserker V
@@ -4331,7 +4331,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-129
   variantType: Full Art
-- id: FILL_THIS-185
+- id: 443-185
   pioId: swsh11-185
   enumId: GIRATINA_V_185
   name: Giratina V
@@ -4356,7 +4356,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-130
   variantType: Full Art
-- id: FILL_THIS-186
+- id: 443-186
   pioId: swsh11-186
   enumId: GIRATINA_V_186
   name: Giratina V
@@ -4381,7 +4381,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-130
   variantType: Full Art
-- id: FILL_THIS-187
+- id: 443-187
   pioId: swsh11-187
   enumId: HISUIAN_GOODRA_V_187
   name: Hisuian Goodra V
@@ -4406,7 +4406,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-135
   variantType: Full Art
-- id: FILL_THIS-188
+- id: 443-188
   pioId: swsh11-188
   enumId: PIDGEOT_V_188
   name: Pidgeot V
@@ -4437,7 +4437,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-137
   variantType: Full Art
-- id: FILL_THIS-189
+- id: 443-189
   pioId: swsh11-189
   enumId: AREZU_189
   name: Arezu
@@ -4452,7 +4452,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-153
   variantType: Full Art
-- id: FILL_THIS-190
+- id: 443-190
   pioId: swsh11-190
   enumId: COLRESS_S_EXPERIMENT_190
   name: Colress's Experiment
@@ -4466,7 +4466,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-155
   variantType: Full Art
-- id: FILL_THIS-191
+- id: 443-191
   pioId: swsh11-191
   enumId: FANTINA_191
   name: Fantina
@@ -4482,7 +4482,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-157
   variantType: Full Art
-- id: FILL_THIS-192
+- id: 443-192
   pioId: swsh11-192
   enumId: ISCAN_192
   name: Iscan
@@ -4495,7 +4495,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-158
   variantType: Full Art
-- id: FILL_THIS-193
+- id: 443-193
   pioId: swsh11-193
   enumId: LADY_193
   name: Lady
@@ -4509,7 +4509,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-159
   variantType: Full Art
-- id: FILL_THIS-194
+- id: 443-194
   pioId: swsh11-194
   enumId: MISS_FORTUNE_SISTERS_194
   name: Miss Fortune Sisters
@@ -4523,7 +4523,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-164
   variantType: Full Art
-- id: FILL_THIS-195
+- id: 443-195
   pioId: swsh11-195
   enumId: THORTON_195
   name: Thorton
@@ -4538,7 +4538,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-167
   variantType: Full Art
-- id: FILL_THIS-196
+- id: 443-196
   pioId: swsh11-196
   enumId: VOLO_196
   name: Volo
@@ -4551,7 +4551,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-169
   variantType: Full Art
-- id: FILL_THIS-197
+- id: 443-197
   pioId: swsh11-197
   enumId: KYUREM_VMAX_197
   name: Kyurem VMAX
@@ -4582,7 +4582,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-49
   variantType: Full Art
-- id: FILL_THIS-198
+- id: 443-198
   pioId: swsh11-198
   enumId: MAGNEZONE_VSTAR_198
   name: Magnezone VSTAR
@@ -4613,7 +4613,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-57
   variantType: Full Art
-- id: FILL_THIS-199
+- id: 443-199
   pioId: swsh11-199
   enumId: AERODACTYL_VSTAR_199
   name: Aerodactyl VSTAR
@@ -4643,7 +4643,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-93
   variantType: Full Art
-- id: FILL_THIS-200
+- id: 443-200
   pioId: swsh11-200
   enumId: DRAPION_VSTAR_200
   name: Drapion VSTAR
@@ -4674,7 +4674,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-119
   variantType: Full Art
-- id: FILL_THIS-201
+- id: 443-201
   pioId: swsh11-201
   enumId: GIRATINA_VSTAR_201
   name: Giratina VSTAR
@@ -4701,7 +4701,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-131
   variantType: Full Art
-- id: FILL_THIS-202
+- id: 443-202
   pioId: swsh11-202
   enumId: HISUIAN_GOODRA_VSTAR_202
   name: Hisuian Goodra VSTAR
@@ -4729,7 +4729,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-136
   variantType: Full Art
-- id: FILL_THIS-203
+- id: 443-203
   pioId: swsh11-203
   enumId: HISUIAN_ZOROARK_VSTAR_203
   name: Hisuian Zoroark VSTAR
@@ -4760,7 +4760,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-147
   variantType: Full Art
-- id: FILL_THIS-204
+- id: 443-204
   pioId: swsh11-204
   enumId: AREZU_204
   name: Arezu
@@ -4775,7 +4775,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-153
   variantType: Full Art
-- id: FILL_THIS-205
+- id: 443-205
   pioId: swsh11-205
   enumId: COLRESS_S_EXPERIMENT_205
   name: Colress's Experiment
@@ -4789,7 +4789,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-155
   variantType: Full Art
-- id: FILL_THIS-206
+- id: 443-206
   pioId: swsh11-206
   enumId: FANTINA_206
   name: Fantina
@@ -4805,7 +4805,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-157
   variantType: Full Art
-- id: FILL_THIS-207
+- id: 443-207
   pioId: swsh11-207
   enumId: ISCAN_207
   name: Iscan
@@ -4818,7 +4818,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-158
   variantType: Full Art
-- id: FILL_THIS-208
+- id: 443-208
   pioId: swsh11-208
   enumId: LADY_208
   name: Lady
@@ -4832,7 +4832,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-159
   variantType: Full Art
-- id: FILL_THIS-209
+- id: 443-209
   pioId: swsh11-209
   enumId: MISS_FORTUNE_SISTERS_209
   name: Miss Fortune Sisters
@@ -4846,7 +4846,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-164
   variantType: Full Art
-- id: FILL_THIS-210
+- id: 443-210
   pioId: swsh11-210
   enumId: THORTON_210
   name: Thorton
@@ -4861,7 +4861,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-167
   variantType: Full Art
-- id: FILL_THIS-211
+- id: 443-211
   pioId: swsh11-211
   enumId: VOLO_211
   name: Volo
@@ -4874,7 +4874,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-169
   variantType: Full Art
-- id: FILL_THIS-212
+- id: 443-212
   pioId: swsh11-212
   enumId: GIRATINA_VSTAR_212
   name: Giratina VSTAR
@@ -4901,7 +4901,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-131
   variantType: Secret Art
-- id: FILL_THIS-213
+- id: 443-213
   pioId: swsh11-213
   enumId: HISUIAN_ZOROARK_VSTAR_213
   name: Hisuian Zoroark VSTAR
@@ -4932,7 +4932,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-147
   variantType: Secret Art
-- id: FILL_THIS-214
+- id: 443-214
   pioId: swsh11-214
   enumId: BOX_OF_DISASTER_214
   name: Box of Disaster
@@ -4949,7 +4949,7 @@ cards:
     have a Pokémon Tool attached.'
   variantOf: FILL_THIS-154
   variantType: Secret Art
-- id: FILL_THIS-215
+- id: 443-215
   pioId: swsh11-215
   enumId: COLLAPSED_STADIUM_215
   name: Collapsed Stadium
@@ -4962,7 +4962,7 @@ cards:
     Benched Pokémon, they discard Benched Pokémon until they have 4 Pokémon on the
     Bench. The player who played this card discards first. If more than one effect
     changes the number of Benched Pokémon allowed, use the smaller number.
-- id: FILL_THIS-216
+- id: 443-216
   pioId: swsh11-216
   enumId: DARK_PATCH_216
   name: Dark Patch
@@ -4974,7 +4974,7 @@ cards:
   - Attach a basic [D] Energy card from your discard pile to 1 of your Benched [D]
     Pokémon.
   - 'Item rule: You may play any number of Item cards during your turn.'
-- id: FILL_THIS-217
+- id: 443-217
   pioId: swsh11-217
   enumId: LOST_VACUUM_217
   name: Lost Vacuum

--- a/data/src/main/resources/cards/443-pokemon_go.yaml
+++ b/data/src/main/resources/cards/443-pokemon_go.yaml
@@ -750,7 +750,7 @@ cards:
   number: '31'
   types: [P]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Mewtwo V
   hp: 280
   retreatCost: 2
@@ -1243,7 +1243,7 @@ cards:
   number: '50'
   types: [N]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Dragonite V
   hp: 280
   retreatCost: 2
@@ -1899,7 +1899,7 @@ cards:
   number: '79'
   types: [P]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Mewtwo V
   hp: 280
   retreatCost: 2
@@ -1965,7 +1965,7 @@ cards:
   number: '81'
   types: [N]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Dragonite V
   hp: 280
   retreatCost: 2
@@ -2053,7 +2053,7 @@ cards:
   number: '86'
   types: [P]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Mewtwo V
   hp: 280
   retreatCost: 2

--- a/data/src/main/resources/cards/443-pokemon_go.yaml
+++ b/data/src/main/resources/cards/443-pokemon_go.yaml
@@ -1,0 +1,2114 @@
+id: '443'
+name: pgo
+enumId: POKEMON_GO
+abbr: PGO
+pioId: pgo
+cards:
+- id: 443-1
+  pioId: pgo-1
+  enumId: BULBASAUR_1
+  name: Bulbasaur
+  number: '1'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Ivysaur]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [G]
+    name: Vine Whip
+    damage: '10'
+  - cost: [G, C]
+    name: Razor Leaf
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: sowsow
+- id: 443-2
+  pioId: pgo-2
+  enumId: IVYSAUR_2
+  name: Ivysaur
+  number: '2'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Bulbasaur
+  evolvesTo: [Venusaur]
+  hp: 100
+  retreatCost: 3
+  moves:
+  - cost: [G]
+    name: Summoning Aroma
+    text: Search your deck for up to 2 Pokémon, reveal them, and put them into your
+      hand. Then, shuffle your deck.
+  - cost: [G, C, C]
+    name: Razor Leaf
+    damage: '60'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: zig
+- id: 443-3
+  pioId: pgo-3
+  enumId: VENUSAUR_3
+  name: Venusaur
+  number: '3'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Ivysaur
+  hp: 180
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Loopy Lasso
+    text: Once during your turn, you may flip a coin. If heads, switch 1 of your opponent's
+      Benched Pokémon with their Active Pokémon, and the new Active Pokémon is now
+      Asleep and Poisoned.
+  moves:
+  - cost: [G, G, C, C]
+    name: Solar Beam
+    damage: '130'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  artist: KEIICHIRO ITO
+- id: 443-4
+  pioId: pgo-4
+  enumId: RADIANT_VENUSAUR_4
+  name: Radiant Venusaur
+  number: '4'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 150
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Sunny Bloom
+    text: Once at the end of your turn (after your attack), you may use this Ability.
+      Draw cards until you have 4 cards in your hand.
+  moves:
+  - cost: [G, G, C]
+    name: Pollen Hazard
+    damage: '90'
+    text: Your opponent's Active Pokémon is now Burned, Confused, and Poisoned.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare
+  text:
+  - 'Radiant Pokémon Rule: You can''t have more than 1 Radiant Pokémon in your deck.'
+  artist: Misa Tsutsui
+- id: 443-5
+  pioId: pgo-5
+  enumId: ALOLAN_EXEGGUTOR_V_5
+  name: Alolan Exeggutor V
+  number: '5'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 240
+  retreatCost: 3
+  moves:
+  - cost: [G]
+    name: Growing Tall
+    text: Flip a coin. If heads, search your deck for up to 5 [G] Energy cards and
+      attach them to your Pokémon in any way you like. Then, shuffle your deck.
+  - cost: [C, C, C]
+    name: Head Swing
+    text: This attack does 30 damage to 1 of your opponent's Pokémon for each [G]
+      Energy attached to this Pokémon. (Don't apply Weakness and Resistance for Benched
+      Pokémon.)
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: MUGENUP
+- id: 443-6
+  pioId: pgo-6
+  enumId: SPINARAK_6
+  name: Spinarak
+  number: '6'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Ariados]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Poison Sting
+    damage: '10'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Common
+  artist: Yuka Morii
+- id: 443-7
+  pioId: pgo-7
+  enumId: ARIADOS_7
+  name: Ariados
+  number: '7'
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Spinarak
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Poison String-Up
+    damage: '20'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed and
+      Poisoned.
+  - cost: [G, C]
+    name: Absorb
+    damage: '50'
+    text: Heal 50 damage from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Uncommon
+  artist: Misa Tsutsui
+- id: 443-8
+  pioId: pgo-8
+  enumId: CHARMANDER_8
+  name: Charmander
+  number: '8'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Charmeleon]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Tail on Fire
+    damage: '10'
+    text: Search your deck for a [R] Energy card and attach it to this Pokémon. Then,
+      shuffle your deck.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: saino misaki
+- id: 443-9
+  pioId: pgo-9
+  enumId: CHARMELEON_9
+  name: Charmeleon
+  number: '9'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Charmander
+  evolvesTo: [Charizard]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [R, C]
+    name: Scratch
+    damage: '30'
+  - cost: [R, R, C, C]
+    name: Flamethrower
+    damage: '100'
+    text: Discard a [R] Energy from this Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Uncommon
+  artist: Shiburingaru
+- id: 443-10
+  pioId: pgo-10
+  enumId: CHARIZARD_10
+  name: Charizard
+  number: '10'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Charmeleon
+  hp: 170
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Burn Brightly
+    text: Each basic [R] Energy attached to your Pokémon provides Fire[R] Energy.
+      You can't apply more than 1 Burn Brightly Ability at a time.
+  moves:
+  - cost: [R, R, C, C]
+    name: Flare Blitz
+    damage: '170'
+    text: Discard all [R] Energy from this Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  artist: N-DESIGN Inc.
+- id: 443-11
+  pioId: pgo-11
+  enumId: RADIANT_CHARIZARD_11
+  name: Radiant Charizard
+  number: '11'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 160
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Excited Heart
+    text: This Pokémon's attacks cost [C] less for each Prize card your opponent has
+      taken.
+  moves:
+  - cost: [R, C, C, C, C]
+    name: Combustion Blast
+    damage: '250'
+    text: During your next turn, this Pokémon can't use Combustion Blast.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare
+  text:
+  - 'Radiant Pokémon Rule: You can''t have more than 1 Radiant Pokémon in your deck.'
+  artist: Shigenori Negishi
+- id: 443-12
+  pioId: pgo-12
+  enumId: MOLTRES_12
+  name: Moltres
+  number: '12'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Flare Symbol
+    text: Your Basic [R] Pokémon's attacks, except any Moltres, do 10 more damage
+      to your opponent's Active Pokémon (before applying Weakness and Resistance).
+  moves:
+  - cost: [R, R, C]
+    name: Fire Wing
+    damage: '110'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  artist: Pani Kobayashi
+- id: 443-13
+  pioId: pgo-13
+  enumId: NUMEL_13
+  name: Numel
+  number: '13'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Camerupt]
+  hp: 80
+  retreatCost: 3
+  moves:
+  - cost: [R, C]
+    name: Tackle
+    damage: '20'
+  - cost: [R, R, C]
+    name: Stomp
+    damage: 50+
+    text: Flip a coin. If heads, this attack does 50 more damage.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Common
+  artist: Shibuzoh.
+- id: 443-14
+  pioId: pgo-14
+  enumId: CAMERUPT_14
+  name: Camerupt
+  number: '14'
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Numel
+  hp: 140
+  retreatCost: 4
+  moves:
+  - cost: [R, C]
+    name: Split Bomb
+    text: This attack does 50 damage to 2 of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  - cost: [R, R, C]
+    name: Heat Blast
+    damage: '120'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Uncommon
+  artist: yuu
+- id: 443-15
+  pioId: pgo-15
+  enumId: SQUIRTLE_15
+  name: Squirtle
+  number: '15'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Wartortle]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Water Gun
+    damage: '20'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: sowsow
+- id: 443-16
+  pioId: pgo-16
+  enumId: WARTORTLE_16
+  name: Wartortle
+  number: '16'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Squirtle
+  evolvesTo: [Blastoise]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Water Gun
+    damage: '30'
+  - cost: [C, C, C]
+    name: Hydro Pump
+    damage: 50+
+    text: This attack does 10 more damage for each [W] Energy attached to this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: kurumitsu
+- id: 443-17
+  pioId: pgo-17
+  enumId: BLASTOISE_17
+  name: Blastoise
+  number: '17'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Wartortle
+  hp: 170
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Vitality Spring
+    text: Once during your turn, you may search your deck for up to 6 Energy cards
+      and attach them to your Pokémon in any way you like. Then, shuffle your deck.
+      If you use this Ability, your turn ends.
+  moves:
+  - cost: [C, C, C, C]
+    name: Hydro Pump
+    damage: 90+
+    text: This attack does 30 more damage for each [W] Energy attached to this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  artist: NC Empire
+- id: 443-18
+  pioId: pgo-18
+  enumId: RADIANT_BLASTOISE_18
+  name: Radiant Blastoise
+  number: '18'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 150
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Pump Shot
+    text: You must discard a [W] Energy card from your hand in order to use this Ability.
+      Once during your turn, you may put 2 damage counters on 1 of your opponent's
+      Benched Pokémon.
+  moves:
+  - cost: [W, W, C]
+    name: Torrential Cannon
+    damage: '170'
+    text: During your next turn, this Pokémon can't use Torrential Cannon.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare
+  text:
+  - 'Radiant Pokémon Rule: You can''t have more than 1 Radiant Pokémon in your deck.'
+  artist: Masakazu Fukuda
+- id: 443-19
+  pioId: pgo-19
+  enumId: SLOWPOKE_19
+  name: Slowpoke
+  number: '19'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Slowbro, Slowking]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Hold Still
+    text: Heal 30 damage from this Pokémon.
+  - cost: [W]
+    name: Ideal Fishing Day
+    text: Put an Item card from your discard pile into your hand.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: N-DESIGN Inc.
+- id: 443-20
+  pioId: pgo-20
+  enumId: SLOWBRO_20
+  name: Slowbro
+  number: '20'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Slowpoke
+  hp: 120
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Tumbling Tackle
+    damage: '20'
+    text: Both Active Pokémon are now Asleep.
+  - cost: [C, C]
+    name: Twilight Inspiration
+    text: You can use this attack only if your opponent has exactly 1 Prize card remaining.
+      Take 2 Prize cards.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Uncommon
+  artist: Mina Nakai
+- id: 443-21
+  pioId: pgo-21
+  enumId: MAGIKARP_21
+  name: Magikarp
+  number: '21'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Gyarados]
+  hp: 30
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Lively Grouping
+    text: Search your deck for any number of Magikarp, reveal them, and put them into
+      your hand. Then, shuffle your deck.
+  - cost: [C, C]
+    name: Raging Fin
+    damage: 10+
+    text: This attack does 30 more damage for each Magikarp and Gyarados in your discard
+      pile.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: N-DESIGN Inc.
+- id: 443-22
+  pioId: pgo-22
+  enumId: GYARADOS_22
+  name: Gyarados
+  number: '22'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Magikarp
+  hp: 170
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Wreak Havoc
+    text: Flip a coin until you get tails. For each heads, discard the top 2 cards
+      of your opponent's deck.
+  - cost: [W, W, C, C]
+    name: Wild Splash
+    damage: '230'
+    text: Discard the top 5 cards of your deck.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  artist: Mitsuhiro Arita
+- id: 443-23
+  pioId: pgo-23
+  enumId: LAPRAS_23
+  name: Lapras
+  number: '23'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Ice Beam
+    damage: '20'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [W, W, C]
+    name: Surf
+    damage: '110'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  artist: N-DESIGN Inc.
+- id: 443-24
+  pioId: pgo-24
+  enumId: ARTICUNO_24
+  name: Articuno
+  number: '24'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Ice Symbol
+    text: Your Basic [W] Pokémon's attacks, except any Articuno, do 10 more damage
+      to your opponent's Active Pokémon (before applying Weakness and Resistance).
+  moves:
+  - cost: [W, W, C]
+    name: Freezing Wind
+    damage: '110'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  artist: Jiro Sasumo
+- id: 443-25
+  pioId: pgo-25
+  enumId: WIMPOD_25
+  name: Wimpod
+  number: '25'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Golisopod]
+  hp: 70
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Punk Out
+    text: If your opponent has any Pokémon V in play, this Pokémon has no Retreat
+      Cost.
+  moves:
+  - cost: [W]
+    name: Gnaw
+    damage: '10'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Common
+  artist: Miki Tanaka
+- id: 443-26
+  pioId: pgo-26
+  enumId: GOLISOPOD_26
+  name: Golisopod
+  number: '26'
+  types: [W]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Wimpod
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: First Impression
+    damage: 20+
+    text: If this Pokémon moved from your Bench to the Active Spot this turn, this
+      attack does 90 more damage.
+  - cost: [W, C, C]
+    name: Slash
+    damage: '100'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Rare Holo
+  artist: otumami
+- id: 443-27
+  pioId: pgo-27
+  enumId: PIKACHU_27
+  name: Pikachu
+  number: '27'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raichu]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [L, C, C]
+    name: Buddy Bolt
+    damage: 30+
+    text: If you played a Supporter card from your hand during this turn, this attack
+      does 30 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: N-DESIGN Inc.
+- id: 443-28
+  pioId: pgo-28
+  enumId: PIKACHU_28
+  name: Pikachu
+  number: '28'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raichu]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [L, L, C]
+    name: Wild Charge
+    damage: '90'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: Narumi Sato
+- id: 443-29
+  pioId: pgo-29
+  enumId: ZAPDOS_29
+  name: Zapdos
+  number: '29'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Lightning Symbol
+    text: Your Basic [L] Pokémon's attacks, except any Zapdos, do 10 more damage to
+      your opponent's Active Pokémon (before applying Weakness and Resistance).
+  moves:
+  - cost: [L, L, C]
+    name: Electric Ball
+    damage: '110'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: Yuya Oka
+- id: 443-30
+  pioId: pgo-30
+  enumId: MEWTWO_V_30
+  name: Mewtwo V
+  number: '30'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [P, C]
+    name: Super Psy Bolt
+    damage: '50'
+  - cost: [P, P, C]
+    name: Transfer Break
+    damage: '160'
+    text: Move an Energy from this Pokémon to 1 of your Benched Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Nurikabe
+- id: 443-31
+  pioId: pgo-31
+  enumId: MEWTWO_VSTAR_31
+  name: Mewtwo VSTAR
+  number: '31'
+  types: [P]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Mewtwo V
+  hp: 280
+  retreatCost: 2
+  moves:
+  - cost: [P, C]
+    name: Psy Purge
+    damage: 90x
+    text: Discard up to 3 [P] Energy from your Pokémon. This attack does 90 damage
+      for each card you discarded in this way.
+  - cost: [P, C]
+    name: Star Raid
+    text: This attack does 120 damage to each of your opponent's Pokémon V. This damage
+      isn't affected by Weakness or Resistance. (You can't use more than 1 VSTAR Power
+      in a game.)
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: PLANETA Mochizuki
+- id: 443-32
+  pioId: pgo-32
+  enumId: NATU_32
+  name: Natu
+  number: '32'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Xatu]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Nap
+    text: Heal 20 damage from this Pokémon.
+  - cost: [P, C]
+    name: Peck
+    damage: '20'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: HYOGONOSUKE
+- id: 443-33
+  pioId: pgo-33
+  enumId: XATU_33
+  name: Xatu
+  number: '33'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Natu
+  hp: 110
+  moves:
+  - cost: [P]
+    name: Pinpoint Wave
+    text: This attack does 90 damage to 1 of your opponent's Pokémon V. This damage
+      isn't affected by Weakness or Resistance.
+  - cost: [P, C]
+    name: Mind Bend
+    damage: '50'
+    text: Your opponent's Active Pokémon is now Confused.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: Hataya
+- id: 443-34
+  pioId: pgo-34
+  enumId: LUNATONE_34
+  name: Lunatone
+  number: '34'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Cycle Draw
+    text: Discard a card from your hand. If you do, draw 3 cards.
+  - cost: [C, C, C]
+    name: Moon Kinesis
+    damage: 30+
+    text: This attack does 30 more damage for each [P] Energy attached to this Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: miki kudo
+- id: 443-35
+  pioId: pgo-35
+  enumId: SYLVEON_35
+  name: Sylveon
+  number: '35'
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Eevee
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Souvenir
+    text: Search your deck for up to 2 cards and put them into your hand. Then, shuffle
+      your deck.
+  - cost: [C, C, C]
+    name: Wonder Flash
+    damage: 90+
+    text: If your opponent's Active Pokémon is a [N] Pokémon, this attack does 90
+      more damage.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  artist: Atsushi Furusawa
+- id: 443-36
+  pioId: pgo-36
+  enumId: ONIX_36
+  name: Onix
+  number: '36'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Steelix]
+  hp: 120
+  retreatCost: 4
+  moves:
+  - cost: [C, C, C]
+    name: Rock Tomb
+    damage: '50'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  - cost: [F, F, C, C]
+    name: Raging Swing
+    damage: 50x
+    text: This attack does 50 damage for each damage counter on this Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Mitsuhiro Arita
+- id: 443-37
+  pioId: pgo-37
+  enumId: LARVITAR_37
+  name: Larvitar
+  number: '37'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Pupitar]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Rock Smash
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 10 more damage.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: sui
+- id: 443-38
+  pioId: pgo-38
+  enumId: PUPITAR_38
+  name: Pupitar
+  number: '38'
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Larvitar
+  evolvesTo: [Tyranitar]
+  hp: 90
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Crashing Bullet
+    damage: '20'
+    text: This attack also does 20 damage to each Benched Pokémon (both yours and
+      your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [F, C, C]
+    name: Tackle
+    damage: '70'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: Sumiyoshi Kizuki
+- id: 443-39
+  pioId: pgo-39
+  enumId: SOLROCK_39
+  name: Solrock
+  number: '39'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Sun Energy
+    text: Once during your turn, you may attach a [P] Energy card from your discard
+      pile to 1 of your Lunatone.
+  moves:
+  - cost: [F, C]
+    name: Spinning Attack
+    damage: '50'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Uncommon
+  artist: Sekio
+- id: 443-40
+  pioId: pgo-40
+  enumId: CONKELDURR_V_40
+  name: Conkeldurr V
+  number: '40'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 230
+  retreatCost: 3
+  moves:
+  - cost: [F]
+    name: Counter
+    damage: 20+
+    text: If this Pokémon was damaged by an attack during your opponent's last turn,
+      this attack does that much more damage.
+  - cost: [F, C, C]
+    name: Dynamic Punch
+    damage: 90+
+    text: Flip a coin. If heads, this attack does 90 more damage, and your opponent's
+      Active Pokémon is now Confused.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Ayaka Yoshida
+- id: 443-41
+  pioId: pgo-41
+  enumId: ALOLAN_RATTATA_41
+  name: Alolan Rattata
+  number: '41'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raticate]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Hyper Fang
+    damage: '50'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: KIYOTAKA OSHIYAMA
+- id: 443-42
+  pioId: pgo-42
+  enumId: ALOLAN_RATICATE_42
+  name: Alolan Raticate
+  number: '42'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Alolan Rattata
+  hp: 120
+  retreatCost: 3
+  moves:
+  - cost: [D]
+    name: Chase Up
+    text: Search your deck for a card and put it into your hand. Then, shuffle your
+      deck.
+  - cost: [C, C, C]
+    name: Super Fang
+    text: Put damage counters on your opponent's Active Pokémon until its remaining
+      HP is 10.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Common
+  artist: Atsuko Nishida
+- id: 443-43
+  pioId: pgo-43
+  enumId: TYRANITAR_43
+  name: Tyranitar
+  number: '43'
+  types: [D]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Pupitar
+  hp: 180
+  retreatCost: 3
+  moves:
+  - cost: [C, C]
+    name: Raging Crash
+    damage: 10x
+    text: This attack does 10 damage for each damage counter on all of your Benched
+      Pokémon.
+  - cost: [D, D, C, C]
+    name: Earthquake
+    damage: '180'
+    text: This attack also does 20 damage to each of your Benched Pokémon. (Don't
+      apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: Nisota Niso
+- id: 443-44
+  pioId: pgo-44
+  enumId: STEELIX_44
+  name: Steelix
+  number: '44'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Onix
+  hp: 180
+  retreatCost: 4
+  moves:
+  - cost: [C, C, C]
+    name: Body Slam
+    damage: '70'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [M, C, C, C]
+    name: Iron Buster
+    damage: '170'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Uncommon
+  artist: GOSSAN
+- id: 443-45
+  pioId: pgo-45
+  enumId: MELTAN_45
+  name: Meltan
+  number: '45'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Melmetal]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Thunder Shock
+    damage: '20'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Common
+  artist: Sumiyoshi Kizuki
+- id: 443-46
+  pioId: pgo-46
+  enumId: MELMETAL_46
+  name: Melmetal
+  number: '46'
+  types: [M]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Meltan
+  hp: 160
+  retreatCost: 4
+  moves:
+  - cost: [C, C]
+    name: Headbutt
+    damage: '60'
+  - cost: [M, C, C]
+    name: Swinging Smash
+    damage: 30+
+    text: Flip 2 coins. This attack does 90 more damage for each heads.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  artist: Shigenori Negishi
+- id: 443-47
+  pioId: pgo-47
+  enumId: MELMETAL_V_47
+  name: Melmetal V
+  number: '47'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [M, M]
+    name: Arm Charge
+    damage: '50'
+    text: You may attach a [M] Energy card from your hand to this Pokémon.
+  - cost: [M, M, M]
+    name: Mega Punch
+    damage: '140'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: sadaji
+- id: 443-48
+  pioId: pgo-48
+  enumId: MELMETAL_VMAX_48
+  name: Melmetal VMAX
+  number: '48'
+  types: [M]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Melmetal V
+  hp: 330
+  retreatCost: 4
+  moves:
+  - cost: [M, M, M]
+    name: G-Max Juggernaut
+    damage: 160+
+    text: This attack does 60 more damage for each extra [M] Energy attached to this
+      Pokémon (in addition to this attack's cost). You can't add more than 120 damage
+      in this way.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: PLANETA Tsuji
+- id: 443-49
+  pioId: pgo-49
+  enumId: DRAGONITE_V_49
+  name: Dragonite V
+  number: '49'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 230
+  retreatCost: 2
+  moves:
+  - cost: [W, L]
+    name: Hyper Beam
+    damage: '60'
+    text: Discard an Energy from your opponent's Active Pokémon.
+  - cost: [W, L, C]
+    name: Buster Tail
+    damage: '160'
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: kawayoo
+- id: 443-50
+  pioId: pgo-50
+  enumId: DRAGONITE_VSTAR_50
+  name: Dragonite VSTAR
+  number: '50'
+  types: [N]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Dragonite V
+  hp: 280
+  retreatCost: 2
+  moves:
+  - cost: [W, L, C, C]
+    name: Giga Impact
+    damage: '250'
+    text: During your next turn, this Pokémon can't attack.
+  - cost: [C]
+    name: Draconic Star
+    text: Look at the top 12 cards of your deck and attach any number of Water or
+      [L] Energy cards you find there to your Pokémon in any way you like. Shuffle
+      the other cards back into your deck. (You can't use more than 1 VSTAR Power
+      in a game.)
+  rarity: Rare Holo
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: PLANETA Tsuji
+- id: 443-51
+  pioId: pgo-51
+  enumId: CHANSEY_51
+  name: Chansey
+  number: '51'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Blissey]
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Delicious Egg
+    text: Heal 30 damage from 1 of your Benched Pokémon.
+  - cost: [C, C]
+    name: Gentle Slap
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Uncommon
+  artist: ryoma uratsuka
+- id: 443-52
+  pioId: pgo-52
+  enumId: BLISSEY_52
+  name: Blissey
+  number: '52'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Chansey
+  hp: 200
+  retreatCost: 4
+  moves:
+  - cost: [C]
+    name: Enriching Egg
+    text: Heal all damage from 1 of your Benched Pokémon.
+  - cost: [C, C, C]
+    name: Zen Headbutt
+    damage: '100'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: Teeziro
+- id: 443-53
+  pioId: pgo-53
+  enumId: DITTO_53
+  name: Ditto
+  number: '53'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Sudden Transformation
+    text: This Pokémon can use the attacks of any Basic Pokémon in your discard pile,
+      except for Pokémon with a Rule Box (Pokémon V, Pokémon-GX, etc. have Rule Boxes).
+      (You still need the necessary Energy to use each attack.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: Misa Tsutsui
+- id: 443-54
+  pioId: pgo-54
+  enumId: EEVEE_54
+  name: Eevee
+  number: '54'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Vaporeon, Jolteon, Flareon, Sylveon, Espeon, Umbreon, Leafeon, Glaceon]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Whiny Voice
+    text: Choose a random card from your opponent's hand. Your opponent reveals that
+      card and shuffles it into their deck.
+  - cost: [C, C]
+    name: Tackle
+    damage: '20'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: N-DESIGN Inc.
+- id: 443-55
+  pioId: pgo-55
+  enumId: SNORLAX_55
+  name: Snorlax
+  number: '55'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 150
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Block
+    text: As long as this Pokémon is in the Active Spot, your opponent's Active Pokémon
+      can't retreat.
+  moves:
+  - cost: [C, C, C, C]
+    name: Collapse
+    damage: '150'
+    text: This Pokémon is now Asleep.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: N-DESIGN Inc.
+- id: 443-56
+  pioId: pgo-56
+  enumId: AIPOM_56
+  name: Aipom
+  number: '56'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Ambipom]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Bustle
+    text: Flip a coin. If heads, during your opponent's next turn, prevent all damage
+      from and effects of attacks done to this Pokémon.
+  - cost: [C, C, C]
+    name: Slap
+    damage: '30'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Sanosuke Sakuma
+- id: 443-57
+  pioId: pgo-57
+  enumId: AMBIPOM_57
+  name: Ambipom
+  number: '57'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Aipom
+  hp: 90
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Primate Dexterity
+    text: If any damage is done to this Pokémon by attacks, flip a coin. If heads,
+      prevent that damage.
+  moves:
+  - cost: [C]
+    name: Full Tilt Fling
+    damage: 60x
+    text: Flip a coin for each Energy attached to this Pokémon. This attack does 60
+      damage for each heads.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Scav
+- id: 443-58
+  pioId: pgo-58
+  enumId: SLAKING_V_58
+  name: Slaking V
+  number: '58'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 230
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Kinda Lazy
+    text: If you have exactly 2, 4, or 6 Prize cards remaining, this Pokémon can't
+      attack.
+  moves:
+  - cost: [C, C, C, C]
+    name: Heavy Impact
+    damage: '260'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Saki Hayashiro
+- id: 443-59
+  pioId: pgo-59
+  enumId: BIDOOF_59
+  name: Bidoof
+  number: '59'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Bibarel]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C, C, C]
+    name: Take Down
+    damage: '50'
+    text: This Pokémon also does 10 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: Tomokazu Komiya
+- id: 443-60
+  pioId: pgo-60
+  enumId: BIBAREL_60
+  name: Bibarel
+  number: '60'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Bidoof
+  hp: 110
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Reassuring Dam
+    text: As long as this Pokémon is on your Bench, cards in your deck can't be discarded
+      by effects of your opponent's attacks, Abilities, Item cards, or Supporter cards.
+  moves:
+  - cost: [C, C, C]
+    name: Hammer In
+    damage: '80'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Common
+  artist: KIYOTAKA OSHIYAMA
+- id: 443-61
+  pioId: pgo-61
+  enumId: PIDOVE_61
+  name: Pidove
+  number: '61'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Tranquill]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Growl
+    text: During your opponent's next turn, the Defending Pokémon's attacks do 20
+      less damage (before applying Weakness and Resistance).
+  - cost: [C, C]
+    name: Flap
+    damage: '20'
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: N-DESIGN Inc.
+- id: 443-62
+  pioId: pgo-62
+  enumId: TRANQUILL_62
+  name: Tranquill
+  number: '62'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Pidove
+  evolvesTo: [Unfezant]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Aerial Ace
+    damage: 20+
+    text: Flip a coin. If heads, this attack does 20 more damage.
+  - cost: [C, C]
+    name: Flap
+    damage: '30'
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Common
+  artist: '0313'
+- id: 443-63
+  pioId: pgo-63
+  enumId: UNFEZANT_63
+  name: Unfezant
+  number: '63'
+  types: [C]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Tranquill
+  hp: 140
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Gust
+    damage: '30'
+  - cost: [C, C]
+    name: Hurricane Wing
+    damage: 70x
+    text: Flip 4 coins. This attack does 70 damage for each heads.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Uncommon
+  artist: GIDORA
+- id: 443-64
+  pioId: pgo-64
+  enumId: BLANCHE_64
+  name: Blanche
+  number: '64'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach
+    a [W] Energy card from your discard pile to 1 of your Benched Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Anesaki Dynamic
+- id: 443-65
+  pioId: pgo-65
+  enumId: CANDELA_65
+  name: Candela
+  number: '65'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach
+    a [R] Energy card from your discard pile to 1 of your Benched Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Ryuta Fuse
+- id: 443-66
+  pioId: pgo-66
+  enumId: EGG_INCUBATOR_66
+  name: Egg Incubator
+  number: '66'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Flip a coin. If heads, search your deck for a Basic Pokémon, put it onto your
+    Bench, and shuffle your deck. If tails, put this Egg Incubator on the bottom of
+    your deck instead of in the discard pile.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: sadaji
+- id: 443-67
+  pioId: pgo-67
+  enumId: LURE_MODULE_67
+  name: Lure Module
+  number: '67'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Each player reveals the top 3 cards of their deck and puts all Pokémon they find
+    there into their hand. Then, each player shuffles the other cards back into their
+    deck.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: ORBITALLINK Inc.
+- id: 443-68
+  pioId: pgo-68
+  enumId: POKESTOP_68
+  name: PokéStop
+  number: '68'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Uncommon
+  text:
+  - Once during each player's turn, that player may discard 3 cards from the top of
+    their deck. If a player discarded any Item cards in this way, they put those Item
+    cards into their hand.
+  artist: Studio Bora Inc.
+- id: 443-69
+  pioId: pgo-69
+  enumId: RARE_CANDY_69
+  name: Rare Candy
+  number: '69'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Uncommon
+  text:
+  - Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand
+    that evolves from that Pokémon, put that card onto the Basic Pokémon to evolve
+    it, skipping the Stage 1. You can't use this card during your first turn or on
+    a Basic Pokémon that was put into play this turn.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: Ayaka Yoshida
+- id: 443-70
+  pioId: pgo-70
+  enumId: SPARK_70
+  name: Spark
+  number: '70'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Uncommon
+  text:
+  - Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach
+    a [L] Energy card from your discard pile to 1 of your Benched Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Naoki Saito
+- id: 443-71
+  pioId: pgo-71
+  enumId: ALOLAN_EXEGGUTOR_V_71
+  name: Alolan Exeggutor V
+  number: '71'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 240
+  retreatCost: 3
+  moves:
+  - cost: [G]
+    name: Growing Tall
+    text: Flip a coin. If heads, search your deck for up to 5 [G] Energy cards and
+      attach them to your Pokémon in any way you like. Then, shuffle your deck.
+  - cost: [C, C, C]
+    name: Head Swing
+    text: This attack does 30 damage to 1 of your opponent's Pokémon for each [G]
+      Energy attached to this Pokémon. (Don't apply Weakness and Resistance for Benched
+      Pokémon.)
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: MUGENUP
+  variantOf: FILL_THIS-5
+  variantType: Full Art
+- id: 443-72
+  pioId: pgo-72
+  enumId: MEWTWO_V_72
+  name: Mewtwo V
+  number: '72'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [P, C]
+    name: Super Psy Bolt
+    damage: '50'
+  - cost: [P, P, C]
+    name: Transfer Break
+    damage: '160'
+    text: Move an Energy from this Pokémon to 1 of your Benched Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: N-DESIGN Inc.
+  variantOf: FILL_THIS-30
+  variantType: Full Art
+- id: 443-73
+  pioId: pgo-73
+  enumId: CONKELDURR_V_73
+  name: Conkeldurr V
+  number: '73'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 230
+  retreatCost: 3
+  moves:
+  - cost: [F]
+    name: Counter
+    damage: 20+
+    text: If this Pokémon was damaged by an attack during your opponent's last turn,
+      this attack does that much more damage.
+  - cost: [F, C, C]
+    name: Dynamic Punch
+    damage: 90+
+    text: Flip a coin. If heads, this attack does 90 more damage, and your opponent's
+      Active Pokémon is now Confused.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Ayaka Yoshida
+  variantOf: FILL_THIS-40
+  variantType: Full Art
+- id: 443-74
+  pioId: pgo-74
+  enumId: CONKELDURR_V_74
+  name: Conkeldurr V
+  number: '74'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 230
+  retreatCost: 3
+  moves:
+  - cost: [F]
+    name: Counter
+    damage: 20+
+    text: If this Pokémon was damaged by an attack during your opponent's last turn,
+      this attack does that much more damage.
+  - cost: [F, C, C]
+    name: Dynamic Punch
+    damage: 90+
+    text: Flip a coin. If heads, this attack does 90 more damage, and your opponent's
+      Active Pokémon is now Confused.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: N-DESIGN Inc.
+  variantOf: FILL_THIS-40
+  variantType: Full Art
+- id: 443-75
+  pioId: pgo-75
+  enumId: MELMETAL_V_75
+  name: Melmetal V
+  number: '75'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [M, M]
+    name: Arm Charge
+    damage: '50'
+    text: You may attach a [M] Energy card from your hand to this Pokémon.
+  - cost: [M, M, M]
+    name: Mega Punch
+    damage: '140'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: sadaji
+  variantOf: FILL_THIS-47
+  variantType: Full Art
+- id: 443-76
+  pioId: pgo-76
+  enumId: DRAGONITE_V_76
+  name: Dragonite V
+  number: '76'
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 230
+  retreatCost: 2
+  moves:
+  - cost: [W, L]
+    name: Hyper Beam
+    damage: '60'
+    text: Discard an Energy from your opponent's Active Pokémon.
+  - cost: [W, L, C]
+    name: Buster Tail
+    damage: '160'
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: 5ban Graphics
+  variantOf: FILL_THIS-49
+  variantType: Full Art
+- id: 443-77
+  pioId: pgo-77
+  enumId: SLAKING_V_77
+  name: Slaking V
+  number: '77'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 230
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Kinda Lazy
+    text: If you have exactly 2, 4, or 6 Prize cards remaining, this Pokémon can't
+      attack.
+  moves:
+  - cost: [C, C, C, C]
+    name: Heavy Impact
+    damage: '260'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Saki Hayashiro
+  variantOf: FILL_THIS-58
+  variantType: Full Art
+- id: 443-78
+  pioId: pgo-78
+  enumId: PROFESSOR_S_RESEARCH_78
+  name: Professor's Research
+  number: '78'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Discard your hand and draw 7 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yusuke Kozaki
+- id: 443-79
+  pioId: pgo-79
+  enumId: MEWTWO_VSTAR_79
+  name: Mewtwo VSTAR
+  number: '79'
+  types: [P]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Mewtwo V
+  hp: 280
+  retreatCost: 2
+  moves:
+  - cost: [P, C]
+    name: Psy Purge
+    damage: 90x
+    text: Discard up to 3 [P] Energy from your Pokémon. This attack does 90 damage
+      for each card you discarded in this way.
+  - cost: [P, C]
+    name: Star Raid
+    text: This attack does 120 damage to each of your opponent's Pokémon V. This damage
+      isn't affected by Weakness or Resistance. (You can't use more than 1 VSTAR Power
+      in a game.)
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: PLANETA Mochizuki
+  variantOf: FILL_THIS-31
+  variantType: Full Art
+- id: 443-80
+  pioId: pgo-80
+  enumId: MELMETAL_VMAX_80
+  name: Melmetal VMAX
+  number: '80'
+  types: [M]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Melmetal V
+  hp: 330
+  retreatCost: 4
+  moves:
+  - cost: [M, M, M]
+    name: G-Max Juggernaut
+    damage: 160+
+    text: This attack does 60 more damage for each extra [M] Energy attached to this
+      Pokémon (in addition to this attack's cost). You can't add more than 120 damage
+      in this way.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Ultra Rare
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: PLANETA Tsuji
+  variantOf: FILL_THIS-48
+  variantType: Full Art
+- id: 443-81
+  pioId: pgo-81
+  enumId: DRAGONITE_VSTAR_81
+  name: Dragonite VSTAR
+  number: '81'
+  types: [N]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Dragonite V
+  hp: 280
+  retreatCost: 2
+  moves:
+  - cost: [W, L, C, C]
+    name: Giga Impact
+    damage: '250'
+    text: During your next turn, this Pokémon can't attack.
+  - cost: [C]
+    name: Draconic Star
+    text: Look at the top 12 cards of your deck and attach any number of Water or
+      [L] Energy cards you find there to your Pokémon in any way you like. Shuffle
+      the other cards back into your deck. (You can't use more than 1 VSTAR Power
+      in a game.)
+  rarity: Ultra Rare
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: PLANETA Tsuji
+  variantOf: FILL_THIS-50
+  variantType: Full Art
+- id: 443-82
+  pioId: pgo-82
+  enumId: BLANCHE_82
+  name: Blanche
+  number: '82'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach
+    a [W] Energy card from your discard pile to 1 of your Benched Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Anesaki Dynamic
+  variantOf: FILL_THIS-64
+  variantType: Full Art
+- id: 443-83
+  pioId: pgo-83
+  enumId: CANDELA_83
+  name: Candela
+  number: '83'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach
+    a [R] Energy card from your discard pile to 1 of your Benched Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Ryuta Fuse
+  variantOf: FILL_THIS-65
+  variantType: Full Art
+- id: 443-84
+  pioId: pgo-84
+  enumId: PROFESSOR_S_RESEARCH_84
+  name: Professor's Research
+  number: '84'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Discard your hand and draw 7 cards.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Yusuke Kozaki
+  variantOf: FILL_THIS-78
+  variantType: Full Art
+- id: 443-85
+  pioId: pgo-85
+  enumId: SPARK_85
+  name: Spark
+  number: '85'
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Draw 2 cards. If you drew any cards in this way, flip a coin. If heads, attach
+    a [L] Energy card from your discard pile to 1 of your Benched Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Naoki Saito
+  variantOf: FILL_THIS-70
+  variantType: Full Art
+- id: 443-86
+  pioId: pgo-86
+  enumId: MEWTWO_VSTAR_86
+  name: Mewtwo VSTAR
+  number: '86'
+  types: [P]
+  superType: POKEMON
+  subTypes: []
+  evolvesFrom: Mewtwo V
+  hp: 280
+  retreatCost: 2
+  moves:
+  - cost: [P, C]
+    name: Psy Purge
+    damage: 90x
+    text: Discard up to 3 [P] Energy from your Pokémon. This attack does 90 damage
+      for each card you discarded in this way.
+  - cost: [P, C]
+    name: Star Raid
+    text: This attack does 120 damage to each of your opponent's Pokémon V. This damage
+      isn't affected by Weakness or Resistance. (You can't use more than 1 VSTAR Power
+      in a game.)
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Secret
+  text:
+  - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
+    cards.'
+  artist: PLANETA Mochizuki
+  variantOf: FILL_THIS-31
+  variantType: Secret Art
+- id: 443-87
+  pioId: pgo-87
+  enumId: EGG_INCUBATOR_87
+  name: Egg Incubator
+  number: '87'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Secret
+  text:
+  - Flip a coin. If heads, search your deck for a Basic Pokémon, put it onto your
+    Bench, and shuffle your deck. If tails, put this Egg Incubator on the bottom of
+    your deck instead of in the discard pile.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: sadaji
+  variantOf: FILL_THIS-66
+  variantType: Secret Art
+- id: 443-88
+  pioId: pgo-88
+  enumId: LURE_MODULE_88
+  name: Lure Module
+  number: '88'
+  superType: TRAINER
+  subTypes: [ITEM]
+  rarity: Secret
+  text:
+  - Each player reveals the top 3 cards of their deck and puts all Pokémon they find
+    there into their hand. Then, each player shuffles the other cards back into their
+    deck.
+  - 'Item rule: You may play any number of Item cards during your turn.'
+  artist: ORBITALLINK Inc.
+  variantOf: FILL_THIS-67
+  variantType: Secret Art

--- a/data/src/main/resources/cards/443-pokemon_go.yaml
+++ b/data/src/main/resources/cards/443-pokemon_go.yaml
@@ -1,3 +1,4 @@
+schema: E2
 id: '443'
 name: pgo
 enumId: POKEMON_GO

--- a/data/src/main/resources/cards/443-pokemon_go.yaml
+++ b/data/src/main/resources/cards/443-pokemon_go.yaml
@@ -1,6 +1,6 @@
 schema: E2
 id: '443'
-name: pgo
+name: Pokémon GO
 enumId: POKEMON_GO
 abbr: PGO
 pioId: pgo

--- a/data/src/main/resources/cards/444-lost_origins.yaml
+++ b/data/src/main/resources/cards/444-lost_origins.yaml
@@ -1,10 +1,10 @@
-id: '443'
+id: '444'
 name: swsh11
 enumId: LOST_ORIGINS
 abbr: LOR
 pioId: swsh11
 cards:
-- id: 443-1
+- id: 444-1
   pioId: swsh11-1
   enumId: ODDISH_1
   name: Oddish
@@ -24,7 +24,7 @@ cards:
     value: x2
   rarity: Common
   artist: Miki Tanaka
-- id: 443-2
+- id: 444-2
   pioId: swsh11-2
   enumId: GLOOM_2
   name: Gloom
@@ -46,7 +46,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Tomokazu Komiya
-- id: 443-3
+- id: 444-3
   pioId: swsh11-3
   enumId: VILEPLUME_3
   name: Vileplume
@@ -73,7 +73,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Jiro Sasumo
-- id: 443-4
+- id: 444-4
   pioId: swsh11-4
   enumId: PARAS_4
   name: Paras
@@ -94,7 +94,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mizue
-- id: 443-5
+- id: 444-5
   pioId: swsh11-5
   enumId: PARASECT_5
   name: Parasect
@@ -120,7 +120,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Pani Kobayashi
-- id: 443-6
+- id: 444-6
   pioId: swsh11-6
   enumId: WURMPLE_6
   name: Wurmple
@@ -144,7 +144,7 @@ cards:
     value: x2
   rarity: Common
   artist: ryoma uratsuka
-- id: 443-7
+- id: 444-7
   pioId: swsh11-7
   enumId: SILCOON_7
   name: Silcoon
@@ -169,7 +169,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Kagemaru Himeno
-- id: 443-8
+- id: 444-8
   pioId: swsh11-8
   enumId: BEAUTIFLY_8
   name: Beautifly
@@ -195,7 +195,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Yuu Nishida
-- id: 443-9
+- id: 444-9
   pioId: swsh11-9
   enumId: CASCOON_9
   name: Cascoon
@@ -220,7 +220,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: GOSSAN
-- id: 443-10
+- id: 444-10
   pioId: swsh11-10
   enumId: DUSTOX_10
   name: Dustox
@@ -244,7 +244,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Mitsuhiro Arita
-- id: 443-11
+- id: 444-11
   pioId: swsh11-11
   enumId: SEEDOT_11
   name: Seedot
@@ -265,7 +265,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yuka Morii
-- id: 443-12
+- id: 444-12
   pioId: swsh11-12
   enumId: NUZLEAF_12
   name: Nuzleaf
@@ -288,7 +288,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Mizue
-- id: 443-13
+- id: 444-13
   pioId: swsh11-13
   enumId: SHIFTRY_13
   name: Shiftry
@@ -314,7 +314,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: kawayoo
-- id: 443-14
+- id: 444-14
   pioId: swsh11-14
   enumId: ROSELIA_14
   name: Roselia
@@ -334,7 +334,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yukiko Baba
-- id: 443-15
+- id: 444-15
   pioId: swsh11-15
   enumId: ROSERADE_15
   name: Roserade
@@ -361,7 +361,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: '0313'
-- id: 443-16
+- id: 444-16
   pioId: swsh11-16
   enumId: PHANTUMP_16
   name: Phantump
@@ -381,7 +381,7 @@ cards:
     value: x2
   rarity: Common
   artist: AKIRA EGAWA
-- id: 443-17
+- id: 444-17
   pioId: swsh11-17
   enumId: TREVENANT_17
   name: Trevenant
@@ -407,7 +407,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Yuya Oka
-- id: 443-18
+- id: 444-18
   pioId: swsh11-18
   enumId: BLIPBUG_18
   name: Blipbug
@@ -427,7 +427,7 @@ cards:
     value: x2
   rarity: Common
   artist: Asako Ito
-- id: 443-19
+- id: 444-19
   pioId: swsh11-19
   enumId: DOTTLER_19
   name: Dottler
@@ -450,7 +450,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Kyoko Umemoto
-- id: 443-20
+- id: 444-20
   pioId: swsh11-20
   enumId: ORBEETLE_20
   name: Orbeetle
@@ -478,7 +478,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: yuu
-- id: 443-21
+- id: 444-21
   pioId: swsh11-21
   enumId: SLUGMA_21
   name: Slugma
@@ -501,7 +501,7 @@ cards:
     value: x2
   rarity: Common
   artist: Scav
-- id: 443-22
+- id: 444-22
   pioId: swsh11-22
   enumId: MAGCARGO_22
   name: Magcargo
@@ -525,7 +525,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Pani Kobayashi
-- id: 443-23
+- id: 444-23
   pioId: swsh11-23
   enumId: TORKOAL_23
   name: Torkoal
@@ -548,7 +548,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Naoyo Kimura
-- id: 443-24
+- id: 444-24
   pioId: swsh11-24
   enumId: LITWICK_24
   name: Litwick
@@ -568,7 +568,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yuka Morii
-- id: 443-25
+- id: 444-25
   pioId: swsh11-25
   enumId: LAMPENT_25
   name: Lampent
@@ -590,7 +590,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: kurumitsu
-- id: 443-26
+- id: 444-26
   pioId: swsh11-26
   enumId: CHANDELURE_26
   name: Chandelure
@@ -615,7 +615,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: sui
-- id: 443-27
+- id: 444-27
   pioId: swsh11-27
   enumId: DELPHOX_V_27
   name: Delphox V
@@ -642,7 +642,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: 443-28
+- id: 444-28
   pioId: swsh11-28
   enumId: LITLEO_28
   name: Litleo
@@ -662,7 +662,7 @@ cards:
     value: x2
   rarity: Common
   artist: Sekio
-- id: 443-29
+- id: 444-29
   pioId: swsh11-29
   enumId: PYROAR_29
   name: Pyroar
@@ -688,7 +688,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Misa Tsutsui
-- id: 443-30
+- id: 444-30
   pioId: swsh11-30
   enumId: POLIWAG_30
   name: Poliwag
@@ -710,7 +710,7 @@ cards:
     value: x2
   rarity: Common
   artist: Miki Tanaka
-- id: 443-31
+- id: 444-31
   pioId: swsh11-31
   enumId: POLIWHIRL_31
   name: Poliwhirl
@@ -735,7 +735,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Scav
-- id: 443-32
+- id: 444-32
   pioId: swsh11-32
   enumId: POLITOED_32
   name: Politoed
@@ -760,7 +760,7 @@ cards:
     value: x2
   rarity: Rare
   artist: ryoma uratsuka
-- id: 443-33
+- id: 444-33
   pioId: swsh11-33
   enumId: SEEL_33
   name: Seel
@@ -783,7 +783,7 @@ cards:
     value: x2
   rarity: Common
   artist: GIDORA
-- id: 443-34
+- id: 444-34
   pioId: swsh11-34
   enumId: DEWGONG_34
   name: Dewgong
@@ -810,7 +810,7 @@ cards:
     value: x2
   rarity: Rare
   artist: chibi
-- id: 443-35
+- id: 444-35
   pioId: swsh11-35
   enumId: HORSEA_35
   name: Horsea
@@ -831,7 +831,7 @@ cards:
     value: x2
   rarity: Common
   artist: Tika Matsuno
-- id: 443-36
+- id: 444-36
   pioId: swsh11-36
   enumId: SEADRA_36
   name: Seadra
@@ -859,7 +859,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: sui
-- id: 443-37
+- id: 444-37
   pioId: swsh11-37
   enumId: KINGDRA_37
   name: Kingdra
@@ -885,7 +885,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: AKIRA EGAWA
-- id: 443-38
+- id: 444-38
   pioId: swsh11-38
   enumId: LUVDISC_38
   name: Luvdisc
@@ -907,7 +907,7 @@ cards:
     value: x2
   rarity: Common
   artist: Sekio
-- id: 443-39
+- id: 444-39
   pioId: swsh11-39
   enumId: SHELLOS_39
   name: Shellos
@@ -930,7 +930,7 @@ cards:
     value: x2
   rarity: Common
   artist: Saya Tsuruta
-- id: 443-40
+- id: 444-40
   pioId: swsh11-40
   enumId: FINNEON_40
   name: Finneon
@@ -955,7 +955,7 @@ cards:
     value: x2
   rarity: Common
   artist: Taira Akitsu
-- id: 443-41
+- id: 444-41
   pioId: swsh11-41
   enumId: LUMINEON_41
   name: Lumineon
@@ -980,7 +980,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: zig
-- id: 443-42
+- id: 444-42
   pioId: swsh11-42
   enumId: SNOVER_42
   name: Snover
@@ -1003,7 +1003,7 @@ cards:
     value: x2
   rarity: Common
   artist: Mitsuhiro Arita
-- id: 443-43
+- id: 444-43
   pioId: swsh11-43
   enumId: ABOMASNOW_43
   name: Abomasnow
@@ -1027,7 +1027,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: kodama
-- id: 443-44
+- id: 444-44
   pioId: swsh11-44
   enumId: HISUIAN_BASCULIN_44
   name: Hisuian Basculin
@@ -1047,7 +1047,7 @@ cards:
     value: x2
   rarity: Common
   artist: Oswaldo KATO
-- id: 443-45
+- id: 444-45
   pioId: swsh11-45
   enumId: HISUIAN_BASCULEGION_45
   name: Hisuian Basculegion
@@ -1073,7 +1073,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: AKIRA EGAWA
-- id: 443-46
+- id: 444-46
   pioId: swsh11-46
   enumId: DUCKLETT_46
   name: Ducklett
@@ -1096,7 +1096,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Yuka Morii
-- id: 443-47
+- id: 444-47
   pioId: swsh11-47
   enumId: SWANNA_47
   name: Swanna
@@ -1124,7 +1124,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Sekio
-- id: 443-48
+- id: 444-48
   pioId: swsh11-48
   enumId: KYUREM_V_48
   name: Kyurem V
@@ -1149,7 +1149,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: takuyoa
-- id: 443-49
+- id: 444-49
   pioId: swsh11-49
   enumId: KYUREM_VMAX_49
   name: Kyurem VMAX
@@ -1179,7 +1179,7 @@ cards:
   - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
     cards.'
   artist: N-DESIGN Inc.
-- id: 443-50
+- id: 444-50
   pioId: swsh11-50
   enumId: CRAMORANT_50
   name: Cramorant
@@ -1204,7 +1204,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Midori Harada
-- id: 443-51
+- id: 444-51
   pioId: swsh11-51
   enumId: GLASTRIER_51
   name: Glastrier
@@ -1229,7 +1229,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Jiro Sasumo
-- id: 443-52
+- id: 444-52
   pioId: swsh11-52
   enumId: PIKACHU_52
   name: Pikachu
@@ -1254,7 +1254,7 @@ cards:
     value: x2
   rarity: Common
   artist: kurumitsu
-- id: 443-53
+- id: 444-53
   pioId: swsh11-53
   enumId: RAICHU_53
   name: Raichu
@@ -1279,7 +1279,7 @@ cards:
     value: x2
   rarity: Rare
   artist: GIDORA
-- id: 443-54
+- id: 444-54
   pioId: swsh11-54
   enumId: ELECTRIKE_54
   name: Electrike
@@ -1303,7 +1303,7 @@ cards:
     value: x2
   rarity: Common
   artist: otumami
-- id: 443-55
+- id: 444-55
   pioId: swsh11-55
   enumId: MANECTRIC_55
   name: Manectric
@@ -1328,7 +1328,7 @@ cards:
     value: x2
   rarity: Rare
   artist: GIDORA
-- id: 443-56
+- id: 444-56
   pioId: swsh11-56
   enumId: MAGNEZONE_V_56
   name: Magnezone V
@@ -1355,7 +1355,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: N-DESIGN Inc.
-- id: 443-57
+- id: 444-57
   pioId: swsh11-57
   enumId: MAGNEZONE_VSTAR_57
   name: Magnezone VSTAR
@@ -1385,7 +1385,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: PLANETA Mochizuki
-- id: 443-58
+- id: 444-58
   pioId: swsh11-58
   enumId: ROTOM_V_58
   name: Rotom V
@@ -1414,7 +1414,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: 443-59
+- id: 444-59
   pioId: swsh11-59
   enumId: TYNAMO_59
   name: Tynamo
@@ -1438,7 +1438,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yukiko Baba
-- id: 443-60
+- id: 444-60
   pioId: swsh11-60
   enumId: EELEKTRIK_60
   name: Eelektrik
@@ -1465,7 +1465,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Uta
-- id: 443-61
+- id: 444-61
   pioId: swsh11-61
   enumId: EELEKTROSS_61
   name: Eelektross
@@ -1491,7 +1491,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Shin Nagasawa
-- id: 443-62
+- id: 444-62
   pioId: swsh11-62
   enumId: CLEFAIRY_62
   name: Clefairy
@@ -1518,7 +1518,7 @@ cards:
     value: x2
   rarity: Common
   artist: Kouki Saitou
-- id: 443-63
+- id: 444-63
   pioId: swsh11-63
   enumId: CLEFABLE_63
   name: Clefable
@@ -1544,7 +1544,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Sekio
-- id: 443-64
+- id: 444-64
   pioId: swsh11-64
   enumId: GASTLY_64
   name: Gastly
@@ -1566,7 +1566,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Tika Matsuno
-- id: 443-65
+- id: 444-65
   pioId: swsh11-65
   enumId: HAUNTER_65
   name: Haunter
@@ -1590,7 +1590,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Kouki Saitou
-- id: 443-66
+- id: 444-66
   pioId: swsh11-66
   enumId: GENGAR_66
   name: Gengar
@@ -1619,7 +1619,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Narumi Sato
-- id: 443-67
+- id: 444-67
   pioId: swsh11-67
   enumId: MR_MIME_67
   name: Mr. Mime
@@ -1647,7 +1647,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Souichirou Gunjima
-- id: 443-68
+- id: 444-68
   pioId: swsh11-68
   enumId: JYNX_68
   name: Jynx
@@ -1673,7 +1673,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Nagomi Nijo
-- id: 443-69
+- id: 444-69
   pioId: swsh11-69
   enumId: RADIANT_GARDEVOIR_69
   name: Radiant Gardevoir
@@ -1701,7 +1701,7 @@ cards:
   text:
   - 'Radiant Pokémon Rule: You cant have more than 1 Radiant Pokémon in your deck.'
   artist: Ryuta Fuse
-- id: 443-70
+- id: 444-70
   pioId: swsh11-70
   enumId: SABLEYE_70
   name: Sableye
@@ -1727,7 +1727,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Shibuzoh.
-- id: 443-71
+- id: 444-71
   pioId: swsh11-71
   enumId: MAWILE_71
   name: Mawile
@@ -1751,7 +1751,7 @@ cards:
     value: x2
   rarity: Common
   artist: kurumitsu
-- id: 443-72
+- id: 444-72
   pioId: swsh11-72
   enumId: SHUPPET_72
   name: Shuppet
@@ -1774,7 +1774,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Kouki Saitou
-- id: 443-73
+- id: 444-73
   pioId: swsh11-73
   enumId: BANETTE_73
   name: Banette
@@ -1803,7 +1803,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Kagemaru Himeno
-- id: 443-74
+- id: 444-74
   pioId: swsh11-74
   enumId: CRESSELIA_74
   name: Cresselia
@@ -1829,7 +1829,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: saino misaki
-- id: 443-75
+- id: 444-75
   pioId: swsh11-75
   enumId: HISUIAN_ZORUA_75
   name: Hisuian Zorua
@@ -1855,7 +1855,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Akira Komayama
-- id: 443-76
+- id: 444-76
   pioId: swsh11-76
   enumId: HISUIAN_ZOROARK_76
   name: Hisuian Zoroark
@@ -1882,7 +1882,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Kouki Saitou
-- id: 443-77
+- id: 444-77
   pioId: swsh11-77
   enumId: INKAY_77
   name: Inkay
@@ -1906,7 +1906,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: miki kudo
-- id: 443-78
+- id: 444-78
   pioId: swsh11-78
   enumId: MALAMAR_78
   name: Malamar
@@ -1934,7 +1934,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Tomokazu Komiya
-- id: 443-79
+- id: 444-79
   pioId: swsh11-79
   enumId: COMFEY_79
   name: Comfey
@@ -1959,7 +1959,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Aya Kusube
-- id: 443-80
+- id: 444-80
   pioId: swsh11-80
   enumId: MIMIKYU_80
   name: Mimikyu
@@ -1986,7 +1986,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Ligton
-- id: 443-81
+- id: 444-81
   pioId: swsh11-81
   enumId: SPECTRIER_81
   name: Spectrier
@@ -2013,7 +2013,7 @@ cards:
     value: '-30'
   rarity: Rare Holo
   artist: Narumi Sato
-- id: 443-82
+- id: 444-82
   pioId: swsh11-82
   enumId: ENAMORUS_V_82
   name: Enamorus V
@@ -2041,7 +2041,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: 443-83
+- id: 444-83
   pioId: swsh11-83
   enumId: HISUIAN_GROWLITHE_83
   name: Hisuian Growlithe
@@ -2061,7 +2061,7 @@ cards:
     value: x2
   rarity: Common
   artist: Kouki Saitou
-- id: 443-84
+- id: 444-84
   pioId: swsh11-84
   enumId: HISUIAN_ARCANINE_84
   name: Hisuian Arcanine
@@ -2085,7 +2085,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Oswaldo KATO
-- id: 443-85
+- id: 444-85
   pioId: swsh11-85
   enumId: POLIWRATH_85
   name: Poliwrath
@@ -2110,7 +2110,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Teeziro
-- id: 443-86
+- id: 444-86
   pioId: swsh11-86
   enumId: MACHOP_86
   name: Machop
@@ -2130,7 +2130,7 @@ cards:
     value: x2
   rarity: Common
   artist: Yuka Morii
-- id: 443-87
+- id: 444-87
   pioId: swsh11-87
   enumId: MACHOKE_87
   name: Machoke
@@ -2154,7 +2154,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Mitsuhiro Arita
-- id: 443-88
+- id: 444-88
   pioId: swsh11-88
   enumId: MACHAMP_88
   name: Machamp
@@ -2180,7 +2180,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Nisota Niso
-- id: 443-89
+- id: 444-89
   pioId: swsh11-89
   enumId: RHYHORN_89
   name: Rhyhorn
@@ -2201,7 +2201,7 @@ cards:
     value: x2
   rarity: Common
   artist: Scav
-- id: 443-90
+- id: 444-90
   pioId: swsh11-90
   enumId: RHYDON_90
   name: Rhydon
@@ -2226,7 +2226,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: HYOGONOSUKE
-- id: 443-91
+- id: 444-91
   pioId: swsh11-91
   enumId: RHYPERIOR_91
   name: Rhyperior
@@ -2252,7 +2252,7 @@ cards:
     value: x2
   rarity: Rare
   artist: GOSSAN
-- id: 443-92
+- id: 444-92
   pioId: swsh11-92
   enumId: AERODACTYL_V_92
   name: Aerodactyl V
@@ -2277,7 +2277,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: N-DESIGN Inc.
-- id: 443-93
+- id: 444-93
   pioId: swsh11-93
   enumId: AERODACTYL_VSTAR_93
   name: Aerodactyl VSTAR
@@ -2306,7 +2306,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: 443-94
+- id: 444-94
   pioId: swsh11-94
   enumId: SUDOWOODO_94
   name: Sudowoodo
@@ -2331,7 +2331,7 @@ cards:
     value: x2
   rarity: Common
   artist: AKIRA EGAWA
-- id: 443-95
+- id: 444-95
   pioId: swsh11-95
   enumId: GLIGAR_95
   name: Gligar
@@ -2352,7 +2352,7 @@ cards:
     value: x2
   rarity: Common
   artist: Miki Tanaka
-- id: 443-96
+- id: 444-96
   pioId: swsh11-96
   enumId: GLISCOR_96
   name: Gliscor
@@ -2374,7 +2374,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Shiburingaru
-- id: 443-97
+- id: 444-97
   pioId: swsh11-97
   enumId: MAKUHITA_97
   name: Makuhita
@@ -2395,7 +2395,7 @@ cards:
     value: x2
   rarity: Common
   artist: Shigenori Negishi
-- id: 443-98
+- id: 444-98
   pioId: swsh11-98
   enumId: HARIYAMA_98
   name: Hariyama
@@ -2420,7 +2420,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Scav
-- id: 443-99
+- id: 444-99
   pioId: swsh11-99
   enumId: MEDITITE_99
   name: Meditite
@@ -2441,7 +2441,7 @@ cards:
     value: x2
   rarity: Common
   artist: '0313'
-- id: 443-100
+- id: 444-100
   pioId: swsh11-100
   enumId: MEDICHAM_100
   name: Medicham
@@ -2463,7 +2463,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Kouki Saitou
-- id: 443-101
+- id: 444-101
   pioId: swsh11-101
   enumId: RELICANTH_101
   name: Relicanth
@@ -2485,7 +2485,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: ryoma uratsuka
-- id: 443-102
+- id: 444-102
   pioId: swsh11-102
   enumId: GASTRODON_102
   name: Gastrodon
@@ -2510,7 +2510,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Sanosuke Sakuma
-- id: 443-103
+- id: 444-103
   pioId: swsh11-103
   enumId: MIENFOO_103
   name: Mienfoo
@@ -2533,7 +2533,7 @@ cards:
     value: x2
   rarity: Common
   artist: yuu
-- id: 443-104
+- id: 444-104
   pioId: swsh11-104
   enumId: MIENSHAO_104
   name: Mienshao
@@ -2557,7 +2557,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Shibuzoh.
-- id: 443-105
+- id: 444-105
   pioId: swsh11-105
   enumId: LANDORUS_105
   name: Landorus
@@ -2580,7 +2580,7 @@ cards:
     value: x2
   rarity: Rare
   artist: KEIICHIRO ITO
-- id: 443-106
+- id: 444-106
   pioId: swsh11-106
   enumId: BINACLE_106
   name: Binacle
@@ -2603,7 +2603,7 @@ cards:
     value: x2
   rarity: Common
   artist: Scav
-- id: 443-107
+- id: 444-107
   pioId: swsh11-107
   enumId: BARBARACLE_107
   name: Barbaracle
@@ -2628,7 +2628,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: KEIICHIRO ITO
-- id: 443-108
+- id: 444-108
   pioId: swsh11-108
   enumId: CARBINK_108
   name: Carbink
@@ -2651,7 +2651,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Tika Matsuno
-- id: 443-109
+- id: 444-109
   pioId: swsh11-109
   enumId: ROCKRUFF_109
   name: Rockruff
@@ -2674,7 +2674,7 @@ cards:
     value: x2
   rarity: Common
   artist: Miki Tanaka
-- id: 443-110
+- id: 444-110
   pioId: swsh11-110
   enumId: FALINKS_110
   name: Falinks
@@ -2698,7 +2698,7 @@ cards:
     value: x2
   rarity: Common
   artist: sowsow
-- id: 443-111
+- id: 444-111
   pioId: swsh11-111
   enumId: STONJOURNER_111
   name: Stonjourner
@@ -2722,7 +2722,7 @@ cards:
     value: x2
   rarity: Rare
   artist: HYOGONOSUKE
-- id: 443-112
+- id: 444-112
   pioId: swsh11-112
   enumId: SPINARAK_112
   name: Spinarak
@@ -2743,7 +2743,7 @@ cards:
     value: x2
   rarity: Common
   artist: Atsuko Nishida
-- id: 443-113
+- id: 444-113
   pioId: swsh11-113
   enumId: ARIADOS_113
   name: Ariados
@@ -2769,7 +2769,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Shinji Kanda
-- id: 443-114
+- id: 444-114
   pioId: swsh11-114
   enumId: MURKROW_114
   name: Murkrow
@@ -2795,7 +2795,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Yuka Morii
-- id: 443-115
+- id: 444-115
   pioId: swsh11-115
   enumId: HONCHKROW_115
   name: Honchkrow
@@ -2823,7 +2823,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Shiburingaru
-- id: 443-116
+- id: 444-116
   pioId: swsh11-116
   enumId: SEVIPER_116
   name: Seviper
@@ -2843,7 +2843,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Tomokazu Komiya
-- id: 443-117
+- id: 444-117
   pioId: swsh11-117
   enumId: SPIRITOMB_117
   name: Spiritomb
@@ -2869,7 +2869,7 @@ cards:
     value: x2
   rarity: Rare
   artist: sui
-- id: 443-118
+- id: 444-118
   pioId: swsh11-118
   enumId: DRAPION_V_118
   name: Drapion V
@@ -2897,7 +2897,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: N-DESIGN Inc.
-- id: 443-119
+- id: 444-119
   pioId: swsh11-119
   enumId: DRAPION_VSTAR_119
   name: Drapion VSTAR
@@ -2927,7 +2927,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: PLANETA Mochizuki
-- id: 443-120
+- id: 444-120
   pioId: swsh11-120
   enumId: DARKRAI_120
   name: Darkrai
@@ -2951,7 +2951,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: Shin Nagasawa
-- id: 443-121
+- id: 444-121
   pioId: swsh11-121
   enumId: INKAY_121
   name: Inkay
@@ -2975,7 +2975,7 @@ cards:
     value: x2
   rarity: Common
   artist: Shibuzoh.
-- id: 443-122
+- id: 444-122
   pioId: swsh11-122
   enumId: HOOPA_122
   name: Hoopa
@@ -2998,7 +2998,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Sanosuke Sakuma
-- id: 443-123
+- id: 444-123
   pioId: swsh11-123
   enumId: RADIANT_HISUIAN_SNEASLER_123
   name: Radiant Hisuian Sneasler
@@ -3025,7 +3025,7 @@ cards:
   text:
   - 'Radiant Pokémon Rule: You cant have more than 1 Radiant Pokémon in your deck.'
   artist: Akira Komayama
-- id: 443-124
+- id: 444-124
   pioId: swsh11-124
   enumId: RADIANT_STEELIX_124
   name: Radiant Steelix
@@ -3055,7 +3055,7 @@ cards:
   text:
   - 'Radiant Pokémon Rule: You cant have more than 1 Radiant Pokémon in your deck.'
   artist: Sanosuke Sakuma
-- id: 443-125
+- id: 444-125
   pioId: swsh11-125
   enumId: BRONZOR_125
   name: Bronzor
@@ -3078,7 +3078,7 @@ cards:
     value: '-30'
   rarity: Common
   artist: Tomokazu Komiya
-- id: 443-126
+- id: 444-126
   pioId: swsh11-126
   enumId: BRONZONG_126
   name: Bronzong
@@ -3106,7 +3106,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: AKIRA EGAWA
-- id: 443-127
+- id: 444-127
   pioId: swsh11-127
   enumId: GALARIAN_STUNFISK_127
   name: Galarian Stunfisk
@@ -3133,7 +3133,7 @@ cards:
     value: '-30'
   rarity: Uncommon
   artist: Shigenori Negishi
-- id: 443-128
+- id: 444-128
   pioId: swsh11-128
   enumId: MAGEARNA_128
   name: Magearna
@@ -3160,7 +3160,7 @@ cards:
     value: '-30'
   rarity: Rare
   artist: Rianti Hidayat
-- id: 443-129
+- id: 444-129
   pioId: swsh11-129
   enumId: GALARIAN_PERRSERKER_V_129
   name: Galarian Perrserker V
@@ -3188,7 +3188,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: PLANETA Yamashita
-- id: 443-130
+- id: 444-130
   pioId: swsh11-130
   enumId: GIRATINA_V_130
   name: Giratina V
@@ -3212,7 +3212,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: 443-131
+- id: 444-131
   pioId: swsh11-131
   enumId: GIRATINA_VSTAR_131
   name: Giratina VSTAR
@@ -3238,7 +3238,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: 443-132
+- id: 444-132
   pioId: swsh11-132
   enumId: GOOMY_132
   name: Goomy
@@ -3258,7 +3258,7 @@ cards:
     damage: '30'
   rarity: Common
   artist: Oswaldo KATO
-- id: 443-133
+- id: 444-133
   pioId: swsh11-133
   enumId: HISUIAN_SLIGGOO_133
   name: Hisuian Sliggoo
@@ -3280,7 +3280,7 @@ cards:
     damage: '40'
   rarity: Uncommon
   artist: Kouki Saitou
-- id: 443-134
+- id: 444-134
   pioId: swsh11-134
   enumId: HISUIAN_GOODRA_134
   name: Hisuian Goodra
@@ -3302,7 +3302,7 @@ cards:
     damage: '140'
   rarity: Rare Holo
   artist: Akira Komayama
-- id: 443-135
+- id: 444-135
   pioId: swsh11-135
   enumId: HISUIAN_GOODRA_V_135
   name: Hisuian Goodra V
@@ -3326,7 +3326,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: 5ban Graphics
-- id: 443-136
+- id: 444-136
   pioId: swsh11-136
   enumId: HISUIAN_GOODRA_VSTAR_136
   name: Hisuian Goodra VSTAR
@@ -3353,7 +3353,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: 5ban Graphics
-- id: 443-137
+- id: 444-137
   pioId: swsh11-137
   enumId: PIDGEOT_V_137
   name: Pidgeot V
@@ -3383,7 +3383,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: Saki Hayashiro
-- id: 443-138
+- id: 444-138
   pioId: swsh11-138
   enumId: LICKITUNG_138
   name: Lickitung
@@ -3403,7 +3403,7 @@ cards:
     value: x2
   rarity: Common
   artist: KIYOTAKA OSHIYAMA
-- id: 443-139
+- id: 444-139
   pioId: swsh11-139
   enumId: LICKILICKY_139
   name: Lickilicky
@@ -3426,7 +3426,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Shibuzoh.
-- id: 443-140
+- id: 444-140
   pioId: swsh11-140
   enumId: PORYGON_140
   name: Porygon
@@ -3450,7 +3450,7 @@ cards:
     value: x2
   rarity: Common
   artist: kurumitsu
-- id: 443-141
+- id: 444-141
   pioId: swsh11-141
   enumId: PORYGON2_141
   name: Porygon2
@@ -3473,7 +3473,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: OKACHEKE
-- id: 443-142
+- id: 444-142
   pioId: swsh11-142
   enumId: PORYGON_Z_142
   name: Porygon-Z
@@ -3497,7 +3497,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Shibuzoh.
-- id: 443-143
+- id: 444-143
   pioId: swsh11-143
   enumId: SNORLAX_143
   name: Snorlax
@@ -3523,7 +3523,7 @@ cards:
     value: x2
   rarity: Rare Holo
   artist: '0313'
-- id: 443-144
+- id: 444-144
   pioId: swsh11-144
   enumId: AIPOM_144
   name: Aipom
@@ -3547,7 +3547,7 @@ cards:
     value: x2
   rarity: Common
   artist: Kouki Saitou
-- id: 443-145
+- id: 444-145
   pioId: swsh11-145
   enumId: AMBIPOM_145
   name: Ambipom
@@ -3572,7 +3572,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: Atsushi Furusawa
-- id: 443-146
+- id: 444-146
   pioId: swsh11-146
   enumId: HISUIAN_ZOROARK_V_146
   name: Hisuian Zoroark V
@@ -3598,7 +3598,7 @@ cards:
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   artist: aky CG Works
-- id: 443-147
+- id: 444-147
   pioId: swsh11-147
   enumId: HISUIAN_ZOROARK_VSTAR_147
   name: Hisuian Zoroark VSTAR
@@ -3628,7 +3628,7 @@ cards:
   - 'VSTAR rule: When your Pokémon VSTAR is Knocked Out, your opponent takes 2 Prize
     cards.'
   artist: aky CG Works
-- id: 443-148
+- id: 444-148
   pioId: swsh11-148
   enumId: BOUFFALANT_148
   name: Bouffalant
@@ -3651,7 +3651,7 @@ cards:
     value: x2
   rarity: Rare
   artist: Nisota Niso
-- id: 443-149
+- id: 444-149
   pioId: swsh11-149
   enumId: KOMALA_149
   name: Komala
@@ -3676,7 +3676,7 @@ cards:
     value: x2
   rarity: Uncommon
   artist: HYOGONOSUKE
-- id: 443-150
+- id: 444-150
   pioId: swsh11-150
   enumId: SKWOVET_150
   name: Skwovet
@@ -3696,7 +3696,7 @@ cards:
     value: x2
   rarity: Common
   artist: Miki Tanaka
-- id: 443-151
+- id: 444-151
   pioId: swsh11-151
   enumId: GREEDENT_151
   name: Greedent
@@ -3721,7 +3721,7 @@ cards:
     value: x2
   rarity: Rare
   artist: sui
-- id: 443-152
+- id: 444-152
   pioId: swsh11-152
   enumId: ARC_PHONE_152
   name: Arc Phone
@@ -3733,7 +3733,7 @@ cards:
   - Look at the top card of your deck. You may switch that card with 1 of your face-down
     Prize cards. (The cards stay face down.)
   - 'Item rule: You may play any number of Item cards during your turn.'
-- id: 443-153
+- id: 444-153
   pioId: swsh11-153
   enumId: AREZU_153
   name: Arezu
@@ -3746,7 +3746,7 @@ cards:
     them, and put them into your hand. Then, shuffle your deck. (Pokémon V, Pokémon-GX,
     etc. have Rule Boxes.)
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: 443-154
+- id: 444-154
   pioId: swsh11-154
   enumId: BOX_OF_DISASTER_154
   name: Box of Disaster
@@ -3761,7 +3761,7 @@ cards:
   - 'Item rule: You may play any number of Item cards during your turn.'
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn''t already
     have a Pokémon Tool attached.'
-- id: 443-155
+- id: 444-155
   pioId: swsh11-155
   enumId: COLRESS_S_EXPERIMENT_155
   name: Colress's Experiment
@@ -3773,7 +3773,7 @@ cards:
   - Look at the top 5 cards of your deck and put 3 of them into your hand. Put the
     other cards in the Lost Zone.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: 443-156
+- id: 444-156
   pioId: swsh11-156
   enumId: DAMAGE_PUMP_156
   name: Damage Pump
@@ -3785,7 +3785,7 @@ cards:
   - Move up to 2 damage counters from 1 of your Pokémon to your other Pokémon in any
     way you like.
   - 'Item rule: You may play any number of Item cards during your turn.'
-- id: 443-157
+- id: 444-157
   pioId: swsh11-157
   enumId: FANTINA_157
   name: Fantina
@@ -3799,7 +3799,7 @@ cards:
     from your opponent's Pokémon V (after applying Weakness and Resistance). (This
     includes Pokémon that come into play during that turn.)
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: 443-158
+- id: 444-158
   pioId: swsh11-158
   enumId: ISCAN_158
   name: Iscan
@@ -3810,7 +3810,7 @@ cards:
   text:
   - Draw 2 cards. If your Active Pokémon has "Hisuian" in its name, draw 2 more cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: 443-159
+- id: 444-159
   pioId: swsh11-159
   enumId: LADY_159
   name: Lady
@@ -3822,7 +3822,7 @@ cards:
   - Search your deck for up to 4 basic Energy cards, reveal them, and put them into
     your hand. Then, shuffle your deck.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: 443-160
+- id: 444-160
   pioId: swsh11-160
   enumId: LAKE_ACUITY_160
   name: Lake Acuity
@@ -3834,7 +3834,7 @@ cards:
   - All Pokémon that have any Water or [F] Energy attached (both yours and your opponent's)
     take 20 less damage from attacks from the opponent's Pokémon (after applying Weakness
     and Resistance).
-- id: 443-161
+- id: 444-161
   pioId: swsh11-161
   enumId: LOST_CITY_161
   name: Lost City
@@ -3845,7 +3845,7 @@ cards:
   text:
   - Whenever a Pokémon (either yours or your opponent's) is Knocked Out, put that
     Pokémon in the Lost Zone instead of the discard pile. (Discard all attached cards.)
-- id: 443-162
+- id: 444-162
   pioId: swsh11-162
   enumId: LOST_VACUUM_162
   name: Lost Vacuum
@@ -3858,7 +3858,7 @@ cards:
     Zone. Choose a Pokémon Tool attached to any Pokémon, or any Stadium in play, and
     put it in the Lost Zone.
   - 'Item rule: You may play any number of Item cards during your turn.'
-- id: 443-163
+- id: 444-163
   pioId: swsh11-163
   enumId: MIRAGE_GATE_163
   name: Mirage Gate
@@ -3871,7 +3871,7 @@ cards:
     your deck for up to 2 basic Energy cards of different types and attach them to
     your Pokémon in any way you like. Then, shuffle your deck.
   - 'Item rule: You may play any number of Item cards during your turn.'
-- id: 443-164
+- id: 444-164
   pioId: swsh11-164
   enumId: MISS_FORTUNE_SISTERS_164
   name: Miss Fortune Sisters
@@ -3883,7 +3883,7 @@ cards:
   - Look at the top 5 cards of your opponent's deck and discard any number of Item
     cards you find there. Your opponent shuffles the other cards back into their deck.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: 443-165
+- id: 444-165
   pioId: swsh11-165
   enumId: PANIC_MASK_165
   name: Panic Mask
@@ -3897,7 +3897,7 @@ cards:
   - 'Item rule: You may play any number of Item cards during your turn.'
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn''t already
     have a Pokémon Tool attached.'
-- id: 443-166
+- id: 444-166
   pioId: swsh11-166
   enumId: RILEY_166
   name: Riley
@@ -3909,7 +3909,7 @@ cards:
   - Reveal the top 5 cards of your deck and have your opponent choose 2 of them. Discard
     the chosen cards and put the remaining cards into your hand.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: 443-167
+- id: 444-167
   pioId: swsh11-167
   enumId: THORTON_167
   name: Thorton
@@ -3922,7 +3922,7 @@ cards:
     Pokémon in play. Any attached cards, damage counters, Special Conditions, turns
     in play, and any other effects remain on the new Pokémon.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: 443-168
+- id: 444-168
   pioId: swsh11-168
   enumId: TOOL_BOX_168
   name: Tool Box
@@ -3935,7 +3935,7 @@ cards:
     cards you find there and put them into your hand. Shuffle the other cards back
     into your deck.
   - 'Item rule: You may play any number of Item cards during your turn.'
-- id: 443-169
+- id: 444-169
   pioId: swsh11-169
   enumId: VOLO_169
   name: Volo
@@ -3946,7 +3946,7 @@ cards:
   text:
   - Discard 1 of your Benched Pokémon V and all attached cards.
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
-- id: 443-170
+- id: 444-170
   pioId: swsh11-170
   enumId: WINDUP_ARM_170
   name: Windup Arm
@@ -3959,7 +3959,7 @@ cards:
   - 'Item rule: You may play any number of Item cards during your turn.'
   - 'Pokémon Tool rule: Attach a Pokémon Tool to 1 of your Pokémon that doesn''t already
     have a Pokémon Tool attached.'
-- id: 443-171
+- id: 444-171
   pioId: swsh11-171
   enumId: GIFT_ENERGY_171
   name: Gift Energy
@@ -3971,7 +3971,7 @@ cards:
   - As long as this card is attached to a Pokémon, it provides [C] Energy. If the
     Pokémon this card is attached to is Knocked Out by damage from an attack from
     your opponent's Pokémon, draw cards until you have 7 cards in your hand.
-- id: 443-172
+- id: 444-172
   pioId: swsh11-172
   enumId: HISUIAN_ELECTRODE_V_172
   name: Hisuian Electrode V
@@ -3996,7 +3996,7 @@ cards:
   rarity: Ultra Rare
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
-- id: 443-173
+- id: 444-173
   pioId: swsh11-173
   enumId: DELPHOX_V_173
   name: Delphox V
@@ -4024,7 +4024,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-27
   variantType: Full Art
-- id: 443-174
+- id: 444-174
   pioId: swsh11-174
   enumId: KYUREM_V_174
   name: Kyurem V
@@ -4050,7 +4050,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-48
   variantType: Full Art
-- id: 443-175
+- id: 444-175
   pioId: swsh11-175
   enumId: MAGNEZONE_V_175
   name: Magnezone V
@@ -4078,7 +4078,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-56
   variantType: Full Art
-- id: 443-176
+- id: 444-176
   pioId: swsh11-176
   enumId: ROTOM_V_176
   name: Rotom V
@@ -4108,7 +4108,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-58
   variantType: Full Art
-- id: 443-177
+- id: 444-177
   pioId: swsh11-177
   enumId: ROTOM_V_177
   name: Rotom V
@@ -4138,7 +4138,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-58
   variantType: Full Art
-- id: 443-178
+- id: 444-178
   pioId: swsh11-178
   enumId: ENAMORUS_V_178
   name: Enamorus V
@@ -4167,7 +4167,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-82
   variantType: Full Art
-- id: 443-179
+- id: 444-179
   pioId: swsh11-179
   enumId: AERODACTYL_V_179
   name: Aerodactyl V
@@ -4193,7 +4193,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-92
   variantType: Full Art
-- id: 443-180
+- id: 444-180
   pioId: swsh11-180
   enumId: AERODACTYL_V_180
   name: Aerodactyl V
@@ -4219,7 +4219,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-92
   variantType: Full Art
-- id: 443-181
+- id: 444-181
   pioId: swsh11-181
   enumId: GALLADE_V_181
   name: Gallade V
@@ -4244,7 +4244,7 @@ cards:
   rarity: Ultra Rare
   text:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
-- id: 443-182
+- id: 444-182
   pioId: swsh11-182
   enumId: DRAPION_V_182
   name: Drapion V
@@ -4273,7 +4273,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-118
   variantType: Full Art
-- id: 443-183
+- id: 444-183
   pioId: swsh11-183
   enumId: GALARIAN_PERRSERKER_V_183
   name: Galarian Perrserker V
@@ -4302,7 +4302,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-129
   variantType: Full Art
-- id: 443-184
+- id: 444-184
   pioId: swsh11-184
   enumId: GALARIAN_PERRSERKER_V_184
   name: Galarian Perrserker V
@@ -4331,7 +4331,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-129
   variantType: Full Art
-- id: 443-185
+- id: 444-185
   pioId: swsh11-185
   enumId: GIRATINA_V_185
   name: Giratina V
@@ -4356,7 +4356,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-130
   variantType: Full Art
-- id: 443-186
+- id: 444-186
   pioId: swsh11-186
   enumId: GIRATINA_V_186
   name: Giratina V
@@ -4381,7 +4381,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-130
   variantType: Full Art
-- id: 443-187
+- id: 444-187
   pioId: swsh11-187
   enumId: HISUIAN_GOODRA_V_187
   name: Hisuian Goodra V
@@ -4406,7 +4406,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-135
   variantType: Full Art
-- id: 443-188
+- id: 444-188
   pioId: swsh11-188
   enumId: PIDGEOT_V_188
   name: Pidgeot V
@@ -4437,7 +4437,7 @@ cards:
   - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
   variantOf: FILL_THIS-137
   variantType: Full Art
-- id: 443-189
+- id: 444-189
   pioId: swsh11-189
   enumId: AREZU_189
   name: Arezu
@@ -4452,7 +4452,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-153
   variantType: Full Art
-- id: 443-190
+- id: 444-190
   pioId: swsh11-190
   enumId: COLRESS_S_EXPERIMENT_190
   name: Colress's Experiment
@@ -4466,7 +4466,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-155
   variantType: Full Art
-- id: 443-191
+- id: 444-191
   pioId: swsh11-191
   enumId: FANTINA_191
   name: Fantina
@@ -4482,7 +4482,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-157
   variantType: Full Art
-- id: 443-192
+- id: 444-192
   pioId: swsh11-192
   enumId: ISCAN_192
   name: Iscan
@@ -4495,7 +4495,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-158
   variantType: Full Art
-- id: 443-193
+- id: 444-193
   pioId: swsh11-193
   enumId: LADY_193
   name: Lady
@@ -4509,7 +4509,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-159
   variantType: Full Art
-- id: 443-194
+- id: 444-194
   pioId: swsh11-194
   enumId: MISS_FORTUNE_SISTERS_194
   name: Miss Fortune Sisters
@@ -4523,7 +4523,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-164
   variantType: Full Art
-- id: 443-195
+- id: 444-195
   pioId: swsh11-195
   enumId: THORTON_195
   name: Thorton
@@ -4538,7 +4538,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-167
   variantType: Full Art
-- id: 443-196
+- id: 444-196
   pioId: swsh11-196
   enumId: VOLO_196
   name: Volo
@@ -4551,7 +4551,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-169
   variantType: Full Art
-- id: 443-197
+- id: 444-197
   pioId: swsh11-197
   enumId: KYUREM_VMAX_197
   name: Kyurem VMAX
@@ -4582,7 +4582,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-49
   variantType: Full Art
-- id: 443-198
+- id: 444-198
   pioId: swsh11-198
   enumId: MAGNEZONE_VSTAR_198
   name: Magnezone VSTAR
@@ -4613,7 +4613,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-57
   variantType: Full Art
-- id: 443-199
+- id: 444-199
   pioId: swsh11-199
   enumId: AERODACTYL_VSTAR_199
   name: Aerodactyl VSTAR
@@ -4643,7 +4643,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-93
   variantType: Full Art
-- id: 443-200
+- id: 444-200
   pioId: swsh11-200
   enumId: DRAPION_VSTAR_200
   name: Drapion VSTAR
@@ -4674,7 +4674,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-119
   variantType: Full Art
-- id: 443-201
+- id: 444-201
   pioId: swsh11-201
   enumId: GIRATINA_VSTAR_201
   name: Giratina VSTAR
@@ -4701,7 +4701,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-131
   variantType: Full Art
-- id: 443-202
+- id: 444-202
   pioId: swsh11-202
   enumId: HISUIAN_GOODRA_VSTAR_202
   name: Hisuian Goodra VSTAR
@@ -4729,7 +4729,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-136
   variantType: Full Art
-- id: 443-203
+- id: 444-203
   pioId: swsh11-203
   enumId: HISUIAN_ZOROARK_VSTAR_203
   name: Hisuian Zoroark VSTAR
@@ -4760,7 +4760,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-147
   variantType: Full Art
-- id: 443-204
+- id: 444-204
   pioId: swsh11-204
   enumId: AREZU_204
   name: Arezu
@@ -4775,7 +4775,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-153
   variantType: Full Art
-- id: 443-205
+- id: 444-205
   pioId: swsh11-205
   enumId: COLRESS_S_EXPERIMENT_205
   name: Colress's Experiment
@@ -4789,7 +4789,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-155
   variantType: Full Art
-- id: 443-206
+- id: 444-206
   pioId: swsh11-206
   enumId: FANTINA_206
   name: Fantina
@@ -4805,7 +4805,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-157
   variantType: Full Art
-- id: 443-207
+- id: 444-207
   pioId: swsh11-207
   enumId: ISCAN_207
   name: Iscan
@@ -4818,7 +4818,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-158
   variantType: Full Art
-- id: 443-208
+- id: 444-208
   pioId: swsh11-208
   enumId: LADY_208
   name: Lady
@@ -4832,7 +4832,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-159
   variantType: Full Art
-- id: 443-209
+- id: 444-209
   pioId: swsh11-209
   enumId: MISS_FORTUNE_SISTERS_209
   name: Miss Fortune Sisters
@@ -4846,7 +4846,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-164
   variantType: Full Art
-- id: 443-210
+- id: 444-210
   pioId: swsh11-210
   enumId: THORTON_210
   name: Thorton
@@ -4861,7 +4861,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-167
   variantType: Full Art
-- id: 443-211
+- id: 444-211
   pioId: swsh11-211
   enumId: VOLO_211
   name: Volo
@@ -4874,7 +4874,7 @@ cards:
   - 'Supporter rule: You may play only 1 Supporter card during your turn.'
   variantOf: FILL_THIS-169
   variantType: Full Art
-- id: 443-212
+- id: 444-212
   pioId: swsh11-212
   enumId: GIRATINA_VSTAR_212
   name: Giratina VSTAR
@@ -4901,7 +4901,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-131
   variantType: Secret Art
-- id: 443-213
+- id: 444-213
   pioId: swsh11-213
   enumId: HISUIAN_ZOROARK_VSTAR_213
   name: Hisuian Zoroark VSTAR
@@ -4932,7 +4932,7 @@ cards:
     cards.'
   variantOf: FILL_THIS-147
   variantType: Secret Art
-- id: 443-214
+- id: 444-214
   pioId: swsh11-214
   enumId: BOX_OF_DISASTER_214
   name: Box of Disaster
@@ -4949,7 +4949,7 @@ cards:
     have a Pokémon Tool attached.'
   variantOf: FILL_THIS-154
   variantType: Secret Art
-- id: 443-215
+- id: 444-215
   pioId: swsh11-215
   enumId: COLLAPSED_STADIUM_215
   name: Collapsed Stadium
@@ -4962,7 +4962,7 @@ cards:
     Benched Pokémon, they discard Benched Pokémon until they have 4 Pokémon on the
     Bench. The player who played this card discards first. If more than one effect
     changes the number of Benched Pokémon allowed, use the smaller number.
-- id: 443-216
+- id: 444-216
   pioId: swsh11-216
   enumId: DARK_PATCH_216
   name: Dark Patch
@@ -4974,7 +4974,7 @@ cards:
   - Attach a basic [D] Energy card from your discard pile to 1 of your Benched [D]
     Pokémon.
   - 'Item rule: You may play any number of Item cards during your turn.'
-- id: 443-217
+- id: 444-217
   pioId: swsh11-217
   enumId: LOST_VACUUM_217
   name: Lost Vacuum

--- a/data/src/main/resources/cards/444-lost_origins.yaml
+++ b/data/src/main/resources/cards/444-lost_origins.yaml
@@ -4990,3 +4990,726 @@ cards:
   - 'Item rule: You may play any number of Item cards during your turn.'
   variantOf: FILL_THIS-162
   variantType: Secret Art
+- id: 444-TG01
+  pioId: swsh11tg-TG01
+  enumId: PARASECT_TG01
+  name: Parasect
+  number: TG01
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Paras
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Lethargy Spores
+    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
+      your turn, you may make both Active Pokémon Asleep and Poisoned.
+  moves:
+  - cost: [G, C]
+    name: X-Scissor
+    damage: 50+
+    text: Flip a coin. If heads, this attack does 50 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  artist: Oswaldo KATO
+- id: 444-TG02
+  pioId: swsh11tg-TG02
+  enumId: ROSERADE_TG02
+  name: Roserade
+  number: TG02
+  types: [G]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Roselia
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Poisonous Whip
+    damage: '30'
+    text: Your opponent's Active Pokémon is now Poisoned.
+  - cost: [G, C]
+    name: Assassin's Rose
+    damage: '60'
+    text: If your opponent's Active Pokémon is affected by a Special Condition, this
+      attack also does 60 damage to 1 of your opponent's Benched Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  artist: saino misaki
+- id: 444-TG03
+  pioId: swsh11tg-TG03
+  enumId: CHARIZARD_TG03
+  name: Charizard
+  number: TG03
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Charmeleon
+  hp: 170
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Battle Sense
+    text: Once during your turn, you may look at the top 3 cards of your deck and
+      put 1 of them into your hand. Discard the other cards.
+  moves:
+  - cost: [R, R]
+    name: Royal Blaze
+    damage: 100+
+    text: This attack does 50 more damage for each Leon card in your discard pile.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  artist: GIDORA
+- id: 444-TG04
+  pioId: swsh11tg-TG04
+  enumId: CHANDELURE_TG04
+  name: Chandelure
+  number: TG04
+  types: [R]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Lampent
+  hp: 150
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Mountain Roasting
+    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
+      your turn, you may discard the top 3 cards of your opponent's deck.
+  moves:
+  - cost: [R, C]
+    name: Heat Blast
+    damage: '90'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  artist: chibi
+- id: 444-TG05
+  pioId: swsh11tg-TG05
+  enumId: PIKACHU_TG05
+  name: Pikachu
+  number: TG05
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raichu]
+  hp: 60
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Pika Dash
+    text: If this Pokémon has any Energy attached, it has no Retreat Cost.
+  moves:
+  - cost: [L, C, C]
+    name: Whimsy Tackle
+    damage: '50'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: Atsushi Furusawa
+- id: 444-TG06
+  pioId: swsh11tg-TG06
+  enumId: GENGAR_TG06
+  name: Gengar
+  number: TG06
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE2, EVOLUTION]
+  evolvesFrom: Haunter
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Netherworld Gate
+    text: Once during your turn, if this Pokémon is in your discard pile, you may
+      put it onto your Bench. If you do, put 3 damage counters on this Pokémon.
+  moves:
+  - cost: [P]
+    name: Screaming Circle
+    text: Put 2 damage counters on your opponent's Active Pokémon for each of your
+      opponent's Benched Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: Akira Komayama
+- id: 444-TG07
+  pioId: swsh11tg-TG07
+  enumId: BANETTE_TG07
+  name: Banette
+  number: TG07
+  types: [P]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION, SINGLE_STRIKE]
+  evolvesFrom: Shuppet
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Resolute Spite
+    damage: 20x
+    text: Put up to 7 damage counters on this Pokémon. This attack does 20 damage
+      for each damage counter you placed in this way.
+  - cost: [P, C]
+    name: Eerie Light
+    damage: '50'
+    text: Your opponent's Active Pokémon is now Confused.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Rare Holo
+  artist: Tomomi Kaneko
+- id: 444-TG08
+  pioId: swsh11tg-TG08
+  enumId: HISUIAN_ARCANINE_TG08
+  name: Hisuian Arcanine
+  number: TG08
+  types: [F]
+  superType: POKEMON
+  subTypes: [STAGE1, EVOLUTION]
+  evolvesFrom: Hisuian Growlithe
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Very Vulnerable
+    damage: 10+
+    text: If you have no cards in your hand, this attack does 150 more damage.
+  - cost: [F, C, C]
+    name: Sharp Fang
+    damage: '100'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: You Iribi
+- id: 444-TG09
+  pioId: swsh11tg-TG09
+  enumId: SPIRITOMB_TG09
+  name: Spiritomb
+  number: TG09
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Cursed Message
+    text: If this Pokémon is Knocked Out by damage from an attack from your opponent's
+      Pokémon, search your deck for a card and put it into your hand. Then, shuffle
+      your deck.
+  moves:
+  - cost: [D, D]
+    name: Chain of Spirits
+    damage: 10+
+    text: This attack does 60 more damage for each Spiritomb in your discard pile.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Rare Holo
+  artist: Hitoshi Ariga
+- id: 444-TG10
+  pioId: swsh11tg-TG10
+  enumId: SNORLAX_TG10
+  name: Snorlax
+  number: TG10
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 150
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Unfazed Fat
+    text: Prevent all effects of attacks from your opponent's Pokémon done to this
+      Pokémon. (Damage is not an effect.)
+  moves:
+  - cost: [C, C, C]
+    name: Thumping Snore
+    damage: '180'
+    text: This Pokémon is now Asleep. During Pokémon Checkup, flip 2 coins instead
+      of 1. If either of them is tails, this Pokémon is still Asleep.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: Kouki Saitou
+- id: 444-TG11
+  pioId: swsh11tg-TG11
+  enumId: CASTFORM_TG11
+  name: Castform
+  number: TG11
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  abilities:
+  - type: Ability
+    name: Weather Reading
+    text: If you have 8 or more Stadium cards in your discard pile, ignore all Energy
+      in this Pokémon's attack costs.
+  moves:
+  - cost: [C, C, C]
+    name: Weather Force
+    damage: '80'
+    text: Draw cards until you have 6 cards in your hand.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  artist: Atsushi Furusawa
+- id: 444-TG12
+  pioId: swsh11tg-TG12
+  enumId: ORBEETLE_V_TG12
+  name: Orbeetle V
+  number: TG12
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 180
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Strafe
+    damage: '20'
+    text: You may switch this Pokémon with 1 of your Benched Pokémon.
+  - cost: [G, C]
+    name: Mysterious Wave
+    damage: 50+
+    text: This attack does 30 more damage for each Energy attached to your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Nisota Niso
+- id: 444-TG13
+  pioId: swsh11tg-TG13
+  enumId: ORBEETLE_VMAX_TG13
+  name: Orbeetle VMAX
+  number: TG13
+  types: [G]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Orbeetle V
+  hp: 310
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Eerie Beam
+    text: Once during your turn, if this Pokémon is in the Active Spot, you may put
+      1 damage counter on each of your opponent's Pokémon.
+  moves:
+  - cost: [G, C]
+    name: G-Max Wave
+    damage: 50+
+    text: This attack does 50 more damage for each Energy attached to your opponent's
+      Active Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: Teeziro
+- id: 444-TG14
+  pioId: swsh11tg-TG14
+  enumId: CENTISKORCH_V_TG14
+  name: Centiskorch V
+  number: TG14
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 3
+  moves:
+  - cost: [R]
+    name: Radiating Heat
+    damage: '20'
+    text: You may discard an Energy from this Pokémon. If you do, discard an Energy
+      from your opponent's Active Pokémon.
+  - cost: [R, R, R, R]
+    name: Burning Train
+    damage: '180'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Yuya Oka
+- id: 444-TG15
+  pioId: swsh11tg-TG15
+  enumId: CENTISKORCH_VMAX_TG15
+  name: Centiskorch VMAX
+  number: TG15
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Centiskorch V
+  hp: 320
+  retreatCost: 3
+  moves:
+  - cost: [C, C]
+    name: G-Max Centiferno
+    damage: 40+
+    text: This attack does 40 more damage for each [R] Energy attached to this Pokémon.
+      If you did any damage with this attack, you may attach a [R] Energy card from
+      your discard pile to this Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: Oswaldo KATO
+- id: 444-TG16
+  pioId: swsh11tg-TG16
+  enumId: PIKACHU_V_TG16
+  name: Pikachu V
+  number: TG16
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  evolvesTo: [Raichu]
+  hp: 190
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Charge
+    text: Search your deck for up to 2 [L] Energy cards and attach them to this Pokémon.
+      Then, shuffle your deck.
+  - cost: [L, L, C]
+    name: Thunderbolt
+    damage: '200'
+    text: Discard all Energy from this Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Ryota Murayama
+- id: 444-TG17
+  pioId: swsh11tg-TG17
+  enumId: PIKACHU_VMAX_TG17
+  name: Pikachu VMAX
+  number: TG17
+  types: [L]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Pikachu V
+  evolvesTo: [Raichu]
+  hp: 310
+  retreatCost: 2
+  moves:
+  - cost: [L, L, L]
+    name: G-Max Volt Tackle
+    damage: 120+
+    text: You may discard all Energy from this Pokémon. If you do, this attack does
+      150 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: Souichirou Gunjima
+- id: 444-TG18
+  pioId: swsh11tg-TG18
+  enumId: ENAMORUS_V_TG18
+  name: Enamorus V
+  number: TG18
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Guardian of Love
+    text: Prevent all effects of your opponent's Pokémon's Abilities done to each
+      of your Pokémon that has any [P] Energy attached, except any Enamorus V.
+  moves:
+  - cost: [P, C, C]
+    name: Blossom Tail
+    damage: '100'
+    text: Attach up to 2 basic Energy cards from your discard pile to your Benched
+      Pokémon in any way you like.
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: AKIRA EGAWA
+- id: 444-TG19
+  pioId: swsh11tg-TG19
+  enumId: GALLADE_V_TG19
+  name: Gallade V
+  number: TG19
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [F, C]
+    name: Rising Sword
+    damage: 20+
+    text: This attack does 50 more damage for each Prize card you have taken.
+  - cost: [F, F, C]
+    name: Buster Swing
+    damage: '130'
+    text: This attack's damage isn't affected by Resistance.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: Souichirou Gunjima
+- id: 444-TG20
+  pioId: swsh11tg-TG20
+  enumId: CROBAT_V_TG20
+  name: Crobat V
+  number: TG20
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 180
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Dark Asset
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may draw cards until you have 6 cards in your hand. You can't use more than
+      1 Dark Asset Ability each turn.
+  moves:
+  - cost: [D, C]
+    name: Venomous Fang
+    damage: '70'
+    text: Your opponent's Active Pokémon is now Poisoned.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: GOSSAN
+- id: 444-TG21
+  pioId: swsh11tg-TG21
+  enumId: ETERNATUS_V_TG21
+  name: Eternatus V
+  number: TG21
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Power Accelerator
+    damage: '30'
+    text: You may attach a [D] Energy card from your hand to 1 of your Benched Pokémon.
+  - cost: [D, C, C, C]
+    name: Dynamax Cannon
+    damage: 120+
+    text: If your opponent's Active Pokémon is a Pokémon VMAX, this attack does 120
+      more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'V rule: When your Pokémon V is Knocked Out, your opponent takes 2 Prize cards.'
+  artist: kodama
+- id: 444-TG22
+  pioId: swsh11tg-TG22
+  enumId: ETERNATUS_VMAX_TG22
+  name: Eternatus VMAX
+  number: TG22
+  types: [D]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Eternatus V
+  hp: 340
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Eternal Zone
+    text: If all of your Pokémon in play are Darkness type, you can have up to 8 Pokémon
+      on your Bench, and you can't put non-[D] Pokémon into play. (If this Ability
+      stops working, discard Pokémon from your Bench until you have 5.)
+  moves:
+  - cost: [D, C]
+    name: Dread End
+    damage: 30x
+    text: This attack does 30 damage for each of your [D] Pokémon in play.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Rare Holo
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: Mitsuhiro Arita
+- id: 444-TG23
+  pioId: swsh11tg-TG23
+  enumId: ADVENTURER_S_DISCOVERY_TG23
+  name: Adventurer's Discovery
+  number: TG23
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Search your deck for up to 3 Pokémon V, reveal them, and put them into your hand.
+    Then, shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Taira Akitsu
+- id: 444-TG24
+  pioId: swsh11tg-TG24
+  enumId: BOSS_S_ORDERS_TG24
+  name: Boss's Orders
+  number: TG24
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Switch 1 of your opponent's Benched Pokémon with their Active Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: NC Empire
+- id: 444-TG25
+  pioId: swsh11tg-TG25
+  enumId: COOK_TG25
+  name: Cook
+  number: TG25
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Heal 70 damage from your Active Pokémon.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Sanosuke Sakuma
+- id: 444-TG26
+  pioId: swsh11tg-TG26
+  enumId: KABU_TG26
+  name: Kabu
+  number: TG26
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Shuffle your hand into your deck. Then, draw 4 cards. If your Active Pokémon is
+    your only Pokémon in play, draw 8 cards instead.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Hideki Ishikawa
+- id: 444-TG27
+  pioId: swsh11tg-TG27
+  enumId: NESSA_TG27
+  name: Nessa
+  number: TG27
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Put up to 4 in any combination of [W] Pokémon and [W] Energy cards from your discard
+    pile into your hand.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: saino misaki
+- id: 444-TG28
+  pioId: swsh11tg-TG28
+  enumId: OPAL_TG28
+  name: Opal
+  number: TG28
+  superType: TRAINER
+  subTypes: [SUPPORTER]
+  rarity: Ultra Rare
+  text:
+  - Flip 2 coins. Search your deck for a number of cards up to the number of heads,
+    put them into your hand, and shuffle your deck.
+  - 'Supporter rule: You may play only 1 Supporter card during your turn.'
+  artist: Taira Akitsu
+- id: 444-TG29
+  pioId: swsh11tg-TG29
+  enumId: PIKACHU_VMAX_TG29
+  name: Pikachu VMAX
+  number: TG29
+  types: [L]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Pikachu V
+  evolvesTo: [Raichu]
+  hp: 310
+  retreatCost: 2
+  moves:
+  - cost: [L, L, L]
+    name: G-Max Volt Tackle
+    damage: 120+
+    text: You may discard all Energy from this Pokémon. If you do, this attack does
+      150 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Secret
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: aky CG Works
+  variantOf: FILL_THIS-TG17
+  variantType: Secret Art
+- id: 444-TG30
+  pioId: swsh11tg-TG30
+  enumId: MEW_VMAX_TG30
+  name: Mew VMAX
+  number: TG30
+  types: [P]
+  superType: POKEMON
+  subTypes: [EVOLUTION, VMAX]
+  evolvesFrom: Mew V
+  hp: 310
+  moves:
+  - cost: [C, C]
+    name: Cross Fusion Strike
+    text: Choose 1 of your Benched Fusion Strike Pokémon's attacks and use it as this
+      attack.
+  - cost: [P, P]
+    name: Max Miracle
+    damage: '130'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Secret
+  text:
+  - 'VMAX rule: When your Pokémon VMAX is Knocked Out, your opponent takes 3 Prize
+    cards.'
+  artist: 5ban Graphics

--- a/data/src/main/resources/cards/444-lost_origins.yaml
+++ b/data/src/main/resources/cards/444-lost_origins.yaml
@@ -1,6 +1,6 @@
 schema: E2
 id: '444'
-name: swsh11
+name: Lost Origins
 enumId: LOST_ORIGINS
 abbr: LOR
 pioId: swsh11

--- a/data/src/main/resources/cards/444-lost_origins.yaml
+++ b/data/src/main/resources/cards/444-lost_origins.yaml
@@ -1363,7 +1363,7 @@ cards:
   number: '57'
   types: [L]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Magnezone V
   hp: 270
   retreatCost: 2
@@ -2285,7 +2285,7 @@ cards:
   number: '93'
   types: [F]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Aerodactyl V
   hp: 260
   retreatCost: 2
@@ -2905,7 +2905,7 @@ cards:
   number: '119'
   types: [D]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Drapion V
   hp: 270
   retreatCost: 3
@@ -3220,7 +3220,7 @@ cards:
   number: '131'
   types: [N]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Giratina V
   hp: 280
   retreatCost: 2
@@ -3334,7 +3334,7 @@ cards:
   number: '136'
   types: [N]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Hisuian Goodra V
   hp: 270
   retreatCost: 3
@@ -3606,7 +3606,7 @@ cards:
   number: '147'
   types: [C]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Hisuian Zoroark V
   hp: 270
   retreatCost: 2
@@ -4590,7 +4590,7 @@ cards:
   number: '198'
   types: [L]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Magnezone V
   hp: 270
   retreatCost: 2
@@ -4621,7 +4621,7 @@ cards:
   number: '199'
   types: [F]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Aerodactyl V
   hp: 260
   retreatCost: 2
@@ -4651,7 +4651,7 @@ cards:
   number: '200'
   types: [D]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Drapion V
   hp: 270
   retreatCost: 3
@@ -4682,7 +4682,7 @@ cards:
   number: '201'
   types: [N]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Giratina V
   hp: 280
   retreatCost: 2
@@ -4709,7 +4709,7 @@ cards:
   number: '202'
   types: [N]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Hisuian Goodra V
   hp: 270
   retreatCost: 3
@@ -4737,7 +4737,7 @@ cards:
   number: '203'
   types: [C]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Hisuian Zoroark V
   hp: 270
   retreatCost: 2
@@ -4882,7 +4882,7 @@ cards:
   number: '212'
   types: [N]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Giratina V
   hp: 280
   retreatCost: 2
@@ -4909,7 +4909,7 @@ cards:
   number: '213'
   types: [C]
   superType: POKEMON
-  subTypes: []
+  subTypes: [VSTAR]
   evolvesFrom: Hisuian Zoroark V
   hp: 270
   retreatCost: 2

--- a/data/src/main/resources/cards/444-lost_origins.yaml
+++ b/data/src/main/resources/cards/444-lost_origins.yaml
@@ -1,3 +1,4 @@
+schema: E2
 id: '444'
 name: swsh11
 enumId: LOST_ORIGINS

--- a/model/src/main/java/tcgone/carddb/model/CardType.java
+++ b/model/src/main/java/tcgone/carddb/model/CardType.java
@@ -60,8 +60,9 @@ public enum CardType {
   VMAX(113, "Pokémon VMAX", "vmax"),
   RAPID_STRIKE(114, "Rapid Strike", "rapid-strike"),
   SINGLE_STRIKE(115, "Single Strike", "single-strike"),
-  VSTAR(116, "Pokémon VSTAR", "vstar"),
-  VUNION(117, "Pokémon V-UNION", "v-union"),
+  FUSION_STRIKE(116, "Fusion Strike", "fusion-strike"),
+  VSTAR(117, "Pokémon VSTAR", "vstar"),
+  VUNION(118, "Pokémon V-UNION", "v-union"),
 
   NOT_IMPLEMENTED(201, "Not Implemented", "not-implemented"),
 

--- a/model/src/main/java/tcgone/carddb/model/CardType.java
+++ b/model/src/main/java/tcgone/carddb/model/CardType.java
@@ -60,6 +60,8 @@ public enum CardType {
   VMAX(113, "Pokémon VMAX", "vmax"),
   RAPID_STRIKE(114, "Rapid Strike", "rapid-strike"),
   SINGLE_STRIKE(115, "Single Strike", "single-strike"),
+  VSTAR(116, "Pokémon VSTAR", "vstar"),
+  VUNION(117, "Pokémon V-UNION", "v-union"),
 
   NOT_IMPLEMENTED(201, "Not Implemented", "not-implemented"),
 


### PR DESCRIPTION
Big PR! Gonna try to get us updated all the way to Lost Origins. So far all I've done is the most preliminary work filling in things. Will probably find more things to add to these lists.

**Main set tasks:**
- [ ] Celebrations
- [ ] Celebrations "reprints"
- [ ] Fusion Strike
- [ ] Brilliant Stars
- [ ] Astral Radiance
- [ ] Pokemon Go
- [ ] Lost Origins
- [ ] Sword & Shield promo update

**Side tasks:**
- [ ] Add V-UNIONs **[1]**
- [ ] Make sure the CardTypes are correct **[1]**
- [ ] Fix up the VSTARs / Radiant Rares **[1]**
- [x] Lost Origins / Astral Radiance trainer gallery appended to their respective sets
- [ ] Update each of the variantOf FILL_THIS's to their respective cards
- [ ] Fix the energy-less attacks (I replaced them with Water Energy so tools would take em)
- [ ] Add variantOfs to the Trainer Gallery cards

**[1]**  _Gonna need some help with these just to make sure I'm doing it correctly._